### PR TITLE
hcl: Removed edge object in favor of depends_on field in resource

### DIFF
--- a/examples/graph0.hcl
+++ b/examples/graph0.hcl
@@ -2,19 +2,13 @@ resource "file" "file1" {
   path = "/tmp/mgmt-hello-world"
   content = "hello, world"
   state = "exists"
+  depends_on = ["noop.noop1", "exec.sleep"]
 }
 
 resource "noop" "noop1" {
   test = "nil"
 }
 
-edge "e1" {
-  from = {
-    kind = "noop"
-    name = "noop1"
-  }
-  to = {
-    kind = "file"
-    name = "file1"
-  }
+resource "exec" "sleep" {
+ cmd = "sleep 10s"
 }


### PR DESCRIPTION
This removes the `edge` type in hcl and adds a `depends_on` field in the `resource` type

For example.
```
edge "e1" {
  from = {
    kind = "noop"
    name = "noop1"
  }
  to = {
    kind = "file"
    name = "file1"
  }
}
```

can now be done in the `resource` that is going to be the "to" node of the edge. It uses the syntax of `<resource-type>.<resource-name>`

```
resource "file" "file1" {
  path = "/tmp/mgmt-hello-world"
  content = "hello, world"
  state = "exists"
  depends_on = ["noop.noop1"]
}
```