### PR TITLE
resources: file: Allow creation of empty directories

### DIFF
--- a/test/shell/t2.sh
+++ b/test/shell/t2.sh
@@ -16,5 +16,6 @@ test -e /tmp/mgmt/f1
 test -e /tmp/mgmt/f2
 test -e /tmp/mgmt/f3
 test ! -e /tmp/mgmt/f4
+test -d /tmp/mgmt/dir1
 
 exit $e

--- a/test/shell/t2.yaml
+++ b/test/shell/t2.yaml
@@ -24,6 +24,9 @@ resources:
     content: |
       i am f4 and i should not be here
     state: absent
+  - name: dir1
+    path: "/tmp/mgmt/dir1/"
+    state: exists
 edges:
 - name: e1
   from:


### PR DESCRIPTION
I could not get mgmt to create empty directories with the file resource, I believe this was not implemented hence this PR. If it is indeed implemented, the test and the doc should probably be updated.