### PR TITLE
README: also list stringer as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ There are currently a few known bugs which I hope to squash soon.
         go get github.com/coreos/go-systemd/dbus
         go get github.com/coreos/go-systemd/util
 
+* stringer (required for building), available as a package on some platforms, otherwise via `go get`
+
+        go get golang.org/x/tools/cmd/stringer
+
 * pandoc (optional, for building a pdf of the documentation)
 * graphviz (optional, for building a visual representation of the graph)
 


### PR DESCRIPTION
Your advice in #5 worked nicely. Debian apparently does not (yet) package `stringer`, so let's mention it and give help.