### PR TITLE
rename the 'stateok' return value to 'checkok'

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -201,7 +201,7 @@ func (obj *ExecRes) Watch(processChan chan Event) {
 }
 
 // TODO: expand the IfCmd to be a list of commands
-func (obj *ExecRes) CheckApply(apply bool) (stateok bool, err error) {
+func (obj *ExecRes) CheckApply(apply bool) (checkok bool, err error) {
 	log.Printf("%v[%v]: CheckApply(%t)", obj.Kind(), obj.GetName(), apply)
 
 	// if there is a watch command, but no if command, run based on state

--- a/file.go
+++ b/file.go
@@ -328,7 +328,7 @@ func (obj *FileRes) FileApply() error {
 	return nil // success
 }
 
-func (obj *FileRes) CheckApply(apply bool) (stateok bool, err error) {
+func (obj *FileRes) CheckApply(apply bool) (checkok bool, err error) {
 	log.Printf("%v[%v]: CheckApply(%t)", obj.Kind(), obj.GetName(), apply)
 
 	if obj.isStateOK { // cache the state

--- a/noop.go
+++ b/noop.go
@@ -92,7 +92,7 @@ func (obj *NoopRes) Watch(processChan chan Event) {
 }
 
 // CheckApply method for Noop resource. Does nothing, returns happy!
-func (obj *NoopRes) CheckApply(apply bool) (stateok bool, err error) {
+func (obj *NoopRes) CheckApply(apply bool) (checkok bool, err error) {
 	log.Printf("%v[%v]: CheckApply(%t)", obj.Kind(), obj.GetName(), apply)
 	return true, nil // state is always okay
 }

--- a/pgraph.go
+++ b/pgraph.go
@@ -729,15 +729,15 @@ func (g *Graph) Process(v *Vertex) {
 
 		obj.SetState(resStateCheckApply)
 		// if this fails, don't UpdateTimestamp()
-		stateok, err := obj.CheckApply(true)
-		if stateok && err != nil { // should never return this way
-			log.Fatalf("%v[%v]: CheckApply(): %t, %+v", obj.Kind(), obj.GetName(), stateok, err)
+		checkok, err := obj.CheckApply(true)
+		if checkok && err != nil { // should never return this way
+			log.Fatalf("%v[%v]: CheckApply(): %t, %+v", obj.Kind(), obj.GetName(), checkok, err)
 		}
 		if DEBUG {
-			log.Printf("%v[%v]: CheckApply(): %t, %v", obj.Kind(), obj.GetName(), stateok, err)
+			log.Printf("%v[%v]: CheckApply(): %t, %v", obj.Kind(), obj.GetName(), checkok, err)
 		}
 
-		if !stateok { // if state *was* not ok, we had to have apply'ed
+		if !checkok { // if state *was* not ok, we had to have apply'ed
 			if err != nil { // error during check or apply
 				ok = false
 			} else {

--- a/pkg.go
+++ b/pkg.go
@@ -241,7 +241,7 @@ func (obj *PkgRes) pkgMappingHelper(bus *Conn) (map[string]*PkPackageIDActionDat
 	return result, nil
 }
 
-func (obj *PkgRes) CheckApply(apply bool) (stateok bool, err error) {
+func (obj *PkgRes) CheckApply(apply bool) (checkok bool, err error) {
 	log.Printf("%v: CheckApply(%t)", obj.fmtNames(obj.getNames()), apply)
 
 	if obj.State == "" { // TODO: Validate() should replace this check!

--- a/svc.go
+++ b/svc.go
@@ -227,7 +227,7 @@ func (obj *SvcRes) Watch(processChan chan Event) {
 	}
 }
 
-func (obj *SvcRes) CheckApply(apply bool) (stateok bool, err error) {
+func (obj *SvcRes) CheckApply(apply bool) (checkok bool, err error) {
 	log.Printf("%v[%v]: CheckApply(%t)", obj.Kind(), obj.GetName(), apply)
 
 	if obj.isStateOK { // cache the state


### PR DESCRIPTION
The naming was confusing because the boolean return value expresses
whether the resource needed changing (the check failed) as opposed to
the state not being not OK.

purpleidea note: The "stateok" (now properly renamed to "checkok") is
actually the historical bool return value of the Check() -> bool
function which is now part of the CheckApply() amalgamation. This is an
easy way to think about it if you're trying to understand why at the end
of a successful apply we return false, nil.