### PR TITLE
prometheus: Initialize mgmt_checkapply_total metrics

### DIFF
--- a/lib/main.go
+++ b/lib/main.go
@@ -269,6 +269,10 @@ func (obj *Main) Run() error {
 		if err := prom.Start(); err != nil {
 			return errwrap.Wrapf(err, "can't start initiate Prometheus instance")
 		}
+
+		if err := prom.InitKindMetrics(resources.RegisteredResourcesNames()); err != nil {
+			return errwrap.Wrapf(err, "can't initialize kind-specific prometheus metrics")
+		}
 	}
 
 	if !obj.NoPgp {

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -149,6 +149,31 @@ func (obj *Prometheus) Stop() error {
 	return nil
 }
 
+// InitKindMetrics initialized prometheus counters. For each kind of
+// resource checkApply counters are initialized with all the possible value.
+func (obj *Prometheus) InitKindMetrics(kinds []string) error {
+	if obj == nil {
+		return nil // happens when mgmt is launched without --prometheus
+	}
+	bools := []bool{true, false}
+	for _, kind := range kinds {
+		for _, apply := range bools {
+			for _, eventful := range bools {
+				for _, errorful := range bools {
+					labels := prometheus.Labels{
+						"kind":     kind,
+						"apply":    strconv.FormatBool(apply),
+						"eventful": strconv.FormatBool(eventful),
+						"errorful": strconv.FormatBool(errorful),
+					}
+					obj.checkApplyTotal.With(labels)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // UpdateCheckApplyTotal refreshes the failing gauge by parsing the internal
 // state map.
 func (obj *Prometheus) UpdateCheckApplyTotal(kind string, apply, eventful, errorful bool) error {

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -52,6 +52,15 @@ func RegisterResource(kind string, fn func() Res) {
 	registeredResources[kind] = fn
 }
 
+// RegisteredResourcesNames returns the kind of the registered resources.
+func RegisteredResourcesNames() []string {
+	kinds := []string{}
+	for k := range registeredResources {
+		kinds = append(kinds, k)
+	}
+	return kinds
+}
+
 // NewResource returns an empty resource object from a registered kind. It
 // errors if the resource kind doesn't exist.
 func NewResource(kind string) (Res, error) {

--- a/resources/resources_test.go
+++ b/resources/resources_test.go
@@ -78,6 +78,18 @@ func TestIFF(t *testing.T) {
 	}
 }
 
+func TestRegisteredResourcesNames(t *testing.T) {
+	kinds := RegisteredResourcesNames()
+	for _, kind := range kinds {
+		if kind == "" {
+			t.Error("Empty kind found")
+		}
+	}
+	if len(kinds) == 0 {
+		t.Error("No registered resources")
+	}
+}
+
 func TestReadEvent(t *testing.T) {
 	//res := FileRes{}
 


### PR DESCRIPTION
It is recommended by Prometheus to initialize metrics:

https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics

This commits initialize the mgmt_checkapply_total metric
for each registered resource.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

## Tips:

* commit message titles must be in the form:
```topic: Capitalized message with no trailing period```
or:
```topic, topic2: Capitalized message with no trailing period```

* golang code must be formatted according to the standard, please run:
```
make gofmt		# formats the entire project correctly
```
or format a single golang file correctly:
```
gofmt -w yourcode.go
```

* please rebase your patch against current git master:
```
git checkout master
git pull origin master
git checkout your-feature
git rebase master
git push your-remote your-feature
hub pull-request	# or submit with the github web ui
```

* after a patch review, please ping @purpleidea so we know to re-review:
```
# make changes based on reviews...
git add -p		# add new changes
git commit --amend	# combine with existing commit
git push your-remote your-feature -f
# now ping @purpleidea in the github PR since it doesn't notify us automatically
```

## Thanks for contributing to mgmt and welcome to the team!
