### PR TITLE
travis: Allow travis builds to access target branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ sudo: true
 dist: trusty
 before_install:
   - sudo apt update
+  - git config remote.origin.fetch +refs/heads/${TRAVIS_BRANCH}:refs/remotes/origin/${TRAVIS_BRANCH}
   - git fetch --unshallow
 install: 'make deps'
 script: 'make test'


### PR DESCRIPTION
Finally works. Turns out travis sets remote.origin.fetch to a temporary version of the master branch, so we have to override with our own remote.origin.fetch before we fetch.