### PR TITLE
prometheus: Remove mgmt_process_start_time_seconds metric

### DIFF
--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -52,7 +52,6 @@ Here is a list of the metrics we provide:
 - `mgmt_checkapply_total`: The number of CheckApply's that mgmt has run
 - `mgmt_failures_total`: The number of resources that have failed
 - `mgmt_failures_current`: The number of resources that have failed
-- `mgmt_process_start_time_seconds`: Start time of the process since unix epoch in seconds
 
 For each metric, you will get some extra labels:
 

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -36,8 +36,7 @@ const DefaultPrometheusListen = "127.0.0.1:9233"
 type Prometheus struct {
 	Listen string // the listen specification for the net/http server
 
-	checkApplyTotal         *prometheus.CounterVec // total of CheckApplies that have been triggered
-	processStartTimeSeconds prometheus.Gauge       // process start time in seconds since unix epoch
+	checkApplyTotal *prometheus.CounterVec // total of CheckApplies that have been triggered
 
 }
 
@@ -59,16 +58,6 @@ func (obj *Prometheus) Init() error {
 		[]string{"kind", "apply", "eventful", "errorful"},
 	)
 	prometheus.MustRegister(obj.checkApplyTotal)
-
-	obj.processStartTimeSeconds = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "mgmt_process_start_time_seconds",
-			Help: "Start time of the process since unix epoch in seconds.",
-		},
-	)
-	prometheus.MustRegister(obj.processStartTimeSeconds)
-	// directly set the processStartTimeSeconds
-	obj.processStartTimeSeconds.SetToCurrentTime()
 
 	return nil
 }

--- a/test/shell/prometheus-1.sh
+++ b/test/shell/prometheus-1.sh
@@ -11,9 +11,6 @@ curl 127.0.0.1:9233/metrics | grep "^etcd_server_has_leader 1"
 # Check that go metrics are loaded
 curl 127.0.0.1:9233/metrics | grep "^go_goroutines [0-9]\+"
 
-# Check mgmt_process_start_time_seconds
-curl 127.0.0.1:9233/metrics | grep "^mgmt_process_start_time_seconds [0-9]\+"
-
 killall -SIGINT mgmt	# send ^C to exit mgmt
 wait $pid	# get exit status
 exit $?


### PR DESCRIPTION
That metric is useless as by default the prometheus golang client
provides the `process_start_time_seconds` metric.

This reverts commit 25e2af7c89a7b91ffc21e29271ebf4970d59811c.