### PR TITLE
github: Add ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Thank you for your interest in mgmt.
+
+This area (github issues) is reserved for bugs in mgmt.
+
+Please use other communication channels for support and/or discussions about the
+future of mgmt:
+
+- IRC: #mgmtconfig on Freenode
+- Mailing list: https://www.redhat.com/mailman/listinfo/mgmtconfig-list
+-->
+
+<!-- Some information about your mgmt setup -->
+
+## mgmt setup
+
+* mgmt version (or git hash):
+
+* operating system/distribution:
+
+* go version:
+
+* compilation options (if any):
+
+## description of the issue
+


### PR DESCRIPTION
Let's add a ISSUE_TEMPLATE so people know that github issue is not the
preferred place to start discussions.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>