### PR TITLE
misc: Don't install packages that are already installed

### DIFF
--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -43,7 +43,7 @@ if [ ! -z "$BREW" ]; then
 fi
 
 if [ ! -z "$PACMAN" ]; then
-	$sudo_command $PACMAN -S --noconfirm libvirt augeas libpcap
+	$sudo_command $PACMAN -S --noconfirm --asdeps --needed libvirt augeas libpcap
 fi
 
 if [ $travis -eq 0 ]; then
@@ -60,7 +60,7 @@ if [ $travis -eq 0 ]; then
 		$sudo_command $APT install -y golang-go.tools || true
 	fi
 	if [ ! -z "$PACMAN" ]; then
-		$sudo_command $PACMAN -S --noconfirm go
+		$sudo_command $PACMAN -S --noconfirm --asdeps --needed go
 	fi
 fi
 


### PR DESCRIPTION
pacman needs `--needed` to prevent reinstalling packages that are
already installed. Without it, pacman will reinstall packages that are already installed. With this switch, packages that are already installed won't be reinstalled.

Additionally I added `--asdeps` to allow later cleanup of unneeded dependencies. This marks the installed packages as dependencies so they can be cleaned up via pacman when cleaning up unused dependencies.