### PR TITLE
language: Use universal way to retrieve loadavg.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Tips:
 
 * please read the style guide before submitting your patch:
-[docs/style-guide.md](docs/style-guide.md)
+[docs/style-guide.md](../docs/style-guide.md)
 
 * commit message titles must be in the form:
 ```topic: Capitalized message with no trailing period```

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+os:
+  - linux
+  - osx
 go:
   - 1.8.x
   - 1.9.x
@@ -7,7 +10,7 @@ go_import_path: github.com/purpleidea/mgmt
 sudo: true
 dist: trusty
 before_install:
-  - sudo apt update
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo apt update; fi
   - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
   - git fetch --unshallow
 install: 'make deps'
@@ -17,6 +20,7 @@ matrix:
   allow_failures:
     - go: tip
     - go: 1.9.x
+    - os: osx
 notifications:
   irc:
     channels:

--- a/bindata/Makefile
+++ b/bindata/Makefile
@@ -35,4 +35,4 @@ bindata.go: ../COPYING
 
 clean:
 	# remove generated bindata/*.go
-	@ROOT=$$(dirname "$${BASH_SOURCE}")/.. && rm *.go
+	@ROOT=$$(dirname "$${BASH_SOURCE}")/.. && rm -f *.go

--- a/docker/scripts/exec-development
+++ b/docker/scripts/exec-development
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# runs command provided as argument inside a development (Linux) Docker container
+
+# Stop on any error
+set -e
+
+script_directory="$( cd "$( dirname "$0" )" && pwd )"
+project_directory=$script_directory/../..
+
+# Specify the Docker image name
+image_name='purpleidea/mgmt:development'
+
+# Run container in development mode
+docker run --rm --name=mgm_development --user=mgmt \
+	-v "$project_directory:/go/src/github.com/purpleidea/mgmt/" \
+	-w /go/src/github.com/purpleidea/mgmt/ \
+	-it "$image_name" /bin/bash -c "$*"

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -14,6 +14,7 @@ Once you're familiar with the general idea, please start hacking...
 * You need golang version 1.8 or greater installed.
 ** To install on rpm style systems: `sudo dnf install golang`
 ** To install on apt style systems: `sudo apt install golang`
+** To install on macOS systems install [Homebrew](https://brew.sh) and run: `brew install go`
 * You can run `go version` to check the golang version.
 * If your distro is tool old, you may need to [download](https://golang.org/dl/) a newer golang version.
 
@@ -97,3 +98,43 @@ At the moment we have:
 * [Arch](https://aur.archlinux.org/packages/mgmt/)
 
 Please contribute more! We'd especially like to see a Debian package!
+
+## OSX/macOS/Darwin development
+Developing and running `mgmt` on macOS is currently not supported (but not discouraged either). Meaning it might work but in the case it doesn't you would have to provide your own patches to fix problems (the project maintainer and community are glad to assist where needed).
+
+There are currently some issues that make `mgmt` less suitable to run for provisioning macOS (eg: https://github.com/purpleidea/mgmt/issues/33). But as a client to provision remote servers it should run fine.
+
+Since the primary supported systems are Linux and these are the environments tested for it is wise to run these suites during macOS development as well. To ease this Docker can be levaraged ((Docker for Mac)[https://docs.docker.com/docker-for-mac/]).
+
+Before running any of the commands below create the development Docker image:
+
+```
+docker/scripts/build-development
+```
+
+This image requires updating every time dependencies (`make-deps.sh`) change.
+
+Then to run the test suite:
+
+```
+docker run --rm -ti \
+  -v $PWD:/go/src/github.com/purpleidea/mgmt/ \
+  -w /go/src/github.com/purpleidea/mgmt/ \
+  purpleidea/mgmt:development \
+  make test
+```
+
+For convenience this command is wrapped in `docker/scripts/exec-development`.
+
+Basically any command can be executed this way. Because the repository source is mounted into the Docker container invocation will be quick and allow rapid testing, example:
+
+```
+docker/scripts/exec-development test/test-shell.sh load0.sh
+```
+
+Other examples:
+
+```
+docker/scripts/exec-development make build
+docker/scripts/exec-development ./mgmt run --tmp-prefix --lang examples/lang/load0.mcl
+```

--- a/lang/funcs/facts/core/load_darwin.go
+++ b/lang/funcs/facts/core/load_darwin.go
@@ -1,0 +1,38 @@
+// Mgmt
+// Copyright (C) 2013-2018+ James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// +build darwin
+
+package core // TODO: should this be in its own individual package?
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+// macOS/Darwin specific implementation to get load.
+func load() (one, five, fifteen float64, err error) {
+	avg := []C.double{0, 0, 0}
+
+	C.getloadavg(&avg[0], C.int(len(avg)))
+
+	one = float64(avg[0])
+	five = float64(avg[1])
+	fifteen = float64(avg[2])
+
+	return
+}

--- a/lang/funcs/facts/core/load_posix.go
+++ b/lang/funcs/facts/core/load_posix.go
@@ -1,0 +1,45 @@
+// Mgmt
+// Copyright (C) 2013-2018+ James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// +build !darwin
+
+package core // TODO: should this be in its own individual package?
+
+import (
+	"syscall"
+)
+
+const (
+	// LoadScale factor scales the output from sysinfo to the correct float
+	// value.
+	LoadScale = 65536 // XXX: is this correct or should it be 65535?
+)
+
+// load returns the system load averages for the last minute, five minutes and
+// fifteen minutes. Calling this more often than once every five seconds seems
+// to be unnecessary, since the kernel only updates these values that often.
+// TODO: is the kernel update interval configurable?
+func load() (one, five, fifteen float64, err error) {
+	var sysinfo syscall.Sysinfo_t
+	if err = syscall.Sysinfo(&sysinfo); err != nil {
+		return
+	}
+	one = float64(sysinfo.Loads[0]) / LoadScale
+	five = float64(sysinfo.Loads[1]) / LoadScale
+	fifteen = float64(sysinfo.Loads[2]) / LoadScale
+	return
+}

--- a/lang/funcs/facts/core/loadfact.go
+++ b/lang/funcs/facts/core/loadfact.go
@@ -18,7 +18,6 @@
 package core // TODO: should this be in its own individual package?
 
 import (
-	"syscall"
 	"time"
 
 	"github.com/purpleidea/mgmt/lang/funcs/facts"
@@ -28,10 +27,6 @@ import (
 )
 
 const (
-	// LoadScale factor scales the output from sysinfo to the correct float
-	// value.
-	LoadScale = 65536 // XXX: is this correct or should it be 65535?
-
 	loadSignature = "struct{x1 float; x5 float; x15 float}"
 )
 
@@ -113,19 +108,4 @@ func (obj *LoadFact) Stream() error {
 func (obj *LoadFact) Close() error {
 	close(obj.closeChan)
 	return nil
-}
-
-// load returns the system load averages for the last minute, five minutes and
-// fifteen minutes. Calling this more often than once every five seconds seems
-// to be unnecessary, since the kernel only updates these values that often.
-// TODO: is the kernel update interval configurable?
-func load() (one, five, fifteen float64, err error) {
-	var sysinfo syscall.Sysinfo_t
-	if err = syscall.Sysinfo(&sysinfo); err != nil {
-		return
-	}
-	one = float64(sysinfo.Loads[0]) / LoadScale
-	five = float64(sysinfo.Loads[1]) / LoadScale
-	fifteen = float64(sysinfo.Loads[2]) / LoadScale
-	return
 }

--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -39,7 +39,8 @@ if [ ! -z "$APT" ]; then
 fi
 
 if [ ! -z "$BREW" ]; then
-	$BREW install libvirt || true
+	# coreutils contains gtimeout
+	$BREW install libvirt augeas coreutils || true
 fi
 
 if [ ! -z "$PACMAN" ]; then

--- a/resources/util.go
+++ b/resources/util.go
@@ -248,7 +248,7 @@ func GetUID(username string) (int, error) {
 
 	userObj, err = user.Lookup(username)
 	if err == nil {
-		return strconv.Atoi(userObj.Gid)
+		return strconv.Atoi(userObj.Uid)
 	}
 
 	return -1, errwrap.Wrapf(err, "user lookup error (%s)", username)

--- a/resources/util_test.go
+++ b/resources/util_test.go
@@ -334,7 +334,12 @@ func TestCurrentUserGroupByName(t *testing.T) {
 		t.Errorf("uid didn't match current user's: %s vs %s", strconv.Itoa(uid), currentUID)
 	}
 
-	if gid, err = GetGID(userObj.Username); err != nil {
+	// macOS users do not have a group with their name on it, so not assuming this here
+	group, err := user.LookupGroupId(currentGID)
+	if err != nil {
+		t.Errorf("failed to lookup group by id: %s", currentGID)
+	}
+	if gid, err = GetGID(group.Name); err != nil {
 		t.Errorf("error trying to lookup current user UID: %s", err.Error())
 	}
 

--- a/test/shell/augeas-1.sh
+++ b/test/shell/augeas-1.sh
@@ -10,7 +10,7 @@ mkdir -p "${MGMT_TMPDIR}"
 > "${MGMT_TMPDIR}"sshd_config
 
 # run empty graph, with prometheus support
-timeout --kill-after=40s 35s ./mgmt run --tmp-prefix --yaml=augeas-1.yaml &
+$timeout --kill-after=40s 35s ./mgmt run --tmp-prefix --yaml=augeas-1.yaml &
 pid=$!
 sleep 5s	# let it converge
 

--- a/test/shell/file-mode.sh
+++ b/test/shell/file-mode.sh
@@ -1,9 +1,15 @@
 #!/bin/bash -e
 
+if [[ $(uname) == "Darwin" ]] ; then
+	# https://github.com/purpleidea/mgmt/issues/33
+	echo "This test is broken on macOS, skipping!"
+	exit
+fi
+
 set -x
 
 # run till completion
-timeout --kill-after=40s 35s ./mgmt run --yaml file-mode.yaml --converged-timeout=5 --no-watch --tmp-prefix &
+$timeout --kill-after=40s 35s ./mgmt run --yaml file-mode.yaml --converged-timeout=5 --no-watch --tmp-prefix &
 pid=$!
 wait $pid	# get exit status
 e=$?

--- a/test/shell/file-move.sh
+++ b/test/shell/file-move.sh
@@ -1,10 +1,16 @@
 #!/bin/bash -e
 
+if [[ $(uname) == "Darwin" ]] ; then
+	# https://github.com/purpleidea/mgmt/issues/33
+	echo "This test is broken on macOS, skipping!"
+	exit
+fi
+
 mkdir -p /tmp/mgmt/
 rm /tmp/mgmt/f1 || true
 
 # run empty graph, with prometheus support
-timeout --kill-after=40s 35s ./mgmt run --tmp-prefix --yaml=file-move.yaml 2>&1 | tee /tmp/mgmt/file-move.log &
+$timeout --kill-after=40s 35s ./mgmt run --tmp-prefix --yaml=file-move.yaml 2>&1 | tee /tmp/mgmt/file-move.log &
 pid=$!
 sleep 5s	# let it converge
 

--- a/test/shell/file-owner.sh
+++ b/test/shell/file-owner.sh
@@ -9,7 +9,7 @@ if ! timeout 1s sudo -A true; then
 fi
 
 # run till completion
-timeout --kill-after=30s 25s sudo -A ./mgmt run --yaml file-owner.yaml --converged-timeout=5 --no-watch --tmp-prefix &
+$timeout --kill-after=30s 25s sudo -A ./mgmt run --yaml file-owner.yaml --converged-timeout=5 --no-watch --tmp-prefix &
 pid=$!
 wait $pid	# get exit status
 e=$?

--- a/test/shell/load0.sh
+++ b/test/shell/load0.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -e
+
+if env | grep -q -e '^TRAVIS=true$' && [[ $(uname) == "Darwin" ]]; then
+	# loadavg glibc calls don't seem to work properly on osx OS in travis
+	echo "Travis and Jenkins give wonky results here, skipping test!"
+	exit
+fi
+
+set -o errexit
+set -o pipefail
+
+# Expected load average values eg: load average: 1.64306640625, 1.8076171875, 1.82958984375
+# High precision results are preferred (more than the 2 digits in /proc/loadavg at least).
+# Precision varies (eg: 4, 9 or 11 digits). Hence no strict check for precision but
+# anything above 3 will do. It is assumed we will hardly ever get a precision lower than 3 digits
+# from the current implementations. Otherwise this test would need to be revised.
+regex="load average: [0-9]\,[0-9]{3,}, [0-9]\,[0-9]{3,}, [0-9]\,[0-9]{3,}"
+
+tmpdir="$($mktemp --tmpdir -d tmp.XXX)"
+
+# macOS workaround https://github.com/purpleidea/mgmt/issues/33
+touch "$tmpdir/loadavg"
+
+cat > "$tmpdir/load0.mcl" <<EOF
+\$theload = load()
+
+\$x1 = structlookup(\$theload, "x1")
+\$x5 = structlookup(\$theload, "x5")
+\$x15 = structlookup(\$theload, "x15")
+
+file "${tmpdir}/loadavg" {
+	content => printf("load average: %f, %f, %f", \$x1, \$x5, \$x15),
+	state => "exists",
+}
+EOF
+
+$timeout --kill-after=30s 15s ./mgmt run --tmp-prefix --converged-timeout=1 --lang "$tmpdir/load0.mcl"  &
+pid=$!
+wait $pid	# get exit status
+e=$?
+
+set +e
+egrep "$regex" "$tmpdir/loadavg" || fail_test "Could not match $tmpdir/loadavg to '$regex'."
+
+# cleanup if everything went well
+rm -r "$tmpdir"
+
+exit $e

--- a/test/shell/prometheus-3.sh
+++ b/test/shell/prometheus-3.sh
@@ -1,7 +1,13 @@
 #!/bin/bash -e
 
+if [[ $(uname) == "Darwin" ]] ; then
+	# https://github.com/purpleidea/mgmt/issues/33
+	echo "This test is broken on macOS, skipping!"
+	exit
+fi
+
 # run a graph, with prometheus support
-timeout --kill-after=40s 35s ./mgmt run --tmp-prefix --no-pgp --prometheus --yaml prometheus-3.yaml &
+$timeout --kill-after=40s 35s ./mgmt run --tmp-prefix --no-pgp --prometheus --yaml prometheus-3.yaml &
 pid=$!
 sleep 10s	# let it converge
 

--- a/test/shell/prometheus-4.sh
+++ b/test/shell/prometheus-4.sh
@@ -1,7 +1,13 @@
 #!/bin/bash -xe
 
+if [[ $(uname) == "Darwin" ]] ; then
+	# https://github.com/purpleidea/mgmt/issues/33
+	echo "This test is broken on macOS, skipping!"
+	exit
+fi
+
 # run a graph, with prometheus support
-timeout --kill-after=30s 25s ./mgmt run --tmp-prefix --no-pgp --prometheus --yaml prometheus-4.yaml &
+$timeout --kill-after=30s 25s ./mgmt run --tmp-prefix --no-pgp --prometheus --yaml prometheus-4.yaml &
 pid=$!
 sleep 10s	# let it converge
 

--- a/test/test-examples.sh
+++ b/test/test-examples.sh
@@ -19,7 +19,7 @@ make build
 buildout='test-examples.out'
 # make symlink to outside of package
 linkto="`pwd`/examples/lib/"
-tmpdir="`mktemp --tmpdir -d tmp.XXX`"	# get a dir outside of the main package
+tmpdir="`$mktemp --tmpdir -d tmp.XXX`"	# get a dir outside of the main package
 cd "$tmpdir"
 ln -s "$linkto"	# symlink outside of dir
 cd `basename "$linkto"`

--- a/test/test-golint.sh
+++ b/test/test-golint.sh
@@ -31,7 +31,7 @@ COUNT=`echo -e "$LINT" | wc -l`	# number of golint problems in current branch
 [ "$LINT" = "" ] && echo PASS && exit	# everything is "perfect"
 echo "$LINT"	# display the issues
 
-T=`mktemp --tmpdir -d tmp.X'X'X`	# add quotes to avoid matching three X's
+T=`$mktemp --tmpdir -d tmp.X'X'X`	# add quotes to avoid matching three X's
 [ "$T" = "" ] && fail_test "Could not create tmpdir"
 cd $T || fail_test "Could not change into tmpdir $T"
 git clone --recursive "${ROOT}" 2>/dev/null	# make a copy

--- a/test/test-govet.sh
+++ b/test/test-govet.sh
@@ -25,7 +25,7 @@ function simplify-gocase() {
 
 function token-coloncheck() {
 	# add quotes to avoid matching three X's
-	if grep -Ei "[\/]+[\/]+[ ]*+(FIXME[^:]|TODO[^:]|X"'X'"X[^:])" "$1"; then
+	if grep -Ei "[\/]+[\/]+[ ]*(FIXME[^:]|TODO[^:]|X"'X'"X[^:])" "$1"; then
 		return 1	# tokens must end with a colon
 	fi
 	return 0

--- a/test/test-reproducible.sh
+++ b/test/test-reproducible.sh
@@ -7,7 +7,7 @@ set -o pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"	# dir!
 cd "$DIR" >/dev/null	# work from main mgmt directory
 make build
-T=`mktemp --tmpdir -d tmp.X'X'X`	# add quotes to avoid matching three X's
+T=`$mktemp --tmpdir -d tmp.X'X'X`	# add quotes to avoid matching three X's
 cp -a ./mgmt "$T"/mgmt.1
 make clean
 make build

--- a/test/util.sh
+++ b/test/util.sh
@@ -2,8 +2,10 @@
 
 if [[ $(uname) == "Darwin" ]] ; then
 	export timeout="gtimeout"
+	export mktemp="gmktemp"
 else
 	export timeout="timeout"
+	export mktemp="mktemp"
 fi
 
 fail_test()


### PR DESCRIPTION
Sysinfo is not supported on macOS and results in a build error. This PR changes the load fact to use a universal method of retrieving load average that should work cross platform.

I don't know what the policy is on excluding external packages into the project with regards to reducing bloat, etc. I would have no problem researching an alternative approach if needed.

This PR fixes my previously posted issue (https://github.com/purpleidea/mgmt/issues/303) and it seems to be the only blocking issue for building/running mgmt on macOS for me.

Only tested on macOS so far:
```
~/.g/s/g/p/mgmt (gopsutil_load|✔) $ uptime; ./mgmt run --tmp-prefix --converged-timeout=1 --lang examples/lang/load0.mcl 2>&1 | grep Msg:\ load
17:09  up 7 days,  5:42, 4 users, load averages: 1.76 1.69 1.82
17:09:12 print.go:89: print[print1]: Msg: load average: 1.86, 1.72, 1.83
```