### PR TITLE
resources: file: MkdirAll parent directories

### DIFF
--- a/resources/file.go
+++ b/resources/file.go
@@ -58,6 +58,7 @@ type FileRes struct {
 	Group      string  `yaml:"group"`
 	Mode       string  `yaml:"mode"`
 	Recurse    bool    `yaml:"recurse"`
+	Parents    bool    `yaml:"parents"` // create parent directories?
 	Force      bool    `yaml:"force"`
 	path       string  // computed path
 	isDir      bool    // computed isDir
@@ -413,6 +414,13 @@ func (obj *FileRes) fileCheckApply(apply bool, src io.ReadSeeker, dst string, sh
 	}
 	if obj.debug {
 		log.Printf("fileCheckApply: Apply: %s -> %s", src, dst)
+	}
+
+	if obj.Parents {
+		err = os.MkdirAll(filepath.Dir(dst), os.ModePerm)
+		if err != nil {
+			return sha256sum, false, err
+		}
 	}
 
 	dstClose() // unlock file usage so we can write to it

--- a/test/shell/t2.sh
+++ b/test/shell/t2.sh
@@ -16,5 +16,6 @@ test -e /tmp/mgmt/f1
 test -e /tmp/mgmt/f2
 test -e /tmp/mgmt/f3
 test ! -e /tmp/mgmt/f4
+test -e /tmp/mgmt/a/long/long/path/f5
 
 exit $e

--- a/test/shell/t2.yaml
+++ b/test/shell/t2.yaml
@@ -24,6 +24,12 @@ resources:
     content: |
       i am f4 and i should not be here
     state: absent
+  - name: file5
+    path: "/tmp/mgmt/a/long/long/path/f5"
+    parents: true
+    content: |
+      i am f5
+    state: exists
 edges:
 - name: e1
   from:


### PR DESCRIPTION
File resource fail if their parent directories is not there. Have it create them all if required. Existing autoedges to them makes it possible to customize them if needed (owner, permissions, ...)