### PR TITLE
lang: Add edges to lexer and parser

### DIFF
--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -11,7 +11,7 @@ frontend. This guide describes some of the internals of the language.
 
 The mgmt language is a declarative (immutable) functional, reactive programming
 language. It is implemented in `golang`. A longer introduction to the language
-is coming soon!
+is [available as a blog post here](https://purpleidea.com/blog/2018/02/05/mgmt-configuration-language/)!
 
 ### Types
 
@@ -83,10 +83,68 @@ These docs will be expanded on when things are more certain to be stable.
 
 ### Statements
 
-Statements, and the `Stmt` interface need to be better documented. For now
-please consume
-[lang/interfaces/ast.go](https://github.com/purpleidea/mgmt/tree/master/lang/interfaces/ast.go).
-These docs will be expanded on when things are more certain to be stable.
+There are a very small number of statements in our language. They include:
+
+- **bind**: bind's an expression to a variable within that scope
+	- eg: `$x = 42`
+- **if**: produces up to one branch of statements based on a conditional
+expression
+
+	```
+	if <conditional> {
+		<statements>
+	} else {
+		# the else branch is optional for if statements
+		<statements>
+	}
+	```
+
+- **resource**: produces a resource
+
+	```
+	file "/tmp/hello" {
+		content => "world",
+		mode => "o=rwx",
+	}
+	```
+
+- **edge**: produces an edge
+
+	```
+	File["/tmp/hello"] -> Print["alert4"]
+	```
+
+All statements produce _output_. Output consists of between zero and more
+`edges` and `resources`. A resource statement can produce a resource, whereas an
+`if` statement produces whatever the chosen branch produces. Ultimately the goal
+of executing our programs is to produce a list of `resources`, which along with
+the produced `edges`, is built into a resource graph. This graph is then passed
+to the engine for desired state application.
+
+#### Bind
+
+This section needs better documentation.
+
+#### If
+
+This section needs better documentation.
+
+#### Resource
+
+This section needs better documentation.
+
+#### Edge
+
+Edges express dependencies in the graph of resources which are output. They can
+be chained as a pair, or in any greater number. For example, you may write:
+
+```
+Pkg["drbd"] -> File["/etc/drbd.conf"] -> Svc["drbd"]
+```
+
+to express a relationship between three resources. The first character in the
+resource kind must be capitalized so that the parser can't ascertain
+unambiguously that we are referring to a dependency relationship.
 
 ### Stages
 

--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -291,7 +291,7 @@ If you'd like to create a built-in, core function, you'll need to implement the
 function API interface named `Func`. It can be found in
 [lang/interfaces/func.go](https://github.com/purpleidea/mgmt/tree/master/lang/interfaces/func.go).
 Your function must have a specific type. For example, a simple math function
-might have a signature of `func(x int, x int) int`. As you can see, all the
+might have a signature of `func(x int, y int) int`. As you can see, all the
 types are known _before_ compile time.
 
 A separate discussion on this matter can be found in the [function guide](function-guide.md).

--- a/examples/lang/edges0.mcl
+++ b/examples/lang/edges0.mcl
@@ -1,0 +1,14 @@
+exec "exec0" {
+	cmd => "sleep 10s",
+	shell => "/bin/bash",
+}
+exec "exec1" {
+	cmd => "sleep 10s",
+	shell => "/bin/bash",
+}
+exec "exec2" {
+	cmd => "sleep 10s",
+	shell => "/bin/bash",
+}
+
+Exec["exec0"] -> Exec["exec1"] -> Exec["exec2"]

--- a/examples/lang/env1.mcl
+++ b/examples/lang/env1.mcl
@@ -1,0 +1,10 @@
+$env = env()
+$m = maplookup($env, "GOPATH", "")
+
+print "print0" {
+	msg => if hasenv("GOPATH") {
+		printf("GOPATH is: %s", $m)
+	} else {
+		"GOPATH is missing!"
+	},
+}

--- a/examples/lang/math2.mcl
+++ b/examples/lang/math2.mcl
@@ -1,0 +1,3 @@
+print "print0" {
+	msg => printf("13.0 ^ 4.2 is: %f", pow(13.0, 4.2)),
+}

--- a/examples/lang/password0.mcl
+++ b/examples/lang/password0.mcl
@@ -1,0 +1,8 @@
+password "pass0" {
+	length => 8,
+}
+
+file "/tmp/mgmt/password" {
+}
+
+Password["pass0"].password -> File["/tmp/mgmt/password"].content

--- a/examples/lang/pkg1.mcl
+++ b/examples/lang/pkg1.mcl
@@ -1,0 +1,3 @@
+pkg "cowsay" {
+	state => "installed",
+}

--- a/examples/lang/sendrecv0.mcl
+++ b/examples/lang/sendrecv0.mcl
@@ -1,0 +1,9 @@
+exec "exec0" {
+	cmd => "echo hello world && echo goodbye world 1>&2", # to stdout && stderr
+	shell => "/bin/bash",
+}
+
+print "print0" {
+}
+
+Exec["exec0"].output -> Print["print0"].msg

--- a/examples/lang/sendrecv1.mcl
+++ b/examples/lang/sendrecv1.mcl
@@ -1,0 +1,14 @@
+file "/tmp/mgmt/foo" {
+	content => "hello from foo\n",
+}
+
+print "print0" {
+}
+
+File["/tmp/mgmt/foo"].content -> Print["print0"].msg
+
+print "print1" {
+	msg => "hello",
+}
+
+Print["print0"] -> Print["print1"]

--- a/examples/lang/sendrecv2.mcl
+++ b/examples/lang/sendrecv2.mcl
@@ -1,0 +1,8 @@
+file "/tmp/mgmt/foo" {
+	content => "hello from foo\n",
+}
+
+file "/tmp/mgmt/bar" {
+}
+
+File["/tmp/mgmt/foo"].content -> File["/tmp/mgmt/bar"].content

--- a/examples/lang/sendrecv3.mcl
+++ b/examples/lang/sendrecv3.mcl
@@ -1,0 +1,21 @@
+$ns = "estate"
+$exchanged = kvlookup($ns)
+$state = maplookup($exchanged, $hostname, "default")
+
+exec "exec0" {
+	cmd => "echo hello world && echo goodbye world 1>&2", # to stdout && stderr
+	shell => "/bin/bash",
+}
+
+kv "kv0" {
+	key => $ns,
+	#value => "two",
+}
+
+Exec["exec0"].output -> Kv["kv0"].value
+
+if $state != "default" {
+	file "/tmp/mgmt/state" {
+		content => printf("state: %s\n", $state),
+	}
+}

--- a/examples/lang/states0.mcl
+++ b/examples/lang/states0.mcl
@@ -8,28 +8,43 @@ if $state == "one" || $state == "default" {
 	file "/tmp/mgmt/state" {
 		content => "state: one\n",
 	}
+
+	exec "timer" {
+		cmd => "/usr/bin/sleep 1s",
+	}
 	kv "${ns}" {
 		key => $ns,
 		value => "two",
 	}
+	Exec["timer"] -> Kv["${ns}"]
 }
 if $state == "two" {
 
 	file "/tmp/mgmt/state" {
 		content => "state: two\n",
 	}
+
+	exec "timer" {
+		cmd => "/usr/bin/sleep 1s",
+	}
 	kv "${ns}" {
 		key => $ns,
 		value => "three",
 	}
+	Exec["timer"] -> Kv["${ns}"]
 }
 if $state == "three" {
 
 	file "/tmp/mgmt/state" {
 		content => "state: three\n",
 	}
+
+	exec "timer" {
+		cmd => "/usr/bin/sleep 1s",
+	}
 	kv "${ns}" {
 		key => $ns,
 		value => "one",
 	}
+	Exec["timer"] -> Kv["${ns}"]
 }

--- a/lang/funcs/simple/math_func.go
+++ b/lang/funcs/simple/math_func.go
@@ -1,0 +1,53 @@
+// Mgmt
+// Copyright (C) 2013-2018+ James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package simple // TODO: should this be in its own individual package?
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/purpleidea/mgmt/lang/types"
+)
+
+func init() {
+	Register("pow", &types.FuncValue{
+		T: types.NewType("func(x float, y float) float"),
+		V: Pow,
+	})
+}
+
+// Pow returns x ^ y, the base-x exponential of y.
+func Pow(input []types.Value) (types.Value, error) {
+	x, y := input[0].Float(), input[1].Float()
+	// FIXME: check for overflow
+	z := math.Pow(x, y)
+	if math.IsNaN(z) {
+		return nil, fmt.Errorf("result is not a number")
+	}
+	if math.IsInf(z, 1) {
+		return nil, fmt.Errorf("result is positive infinity")
+	}
+	if math.IsInf(z, -1) {
+		return nil, fmt.Errorf("result is negative infinity")
+	}
+	// TODO: consider only returning floats, and adding isinf and
+	// isnan functions so that users can decide for themselves...
+	return &types.FloatValue{
+		V: z,
+	}, nil
+}

--- a/lang/interpret_test.go
+++ b/lang/interpret_test.go
@@ -537,6 +537,43 @@ func TestAstInterpret0(t *testing.T) {
 			graph: graph,
 		})
 	}
+	{
+		// FIXME: add a better vertexCmpFn so we can compare send/recv!
+		graph, _ := pgraph.NewGraph("g")
+		t1, _ := resources.NewNamedResource("test", "t1")
+		{
+			x := t1.(*resources.TestRes)
+			int64Ptr := int64(42)
+			x.Int64Ptr = &int64Ptr
+			graph.AddVertex(t1)
+		}
+		t2, _ := resources.NewNamedResource("test", "t2")
+		{
+			x := t2.(*resources.TestRes)
+			int64Ptr := int64(13)
+			x.Int64Ptr = &int64Ptr
+			graph.AddVertex(t2)
+		}
+		edge := &resources.Edge{
+			Name:   fmt.Sprintf("%s -> %s", t1, t2),
+			Notify: false,
+		}
+		graph.AddEdge(t1, t2, edge)
+		values = append(values, test{
+			name: "two resources and send/recv edge",
+			code: `
+			test "t1" {
+				int64ptr => 42,
+			}
+			test "t2" {
+				int64ptr => 13,
+			}
+
+			Test["t1"].foosend -> Test["t2"].barrecv # send/recv
+			`,
+			graph: graph,
+		})
+	}
 
 	for index, test := range values { // run all the tests
 		name, code, fail, exp := test.name, test.code, test.fail, test.graph

--- a/lang/lexer.nex
+++ b/lang/lexer.nex
@@ -134,6 +134,16 @@
 			lval.str = yylex.Text()
 			return IN
 		}
+/\->/		{
+			yylex.pos(lval) // our pos
+			lval.str = yylex.Text()
+			return ARROW
+		}
+/\./		{
+			yylex.pos(lval) // our pos
+			lval.str = yylex.Text()
+			return DOT
+		}
 /bool/		{
 			yylex.pos(lval) // our pos
 			lval.str = yylex.Text()
@@ -294,6 +304,13 @@
 			s := yylex.Text()
 			lval.str = s[1:len(s)] // remove the leading $
 			return VAR_IDENTIFIER
+		}
+/[A-Z][a-z0-9]*/
+		{
+			yylex.pos(lval) // our pos
+			s := yylex.Text()
+			lval.str = strings.ToLower(s) // uncapitalize it
+			return CAPITALIZED_IDENTIFIER
 		}
 /[a-z][a-z0-9]*/
 		{

--- a/lang/lexparse_test.go
+++ b/lang/lexparse_test.go
@@ -80,7 +80,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "bad escaping",
 			code: `
-			test "n1" {
+			test "t1" {
 				str => "he\ llo", # incorrect escaping
 			}
 			`,
@@ -91,7 +91,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "int overflow",
 			code: `
-			test "n1" {
+			test "t1" {
 				int => 888888888888888888888888, # overflows
 			}
 			`,
@@ -102,7 +102,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "overflow after lexer",
 			code: `
-			test "n1" {
+			test "t1" {
 				uint8 => 128, # does not overflow at lexer stage
 			}
 			`,
@@ -114,7 +114,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "one res",
 			code: `
-			test "n1" {
+			test "t1" {
 				int16 => 01134, # some comment
 			}
 			`,
@@ -262,7 +262,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "res with floats",
 			code: `
-			test "n1" {
+			test "t1" {
 				float32 => -25.38789, # some float
 				float64 => 53.393908945, # some float
 			}
@@ -279,7 +279,7 @@ func TestLexParse0(t *testing.T) {
 	//	values = append(values, test{
 	//		name: "overflowing float",
 	//		code: `
-	//		test "n1" {
+	//		test "t1" {
 	//			float32 => -457643875645764387564578645457864525457643875645764387564578645457864525.457643875645764387564578645457864525387899898753459879587574928798759863965, # overflow
 	//		}
 	//		`,
@@ -290,7 +290,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "res and addition",
 			code: `
-			test "n1" {
+			test "t1" {
 				float32 => -25.38789 + 32.6,
 			}
 			`,
@@ -304,7 +304,7 @@ func TestLexParse0(t *testing.T) {
 				&StmtRes{
 					Kind: "test",
 					Name: &ExprStr{
-						V: "n1",
+						V: "t1",
 					},
 					Fields: []*StmtResField{
 						{
@@ -331,7 +331,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "addition",
 			code: `
-			test "n1" {
+			test "t1" {
 				int64ptr => 13 + 42,
 			}
 			`,
@@ -345,7 +345,7 @@ func TestLexParse0(t *testing.T) {
 				&StmtRes{
 					Kind: "test",
 					Name: &ExprStr{
-						V: "n1",
+						V: "t1",
 					},
 					Fields: []*StmtResField{
 						{
@@ -383,7 +383,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "multiple float addition",
 			code: `
-			test "n1" {
+			test "t1" {
 				float32 => -25.38789 + 32.6 + 13.7,
 			}
 			`,
@@ -397,7 +397,7 @@ func TestLexParse0(t *testing.T) {
 				&StmtRes{
 					Kind: "test",
 					Name: &ExprStr{
-						V: "n1",
+						V: "t1",
 					},
 					Fields: []*StmtResField{
 						{
@@ -435,7 +435,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "order of operations lucky",
 			code: `
-			test "n1" {
+			test "t1" {
 				int64ptr => 4 + 3 * 12, # 40, not 84
 			}
 			`,
@@ -449,7 +449,7 @@ func TestLexParse0(t *testing.T) {
 				&StmtRes{
 					Kind: "test",
 					Name: &ExprStr{
-						V: "n1",
+						V: "t1",
 					},
 					Fields: []*StmtResField{
 						{
@@ -487,7 +487,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "order of operations needs left precedence",
 			code: `
-			test "n1" {
+			test "t1" {
 				int64ptr => 3 * 12 + 4, # 40, not 48
 			}
 			`,
@@ -501,7 +501,7 @@ func TestLexParse0(t *testing.T) {
 				&StmtRes{
 					Kind: "test",
 					Name: &ExprStr{
-						V: "n1",
+						V: "t1",
 					},
 					Fields: []*StmtResField{
 						{
@@ -539,7 +539,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "order of operations parens",
 			code: `
-			test "n1" {
+			test "t1" {
 				int64ptr => 3 * (12 + 4), # 48, not 40
 			}
 			`,
@@ -553,7 +553,7 @@ func TestLexParse0(t *testing.T) {
 				&StmtRes{
 					Kind: "test",
 					Name: &ExprStr{
-						V: "n1",
+						V: "t1",
 					},
 					Fields: []*StmtResField{
 						{
@@ -591,7 +591,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "order of operations bools",
 			code: `
-			test "n1" {
+			test "t1" {
 				boolptr => 3 + 4 > 5, # should be true
 			}
 			`,
@@ -605,7 +605,7 @@ func TestLexParse0(t *testing.T) {
 				&StmtRes{
 					Kind: "test",
 					Name: &ExprStr{
-						V: "n1",
+						V: "t1",
 					},
 					Fields: []*StmtResField{
 						{
@@ -643,7 +643,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "order of operations bools reversed",
 			code: `
-			test "n1" {
+			test "t1" {
 				boolptr => 3 > 4 + 5, # should be false
 			}
 			`,
@@ -657,7 +657,7 @@ func TestLexParse0(t *testing.T) {
 				&StmtRes{
 					Kind: "test",
 					Name: &ExprStr{
-						V: "n1",
+						V: "t1",
 					},
 					Fields: []*StmtResField{
 						{
@@ -692,7 +692,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "order of operations with not",
 			code: `
-			test "n1" {
+			test "t1" {
 				boolptr => ! 3 > 4, # should parse, but not compile
 			}
 			`,
@@ -706,7 +706,7 @@ func TestLexParse0(t *testing.T) {
 				&StmtRes{
 					Kind: "test",
 					Name: &ExprStr{
-						V: "n1",
+						V: "t1",
 					},
 					Fields: []*StmtResField{
 						{
@@ -744,7 +744,7 @@ func TestLexParse0(t *testing.T) {
 		values = append(values, test{
 			name: "order of operations logical",
 			code: `
-			test "n1" {
+			test "t1" {
 				boolptr => 7 < 4 && true, # should be false
 			}
 			`,
@@ -879,7 +879,7 @@ func TestLexParse1(t *testing.T) {
 	}
 	# hello
 	# world
-	test "n1" {}
+	test "t1" {}
 	` // error
 	str := strings.NewReader(code)
 	_, err := LexParse(str)

--- a/lang/lexparse_test.go
+++ b/lang/lexparse_test.go
@@ -752,6 +752,73 @@ func TestLexParse0(t *testing.T) {
 			exp:  exp,
 		})
 	}
+	{
+		exp := &StmtProg{
+			Prog: []interfaces.Stmt{
+				&StmtRes{
+					Kind: "test",
+					Name: &ExprStr{
+						V: "t1",
+					},
+					Fields: []*StmtResField{
+						{
+							Field: "int64ptr",
+							Value: &ExprInt{
+								V: 42,
+							},
+						},
+					},
+				},
+				&StmtRes{
+					Kind: "test",
+					Name: &ExprStr{
+						V: "t2",
+					},
+					Fields: []*StmtResField{
+						{
+							Field: "int64ptr",
+							Value: &ExprInt{
+								V: 13,
+							},
+						},
+					},
+				},
+				&StmtEdge{
+					EdgeHalfList: []*StmtEdgeHalf{
+						{
+							Kind: "test",
+							Name: &ExprStr{
+								V: "t1",
+							},
+							SendRecv: "foosend",
+						},
+						{
+							Kind: "test",
+							Name: &ExprStr{
+								V: "t2",
+							},
+							SendRecv: "barrecv",
+						},
+					},
+				},
+			},
+		}
+		values = append(values, test{
+			name: "edge stmt",
+			code: `
+			test "t1" {
+				int64ptr => 42,
+			}
+			test "t2" {
+				int64ptr => 13,
+			}
+
+			Test["t1"].foosend -> Test["t2"].barrecv # send/recv
+			`,
+			fail: false,
+			exp:  exp,
+		})
+	}
 
 	for index, test := range values { // run all the tests
 		name, code, fail, exp := test.name, test.code, test.fail, test.exp
@@ -789,8 +856,8 @@ func TestLexParse0(t *testing.T) {
 			if !reflect.DeepEqual(ast, exp) {
 				t.Errorf("test #%d: AST did not match expected", index)
 				// TODO: consider making our own recursive print function
-				t.Logf("test #%d:   actual: \n%s", index, spew.Sdump(ast))
-				t.Logf("test #%d: expected: \n%s", index, spew.Sdump(exp))
+				t.Logf("test #%d:   actual: \n\n%s\n", index, spew.Sdump(ast))
+				t.Logf("test #%d: expected: \n\n%s", index, spew.Sdump(exp))
 				continue
 			}
 		}

--- a/lang/structs.go
+++ b/lang/structs.go
@@ -836,6 +836,7 @@ func (obj *StmtProg) Graph() (*pgraph.Graph, error) {
 // called by this Output function if they are needed to produce the output.
 func (obj *StmtProg) Output() (*interfaces.Output, error) {
 	resources := []resources.Res{}
+	edges := []*interfaces.Edge{}
 
 	for _, stmt := range obj.Prog {
 		output, err := stmt.Output()
@@ -844,13 +845,13 @@ func (obj *StmtProg) Output() (*interfaces.Output, error) {
 		}
 		if output != nil {
 			resources = append(resources, output.Resources...)
-			//edges = append(edges, output.Edges)
+			edges = append(edges, output.Edges...)
 		}
 	}
 
 	return &interfaces.Output{
 		Resources: resources,
-		//Edges: edges,
+		Edges:     edges,
 	}, nil
 }
 

--- a/resources/print.go
+++ b/resources/print.go
@@ -83,6 +83,11 @@ func (obj *PrintRes) Watch() error {
 // CheckApply method for Print resource. Does nothing, returns happy!
 func (obj *PrintRes) CheckApply(apply bool) (checkOK bool, err error) {
 	log.Printf("%s: CheckApply: %t", obj, apply)
+	if val, exists := obj.Recv["Msg"]; exists && val.Changed {
+		// if we received on Msg, and it changed, log message
+		log.Printf("CheckApply: Received `Msg` of: %s", obj.Msg)
+	}
+
 	if obj.Refresh() {
 		log.Printf("%s: Received a notification!", obj)
 	}

--- a/test.sh
+++ b/test.sh
@@ -89,7 +89,7 @@ if [[ -n "$failures" ]]; then
 	echo
 	echo 'You can rerun a single suite like so:'
 	echo
-	echo 'make test-gofmt'
+	echo '`make test-gofmt` or `make test-shell-<testname>`'
 	exit 1
 fi
 echo 'ALL PASSED'


### PR DESCRIPTION
Here is my WIP branch for adding lexing and parsing for standalone edges and send/recv.
Some of my WIP hacking is present in the source but commented out.

Since I suck at yacc, I get this issue:

```
$ make lang
Generating: lang...
make --quiet -C lang

conflicts: 15 shift/reduce, 1 reduce/reduce
```

I think this *might* be due to the fact that the `foo["hey"] -> bar["blah"]` syntax might be confused for a `["list"]`, but I have no idea and I don't know how to debug yacc shift or reduce issues yet.

Help wanted!
/cc @ffrank 