### PR TITLE
resources: Refresh packagekit cache before install

### DIFF
--- a/resources/packagekit/packagekit.go
+++ b/resources/packagekit/packagekit.go
@@ -396,7 +396,11 @@ func (bus *Conn) InstallPackages(packageIDs []string, transactionFlags uint64) e
 	bus.matchSignal(ch, interfacePath, PkIfaceTransaction, signals)
 
 	obj := bus.GetBus().Object(PkIface, interfacePath) // pass in found transaction path
-	call := obj.Call(FmtTransactionMethod("InstallPackages"), 0, transactionFlags, packageIDs)
+	call := obj.Call(FmtTransactionMethod("RefreshCache"), 0, false)
+	if call.Err != nil {
+		return call.Err
+	}
+	call = obj.Call(FmtTransactionMethod("InstallPackages"), 0, transactionFlags, packageIDs)
 	if call.Err != nil {
 		return call.Err
 	}


### PR DESCRIPTION
Fixes #80 
Packagekit has its own cache and if that cache is empty or invalid it won't refresh it automatically