### PR TITLE
vagrant: Fix PATH.

### DIFF
--- a/vagrant/mgmt.bashrc
+++ b/vagrant/mgmt.bashrc
@@ -2,3 +2,4 @@
 alias cdmgmt='cd $GOPATH/src/github.com/purpleidea/mgmt'
 
 export GOPATH=~/gopath
+export PATH=${GOPATH}/bin:${PATH}


### PR DESCRIPTION
gometalinter failed because it's not in $PATH