### PR TITLE
Add pcap.h dependency on Debian/Ubuntu

### DIFF
--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -29,6 +29,7 @@ if [ $travis -eq 0 ]; then
 		# one of these two golang tools packages should work on debian
 		$sudo_command $APT install -y golang-golang-x-tools || true
 		$sudo_command $APT install -y golang-go.tools || true
+		$sudo_command $APT install -y libpcap0.8-dev || true
 	fi
 fi
 


### PR DESCRIPTION
```
# github.com/akrennmair/gopcap
../../akrennmair/gopcap/pcap.go:12:18: fatal error: pcap.h: No such file or directory
compilation terminated.
# github.com/purpleidea/mgmt/vendor/github.com/coreos/etcd/cmd/vendor/github.com/akrennmair/gopcap
vendor/github.com/coreos/etcd/cmd/vendor/github.com/akrennmair/gopcap/pcap.go:12:18: fatal error: pcap.h: No such file or directory
compilation terminated.
```
`make deps` returns this error on Ubuntu 16.04. The added dependency solve this issue.


