### PR TITLE
travis: Add go_import_path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.7.x
   - 1.8.x
   - tip
+go_import_path: github.com/purpleidea/mgmt
 sudo: true
 dist: trusty
 before_install:


### PR DESCRIPTION
This should fix an issue with turning on travis for any mgmt fork.