### PR TITLE
build requires (at least) stringer - add package which contains missi…

### DIFF
--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -19,7 +19,7 @@ if [ $travis -eq 0 ]; then
 
 	fi
 	if [ ! -z "$APT" ]; then
-		sudo $APT install -y golang mercurial
+		sudo $APT install -y golang golang-golang-x-tools mercurial
 
 	fi
 fi


### PR DESCRIPTION
…ng dependency

Fixes error:

```
$ make build
Building: mgmt, version: 0.0.2-11-g674cb24.
go generate
/usr/lib/go/src/purpleidea/mgmt/etcd.go:30: running "stringer": exec: "stringer": executable file not found in $PATH
```