### PR TITLE
Build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There are currently a few known bugs which I hope to squash soon.
   * TODO
 
 ## Dependencies:
-* golang (required, available in most distros)
+* golang 1.4 or higher (required, available in most distros)
 * golang libraries (required, available with `go get`)
 
         go get github.com/coreos/etcd/client

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ There are currently a few known bugs which I hope to squash soon.
 ## Dependencies:
 * golang (required, available in most distros)
 * golang libraries (required, available with `go get`)
-  ```
-  go get github.com/coreos/etcd/client
-  go get gopkg.in/yaml.v2
-  go get gopkg.in/fsnotify.v1
-  go get github.com/codegangsta/cli
-  go get github.com/coreos/go-systemd/dbus
-  go get github.com/coreos/go-systemd/util
-  ```
+
+        go get github.com/coreos/etcd/client
+        go get gopkg.in/yaml.v2
+        go get gopkg.in/fsnotify.v1
+        go get github.com/codegangsta/cli
+        go get github.com/coreos/go-systemd/dbus
+        go get github.com/coreos/go-systemd/util
+
 * pandoc (optional, for building a pdf of the documentation)
 * graphviz (optional, for building a visual representation of the graph)
 


### PR DESCRIPTION
Issues found while following README to compile `mgmt`:

* the `go get` commands are inlined in the rendering on GitHub
* the `golang 1.3` package from Debian stable errors out of `make build` because `go generate` is not a thing yet