### PR TITLE
Add recording and slides from DebConf16 presentation by James Shubin

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ We'd love to have your patches! Please send them by email, or as a pull request.
 * Felix Frank; blog: [Puppet Powered Mgmt (puppet to mgmt tl;dr)](https://ffrank.github.io/features/2016/06/19/puppet-powered-mgmt/)
 * James Shubin; blog: [Automatic clustering in mgmt](https://ttboj.wordpress.com/2016/06/20/automatic-clustering-in-mgmt/)
 * James Shubin; video: [Recording from CoreOSFest 2016](https://www.youtube.com/watch?v=KVmDCUA42wc&html5=1)
+* James Shubin; video: [Recording from DebConf16](http://meetings-archive.debian.net/pub/debian-meetings/2016/debconf16/Next_Generation_Config_Mgmt.webm) ([Slides](https://annex.debconf.org//debconf-share/debconf16/slides/15-next-generation-config-mgmt.pdf))
 
 ##
 


### PR DESCRIPTION
Just watched the recording from DebConf, checked out the repo and saw that the video link was  missing.
Fixed  :+1: