### PR TITLE
compilation: Make build the default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ ifneq ($(GOTAGS),)
     BUILD_FLAGS = -tags '$(GOTAGS)'
 endif
 
+default: build
+
 #
 #	art
 #


### PR DESCRIPTION
It is really strange that whe I run make, it does not build mgmt. This
commit makes build the default target, without moving the target,
therefore we keep as much as we can the order of the file.

This also removes the confusion for designers that would run "make"
instead of "make art", whose work would be disrupted when we add a --
let's say -- make alpharelese command.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>