### PR TITLE
misc: systemd unit: Split OPTS variable

### DIFF
--- a/misc/mgmt.service
+++ b/misc/mgmt.service
@@ -5,7 +5,7 @@ After=systemd-networkd.service
 Requires=systemd-networkd.service
 
 [Service]
-ExecStart=/usr/bin/mgmt run ${OPTS}
+ExecStart=/usr/bin/mgmt run $OPTS
 RestartSec=5s
 Restart=always
 

--- a/misc/mgmt.service
+++ b/misc/mgmt.service
@@ -5,6 +5,7 @@ After=systemd-networkd.service
 Requires=systemd-networkd.service
 
 [Service]
+Environment="OPTS=--yaml /etc/mgmt.yaml"
 ExecStart=/usr/bin/mgmt run $OPTS
 RestartSec=5s
 Restart=always


### PR DESCRIPTION
Systemd split variables when specified like `$VAR` and not when specified
like `${VAR}`. Since `OPTS` must contain multiple options, we must ensure
systemd will split it.

See also systemd.service(5)