### PR TITLE
test: Don't fail on tag builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: true
 dist: trusty
 before_install:
   - sudo apt update
-  - git config remote.origin.fetch +refs/heads/${TRAVIS_BRANCH}:refs/remotes/origin/${TRAVIS_BRANCH}
+  - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
   - git fetch --unshallow
 install: 'make deps'
 script: 'make test'


### PR DESCRIPTION
This seems to be causing our failures with:

$ git fetch --unshallow
fatal: Couldn't find remote ref refs/heads/0.0.14

Hopefully this doesn't break the other use case we added this patch for!
