### PR TITLE
Change "uname -i" to "uname -m" to be portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifeq ($(VERSION),$(SVERSION))
 else
 	RELEASE = untagged
 endif
-ARCH = $(uname -i)
+ARCH = $(uname -m)
 SPEC = rpmbuild/SPECS/$(PROGRAM).spec
 SOURCE = rpmbuild/SOURCES/$(PROGRAM)-$(VERSION).tar.bz2
 SRPM = rpmbuild/SRPMS/$(PROGRAM)-$(VERSION)-$(RELEASE).src.rpm


### PR DESCRIPTION
According to the documentation for uname:

       -m, --machine
              print the machine hardware name

       -i, --hardware-platform
              print the hardware platform (non-portable)

So use the portable -m version.