### PR TITLE
resources: aws: ec2: bugfixes

### DIFF
--- a/resources/aws_ec2.go
+++ b/resources/aws_ec2.go
@@ -907,9 +907,11 @@ func (obj *AwsEc2Res) prependName() string {
 }
 
 // snsListener returns a listener bound to watchlistenaddr.
-func (obj *AwsEc2Res) snsListener(addr string) (net.Listener, error) {
-	if _, err := strconv.Atoi(obj.WatchListenAddr); err == nil {
-		addr = fmt.Sprintf(":%s", obj.WatchListenAddr)
+func (obj *AwsEc2Res) snsListener(listenAddr string) (net.Listener, error) {
+	addr := listenAddr
+	// if listenAddr is a port
+	if _, err := strconv.Atoi(listenAddr); err == nil {
+		addr = fmt.Sprintf(":%s", listenAddr)
 	}
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/resources/aws_ec2.go
+++ b/resources/aws_ec2.go
@@ -582,7 +582,6 @@ func (obj *AwsEc2Res) snsWatch() error {
 	send := false
 	var exit *error
 	defer obj.wg.Wait()
-	defer close(obj.closeChan)
 	// create the sns listener
 	// closing is handled by http.Server.Shutdown in the defer func below
 	listener, err := obj.snsListener(obj.WatchListenAddr)
@@ -605,6 +604,7 @@ func (obj *AwsEc2Res) snsWatch() error {
 			log.Printf("%s: sns server shutdown cancelled", obj)
 		}
 	}()
+	defer close(obj.closeChan)
 	obj.wg.Add(1)
 	// start the sns server
 	go func() {


### PR DESCRIPTION
I think this is now race free. 
Here's the control flow:

0. SIGINT is received from CTRL^C
1. Shutdown() is called
2. Server immediately returns http.ErrServerClosed
3. Open listener(s) and idle connection(s) are closed
4. Shutdown() returns any errors from closing the listeners or context
5. We return *exit