### PR TITLE
spec: Fix rpmlint warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ $(SRPM): $(SPEC) $(SOURCE)
 #
 $(SPEC): rpmbuild/ spec.in
 	@echo Running templater...
-	#cat spec.in > $(SPEC)
+	cat spec.in > $(SPEC)
 	sed -e s/__PROGRAM__/$(PROGRAM)/g -e s/__VERSION__/$(VERSION)/g -e s/__RELEASE__/$(RELEASE)/g < spec.in > $(SPEC)
 	# append a changelog to the .spec file
 	git log --format="* %cd %aN <%aE>%n- (%h) %s%d%n" --date=local | sed -r 's/[0-9]+:[0-9]+:[0-9]+ //' >> $(SPEC)

--- a/spec.in
+++ b/spec.in
@@ -13,18 +13,18 @@ Source0:	https://dl.fedoraproject.org/pub/alt/purpleidea/__PROGRAM__/SOURCES/__P
 Requires: graphviz
 
 # If go_compiler is not set to 1, there is no virtual provide. Use golang instead.
-BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang}
+BuildRequires:	%{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang}
 BuildRequires:	golang-googlecode-tools-stringer
 BuildRequires:	git-core
 BuildRequires:	mercurial
 
-ExclusiveArch:  %{go_arches}
+ExclusiveArch:	%{go_arches}
 
 %description
 A next generation config management prototype!
 
 %prep
-%setup
+%setup -q
 
 %build
 # FIXME: in the future, these could be vendor-ed in


### PR DESCRIPTION
Minor fixes for ``rpmlint`` errors:

- Switched spces to tabs
- Added quiet switch to setup