### PR TITLE
Simplify file watch

### DIFF
--- a/file.go
+++ b/file.go
@@ -149,16 +149,16 @@ func (obj *FileRes) Watch(processChan chan Event) {
 					if watchDepth < 0 {
 						log.Fatal("somehow trying to watch file above the fs root")
 					}
-				} else if err == syscall.ENOSPC {
+					continue
+				}
+				if err == syscall.ENOSPC {
 					// XXX: occasionally: no space left on device,
 					// XXX: probably due to lack of inotify watches
 					log.Printf("%v[%v]: Out of inotify watches!", obj.Kind(), obj.GetName())
-					log.Fatal(err)
 				} else {
 					log.Printf("Unknown file[%v] error:", obj.Name)
-					log.Fatal(err)
 				}
-				continue
+				log.Fatal(err)
 			}
 			watching = true
 		}


### PR DESCRIPTION
So here's my proposal for an easier logic around watching files and their parent directories if necessary. It's quite a mouthful, it is likely easier to review the initial commit first. It's the biggest, but it avoids unnecessary shortcuts and should be more comprehensible than the full diff.

The followups clear up some problems I found during testing. Here's how to reproduce. Graph:
```yaml
---
graph: mygraph
resources:
  file:
  - name: file1
    path: "/tmp/mgmt-test/a/b/c/file"
    content: |
      i am file
    state: exists
edges: []
```

Run mgmt without a/b/c/ existing. It will watch /tmp/mgmt-test. Now `mkdir -p /tmp/mgmt-test/a/b/c`. Current master will start watching `/tmp/mgmt-test/a`, and miss both a/b and a/b/c.

The new logic just finds the longest path prefix it can watch on every loop iteration, and *will* start watching `/tmp/mgmt-test/a/b/c`.

This still has a major problem: Even though mgmt is now *watching* the file's parent, it has missed its creation event, and hence not `CheckApply` is triggered. This is a tough one, unless we pragmatically decide to send resource events from *any* directory creation notification.

All that said, I hope this proposal makes it easier to reason about this code's behavior. It will definitely help me add directory handling. Note that I did away with carrying the deltaDepth in favor of doing the math whenever required.