### PR TITLE
misc: fix graphviz output for hostnames with dot in them.

### DIFF
--- a/pgraph/graphviz.go
+++ b/pgraph/graphviz.go
@@ -41,7 +41,7 @@ func (g *Graph) Graphviz() (out string) {
 	//	B -> C [label=g];
 	//	D -> E [label=h];
 	//}
-	out += fmt.Sprintf("digraph %s {\n", g.GetName())
+	out += fmt.Sprintf("digraph \"%s\" {\n", g.GetName())
 	out += fmt.Sprintf("\tlabel=\"%s\";\n", g.GetName())
 	//out += "\tnode [shape=box];\n"
 	str := ""


### PR DESCRIPTION
title says it all. Solves: 
```
# dot -Tpng out.dot@faalserver > out.png
Error: out.dot@faalserver: syntax error in line 1 near '.'
```