### PR TITLE
virt: don't set emulator path

### DIFF
--- a/resources/virt.go
+++ b/resources/virt.go
@@ -525,9 +525,6 @@ func (obj *VirtRes) getDomainXML() string {
 	b += fmt.Sprintf("</os>")
 
 	b += fmt.Sprintf("<devices>") // start devices
-	// TODO: use capabilities to determine emulator
-	//b += "<emulator>/usr/bin/kvm-spice</emulator>" // TODO: ?
-	b += "<emulator>/usr/bin/qemu-kvm</emulator>"
 
 	if obj.Disk != nil {
 		for i, disk := range obj.Disk {


### PR DESCRIPTION
Remove the implicit emulator path from the domain definition. Libvirt is
already configured to use the correct emulator for kvm or qemu and
specifying it creates distro dependence.

Fixes #85