### PR TITLE
puppet: avoid empty parameters to puppet mgmtgraph

### DIFF
--- a/puppet/puppet.go
+++ b/puppet/puppet.go
@@ -89,19 +89,20 @@ func runPuppetCommand(cmd *exec.Cmd) ([]byte, error) {
 // ParseConfigFromPuppet takes a special puppet param string and config and
 // returns the graph configuration structure.
 func ParseConfigFromPuppet(puppetParam, puppetConf string) *yamlgraph.GraphConfig {
-	var puppetConfArg string
-	if puppetConf != "" {
-		puppetConfArg = "--config=" + puppetConf
+	var args []string
+	if puppetParam == "agent" {
+		args = []string{"mgmtgraph", "print"}
+	} else if strings.HasSuffix(puppetParam, ".pp") {
+		args = []string{"mgmtgraph", "print", "--manifest", puppetParam}
+	} else {
+		args = []string{"mgmtgraph", "print", "--code", puppetParam}
 	}
 
-	var cmd *exec.Cmd
-	if puppetParam == "agent" {
-		cmd = exec.Command("puppet", "mgmtgraph", "print", puppetConfArg)
-	} else if strings.HasSuffix(puppetParam, ".pp") {
-		cmd = exec.Command("puppet", "mgmtgraph", "print", puppetConfArg, "--manifest", puppetParam)
-	} else {
-		cmd = exec.Command("puppet", "mgmtgraph", "print", puppetConfArg, "--code", puppetParam)
+	if puppetConf != "" {
+		args = append(args, "--config="+puppetConf)
 	}
+
+	cmd := exec.Command("puppet", args...)
 
 	log.Println("Puppet: launching translator")
 


### PR DESCRIPTION
This solves an issue first observed with golang 1.8.

Creating an exec.Command with an empty string parameter (when no puppet.conf
file is specified) would lead to an error from Puppet, stating that an
unexpected argument was passed to "puppet mgmtgraph print".

The workaround is to not include *any* positional argument (not even the
empty string) when --puppet-conf is not used.
