### PR TITLE
hcl: added hil string interpolation to hcl frontend

### DIFF
--- a/examples/hil.hcl
+++ b/examples/hil.hcl
@@ -1,0 +1,9 @@
+resource "file" "file1" {
+  path = "/tmp/mgmt-hello-world"
+  content = "${exec.sleep.Output}"
+  state = "exists"
+}
+
+resource "exec" "sleep" {
+ cmd = "echo hello"
+}

--- a/hil/interpolate.go
+++ b/hil/interpolate.go
@@ -1,0 +1,89 @@
+// Mgmt
+// Copyright (C) 2013-2017+ James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package hil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hil/ast"
+)
+
+// Variable defines an interpolated variable.
+type Variable interface {
+	Key() string
+}
+
+// ResourceVariable defines a variable type used to reference fields of a resource
+// e.g.  ${file.file1.Content}
+type ResourceVariable struct {
+	Kind, Name, Field string
+}
+
+// Key returns a string representation of the variable key.
+func (r *ResourceVariable) Key() string {
+	return fmt.Sprintf("%s.%s.%s", r.Kind, r.Name, r.Field)
+}
+
+// NewInterpolatedVariable takes a variable key and return the interpolated variable
+// of the required type.
+func NewInterpolatedVariable(k string) (Variable, error) {
+	// for now resource variables are the only thing.
+	parts := strings.SplitN(k, ".", 3)
+
+	return &ResourceVariable{
+		Kind:  parts[0],
+		Name:  parts[1],
+		Field: parts[2],
+	}, nil
+}
+
+// ParseVariables will traverse a HIL tree looking for variables and returns a
+// list of them.
+func ParseVariables(tree ast.Node) ([]Variable, error) {
+	var result []Variable
+	var finalErr error
+
+	visitor := func(n ast.Node) ast.Node {
+		if finalErr != nil {
+			return n
+		}
+
+		switch nt := n.(type) {
+		case *ast.VariableAccess:
+			v, err := NewInterpolatedVariable(nt.Name)
+			if err != nil {
+				finalErr = err
+				return n
+			}
+			result = append(result, v)
+		default:
+			return n
+		}
+
+		return n
+	}
+
+	tree.Accept(visitor)
+
+	if finalErr != nil {
+		return nil, finalErr
+	}
+
+	return result, nil
+}

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -139,6 +139,7 @@ type Base interface {
 	Refresh() bool                         // is there a pending refresh to run?
 	SetRefresh(bool)                       // set the refresh state of this resource
 	SendRecv(Res) (map[string]bool, error) // send->recv data passing function
+	SetRecv(map[string]*Send)
 	IsStateOK() bool
 	StateOK(b bool)
 	GroupCmp(Res) bool  // TODO: is there a better name for this?

--- a/resources/sendrecv.go
+++ b/resources/sendrecv.go
@@ -173,6 +173,11 @@ type Send struct {
 	Changed bool // set to true if this key was updated, read only!
 }
 
+// SetRecv sets the Res Recv field to given map of Send structs
+func (obj *BaseRes) SetRecv(recv map[string]*Send) {
+	obj.Recv = recv
+}
+
 // SendRecv pulls in the sent values into the receive slots. It is called by the
 // receiver and must be given as input the full resource struct to receive on.
 func (obj *BaseRes) SendRecv(res Res) (map[string]bool, error) {


### PR DESCRIPTION
This adds string interpolation to fields in hcl frontend, allowing for declarative `Receiver` support and automatically creates edges for resources that use values from other resources.

*Example*
```
resource "file" "file1" {
  path = "/tmp/mgmt-hello-world"
  content = "${exec.sleep.Output}"
  state = "exists"
}

resource "exec" "sleep" {
 cmd = "echo hello"
}
```

The following will create a file at `/tmp/mgmt-hello-world` with `hello` as the contents.

*Gotchas:*
- currently you need to capitalize the field name (i.e. `Output`) 