### PR TITLE
resources: virt: Update libvirt-xml target

### DIFF
--- a/resources/virt.go
+++ b/resources/virt.go
@@ -185,9 +185,9 @@ func (obj *VirtRes) Init() error {
 
 		// guest agent: domain->devices->channel->target->state == connected?
 		for _, x := range domXML.Devices.Channels {
-			if x.Target.Type == "virtio" && strings.HasPrefix(x.Target.Name, "org.qemu.guest_agent.") {
+			if x.Target.VirtIO != nil && strings.HasPrefix(x.Target.VirtIO.Name, "org.qemu.guest_agent.") {
 				// last connection found wins (usually 1 anyways)
-				obj.guestAgentConnected = (x.Target.State == "connected")
+				obj.guestAgentConnected = (x.Target.VirtIO.State == "connected")
 			}
 		}
 	}


### PR DESCRIPTION
~~***This compiles, and in theory should work, but I haven't tested it***~~

Builds started failing due to go-libvirt-xml 6d97448. In that patch,
the DomainChannelTarget struct was changed from having a single type
field, to having an individual field for each virtualization type.

This patch updates the connection check in Init to reflect the changes
to go-libvirt-xml, so that builds no longer fail.