### PR TITLE
test: Streamline test suite a little

### DIFF
--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -216,6 +216,10 @@ func NewEmbdEtcd(hostname string, seeds, clientURLs, serverURLs, advertiseClient
 	if hostname == seedSentinel { // safety
 		return nil
 	}
+	if noServer && len(seeds) == 0 {
+		log.Printf("Etcd: need at least one seed if running with --no-server!")
+		return nil
+	}
 	if len(seeds) > 0 {
 		endpoints[seedSentinel] = seeds
 		idealClusterSize = 0 // unset, get from running cluster

--- a/etcd/etcd_test.go
+++ b/etcd/etcd_test.go
@@ -1,0 +1,49 @@
+// Mgmt
+// Copyright (C) 2013-2018+ James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package etcd
+
+import (
+	"testing"
+
+	etcdtypes "github.com/coreos/etcd/pkg/types"
+)
+
+func TestNewEmbdEtcd(t *testing.T) {
+	// should return a new etcd object
+
+	noServer := false
+	var flags Flags
+
+	obj := NewEmbdEtcd("", nil, nil, nil, nil, nil, noServer, 0, flags, "", nil)
+	if obj == nil {
+		t.Fatal("failed to create server object")
+	}
+}
+
+func TestNewEmbdEtcdConfigValidation(t *testing.T) {
+	// running --no-server with no --seeds specified should fail early
+
+	seeds := make(etcdtypes.URLs, 0)
+	noServer := true
+	var flags Flags
+
+	obj := NewEmbdEtcd("", seeds, nil, nil, nil, nil, noServer, 0, flags, "", nil)
+	if obj != nil {
+		t.Fatal("server initialization should fail on invalid configuration")
+	}
+}

--- a/lib/cli.go
+++ b/lib/cli.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"reflect"
 	"sort"
 	"syscall"
 
@@ -164,7 +165,7 @@ func run(c *cli.Context) error {
 	}()
 
 	if err := obj.Run(); err != nil {
-		//return cli.NewExitError(err.Error(), 1) // TODO: ?
+		log.Printf("%s: %s", reflect.TypeOf(obj).Elem().String(), err.Error())
 		return cli.NewExitError("", 1)
 	}
 	return nil

--- a/lib/cli.go
+++ b/lib/cli.go
@@ -295,7 +295,7 @@ func CLI(program, version string, flags Flags) error {
 		},
 		cli.BoolFlag{
 			Name:  "no-server",
-			Usage: "do not let other servers peer with me",
+			Usage: "do not start embedded etcd server (only act as client of a cluster)",
 		},
 
 		cli.IntFlag{

--- a/lib/main.go
+++ b/lib/main.go
@@ -164,31 +164,31 @@ func (obj *Main) Init() error {
 		util.FlattenListWithSplit(obj.Seeds, []string{",", ";", " "}),
 	)
 	if err != nil && len(obj.Seeds) > 0 {
-		return fmt.Errorf("the Seeds didn't parse correctly")
+		return fmt.Errorf("the Seeds didn't parse correctly: %s", err)
 	}
 	obj.clientURLs, err = etcdtypes.NewURLs(
 		util.FlattenListWithSplit(obj.ClientURLs, []string{",", ";", " "}),
 	)
 	if err != nil && len(obj.ClientURLs) > 0 {
-		return fmt.Errorf("the ClientURLs didn't parse correctly")
+		return fmt.Errorf("the ClientURLs didn't parse correctly: %s", err)
 	}
 	obj.serverURLs, err = etcdtypes.NewURLs(
 		util.FlattenListWithSplit(obj.ServerURLs, []string{",", ";", " "}),
 	)
 	if err != nil && len(obj.ServerURLs) > 0 {
-		return fmt.Errorf("the ServerURLs didn't parse correctly")
+		return fmt.Errorf("the ServerURLs didn't parse correctly: %s", err)
 	}
 	obj.advertiseClientURLs, err = etcdtypes.NewURLs(
 		util.FlattenListWithSplit(obj.AdvertiseClientURLs, []string{",", ";", " "}),
 	)
 	if err != nil && len(obj.AdvertiseClientURLs) > 0 {
-		return fmt.Errorf("the AdvertiseClientURLs didn't parse correctly")
+		return fmt.Errorf("the AdvertiseClientURLs didn't parse correctly: %s", err)
 	}
 	obj.advertiseServerURLs, err = etcdtypes.NewURLs(
 		util.FlattenListWithSplit(obj.AdvertiseServerURLs, []string{",", ";", " "}),
 	)
 	if err != nil && len(obj.AdvertiseServerURLs) > 0 {
-		return fmt.Errorf("the AdvertiseServerURLs didn't parse correctly")
+		return fmt.Errorf("the AdvertiseServerURLs didn't parse correctly: %s", err)
 	}
 
 	obj.exit = make(chan error)

--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -38,6 +38,10 @@ if [ ! -z "$APT" ]; then
 	$sudo_command $APT install -y libpcap0.8-dev || true
 	# dependencies for building debian packages with `make deb`
 	$sudo_command $APT install -y dpkg-dev devscripts debhelper dh-golang dh-systemd
+	# `realpath` is a more universal alternative to `readlink -f` for absolute path resolution
+	# (-f is missing on BSD/macOS), but older Debian/Ubuntu's don't include it in coreutils yet.
+	# https://unix.stackexchange.com/a/136527
+	$sudo_command $APT install -y realpath || true
 fi
 
 if [ ! -z "$BREW" ]; then

--- a/test.sh
+++ b/test.sh
@@ -31,7 +31,7 @@ function skip-testsuite()
 	# show skip message only when running full suite
 	if test -z "$testsuite";then
 		echo skipping "$@" "($REASON)"
-		echo 'SKIP'
+		blue 'SKIP'
 	else
 		# if a skipped suite is explicity called, run it anyway
 		if test "test-$testsuite" == "$testname";then
@@ -82,7 +82,7 @@ REASON="https://github.com/purpleidea/mgmt/issues/327" skip-testsuite ./test/tes
 run-testsuite ./test/test-golint.sh	# test last, because this test is somewhat arbitrary
 
 if [[ -n "$failures" ]]; then
-	echo 'FAIL'
+	red 'FAIL'
 	echo 'The following tests have failed:'
 	echo -e "$failures"
 	echo
@@ -91,4 +91,4 @@ if [[ -n "$failures" ]]; then
 	echo 'make test-gofmt'
 	exit 1
 fi
-echo 'ALL PASSED'
+green 'ALL PASSED'

--- a/test/shell/augeas-1.sh
+++ b/test/shell/augeas-1.sh
@@ -10,7 +10,7 @@ mkdir -p "${MGMT_TMPDIR}"
 > "${MGMT_TMPDIR}"sshd_config
 
 # run empty graph, with prometheus support
-$timeout --kill-after=60s 55s ./mgmt run --tmp-prefix --yaml=augeas-1.yaml &
+$timeout --kill-after=60s 55s "$MGMT" run --tmp-prefix --yaml=augeas-1.yaml &
 pid=$!
 
 # kill server on error

--- a/test/shell/augeas-1.sh
+++ b/test/shell/augeas-1.sh
@@ -12,19 +12,34 @@ mkdir -p "${MGMT_TMPDIR}"
 # run empty graph, with prometheus support
 $timeout --kill-after=60s 55s ./mgmt run --tmp-prefix --yaml=augeas-1.yaml &
 pid=$!
+
+# kill server on error
+trap 'kill -SIGINT "$pid"' EXIT
+
 sleep 10s	# let it converge
 
-grep "X11Forwarding no" "${MGMT_TMPDIR}"sshd_config
+# make an exception on macOS as augeas behaves differently
+if [[ $(uname) == "Darwin" ]] ; then
+	value=false
+else
+	value=no
+fi
 
-sed -i "s/no/yes/" "${MGMT_TMPDIR}"sshd_config
+# make it easier to see why the test failed
+set -x
+cat "${MGMT_TMPDIR}"sshd_config
+
+grep "X11Forwarding ${value}" "${MGMT_TMPDIR}"sshd_config
+
+sed -i '' "s/${value}/yes/" "${MGMT_TMPDIR}"sshd_config
 
 grep "X11Forwarding yes" "${MGMT_TMPDIR}"sshd_config
 
 sleep 10s	# Augeas is slow
 
-grep "X11Forwarding no" "${MGMT_TMPDIR}"sshd_config
+grep "X11Forwarding ${value}" "${MGMT_TMPDIR}"sshd_config
 
-
+trap '' EXIT
 killall -SIGINT mgmt	# send ^C to exit mgmt
 wait $pid	# get exit status
 exit $?

--- a/test/shell/exec-fail.sh
+++ b/test/shell/exec-fail.sh
@@ -3,7 +3,7 @@
 # should take a few seconds plus converged timeout, and test we don't hang!
 # TODO: should we return a different exit code if the resources fail?
 # TODO: should we be converged if one of the resources has permanently failed?
-$timeout --kill-after=60s 55s ./mgmt run --yaml exec-fail.yaml --converged-timeout=5 --no-watch --no-pgp --tmp-prefix &
+$timeout --kill-after=60s 55s "$MGMT" run --yaml exec-fail.yaml --converged-timeout=5 --no-watch --no-pgp --tmp-prefix &
 pid=$!
 wait $pid	# get exit status
 exit $?

--- a/test/shell/exec-usergroup.sh
+++ b/test/shell/exec-usergroup.sh
@@ -38,7 +38,7 @@ function run_usergroup_test() {
 	setup
 
 	# run till completion
-	sudo -A timeout --kill-after=30s 25s ./mgmt run --yaml ./exec-usergroup/${graph} --converged-timeout=5 --no-watch --tmp-prefix &
+	sudo -A timeout --kill-after=30s 25s "$MGMT" run --yaml ./exec-usergroup/${graph} --converged-timeout=5 --no-watch --tmp-prefix &
 	pid=$!
 	wait $pid	# get exit status
 	e=$?

--- a/test/shell/file-mode.sh
+++ b/test/shell/file-mode.sh
@@ -9,7 +9,7 @@ fi
 set -x
 
 # run till completion
-$timeout --kill-after=60s 55s ./mgmt run --yaml file-mode.yaml --converged-timeout=5 --no-watch --tmp-prefix &
+$timeout --kill-after=60s 55s "$MGMT" run --yaml file-mode.yaml --converged-timeout=5 --no-watch --tmp-prefix &
 pid=$!
 wait $pid	# get exit status
 e=$?

--- a/test/shell/file-move-upper-dir.sh
+++ b/test/shell/file-move-upper-dir.sh
@@ -7,7 +7,7 @@ exit 0
 mkdir -p /tmp/mgmt/a/b/c/
 
 # run empty graph, with prometheus support
-$timeout --kill-after=60s 55s ./mgmt run --tmp-prefix --yaml=examples/deep-dirs.yaml &
+$timeout --kill-after=60s 55s "$MGMT" run --tmp-prefix --yaml=examples/deep-dirs.yaml &
 pid=$!
 sleep 10s	# let it converge
 

--- a/test/shell/file-move.sh
+++ b/test/shell/file-move.sh
@@ -10,7 +10,7 @@ mkdir -p /tmp/mgmt/
 rm /tmp/mgmt/f1 || true
 
 # run empty graph, with prometheus support
-$timeout --kill-after=60s 55s ./mgmt run --tmp-prefix --yaml=file-move.yaml 2>&1 | tee /tmp/mgmt/file-move.log &
+$timeout --kill-after=60s 55s "$MGMT" run --tmp-prefix --yaml=file-move.yaml 2>&1 | tee /tmp/mgmt/file-move.log &
 pid=$!
 sleep 5s	# let it converge
 

--- a/test/shell/file-owner.sh
+++ b/test/shell/file-owner.sh
@@ -9,7 +9,7 @@ if ! timeout 1s sudo -A true; then
 fi
 
 # run till completion
-$timeout --kill-after=30s 25s sudo -A ./mgmt run --yaml file-owner.yaml --converged-timeout=5 --no-watch --tmp-prefix &
+$timeout --kill-after=30s 25s sudo -A "$MGMT" run --yaml file-owner.yaml --converged-timeout=5 --no-watch --tmp-prefix &
 pid=$!
 wait $pid	# get exit status
 e=$?

--- a/test/shell/graph-exit1.sh
+++ b/test/shell/graph-exit1.sh
@@ -2,7 +2,7 @@
 
 # should take 15 seconds for longest resources plus startup time to shutdown
 # we don't want the ^C to allow the rest of the graph to continue executing!
-$timeout --kill-after=65s 55s ./mgmt run --yaml graph-exit1.yaml --no-watch --no-pgp --tmp-prefix &
+$timeout --kill-after=65s 55s "$MGMT" run --yaml graph-exit1.yaml --no-watch --no-pgp --tmp-prefix &
 pid=$!
 sleep 5s	# let the initial resources start to run...
 killall -SIGINT mgmt	# send ^C to exit mgmt

--- a/test/shell/graph-exit2.sh
+++ b/test/shell/graph-exit2.sh
@@ -2,7 +2,7 @@
 
 # should take 15 seconds for longest resources plus startup time to shutdown
 # we don't want the ^C to allow the rest of the graph to continue executing!
-$timeout --kill-after=65s 55s ./mgmt run --yaml graph-exit2.yaml --no-watch --no-pgp --tmp-prefix &
+$timeout --kill-after=65s 55s "$MGMT" run --yaml graph-exit2.yaml --no-watch --no-pgp --tmp-prefix &
 pid=$!
 sleep 10s	# let the initial resources start to run...
 killall -SIGINT mgmt	# send ^C to exit mgmt

--- a/test/shell/graph-fanin-1.sh
+++ b/test/shell/graph-fanin-1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # should take more than 25s plus overhead
-$timeout --kill-after=50s 45s ./mgmt run --yaml graph-fanin-1.yaml --converged-timeout=5 --no-watch --tmp-prefix --no-pgp &
+$timeout --kill-after=50s 45s "$MGMT" run --yaml graph-fanin-1.yaml --converged-timeout=5 --no-watch --tmp-prefix --no-pgp &
 pid=$!
 wait $pid	# get exit status
 exit $?

--- a/test/shell/load0.sh
+++ b/test/shell/load0.sh
@@ -34,7 +34,7 @@ file "${tmpdir}/loadavg" {
 }
 EOF
 
-$timeout --kill-after=60s 55s ./mgmt run --tmp-prefix --converged-timeout=1 --lang "$tmpdir/load0.mcl"  &
+$timeout --kill-after=60s 55s "$MGMT" run --tmp-prefix --converged-timeout=1 --lang "$tmpdir/load0.mcl"  &
 pid=$!
 wait $pid	# get exit status
 e=$?

--- a/test/shell/prometheus-1.sh
+++ b/test/shell/prometheus-1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # run empty graph, with prometheus support
-$timeout --kill-after=60s 55s ./mgmt run --tmp-prefix --prometheus &
+$timeout --kill-after=60s 55s "$MGMT" run --tmp-prefix --prometheus &
 pid=$!
 sleep 5s	# let it converge
 

--- a/test/shell/prometheus-2.sh
+++ b/test/shell/prometheus-2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # run empty graph, with prometheus support
-$timeout --kill-after=60s 55s ./mgmt run --tmp-prefix --prometheus --prometheus-listen :52637 &
+$timeout --kill-after=60s 55s "$MGMT" run --tmp-prefix --prometheus --prometheus-listen :52637 &
 pid=$!
 sleep 5s	# let it converge
 

--- a/test/shell/prometheus-3.sh
+++ b/test/shell/prometheus-3.sh
@@ -7,7 +7,7 @@ if [[ $(uname) == "Darwin" ]] ; then
 fi
 
 # run a graph, with prometheus support
-$timeout --kill-after=60s 55s ./mgmt run --tmp-prefix --no-pgp --prometheus --yaml prometheus-3.yaml &
+$timeout --kill-after=60s 55s "$MGMT" run --tmp-prefix --no-pgp --prometheus --yaml prometheus-3.yaml &
 pid=$!
 sleep 10s	# let it converge
 

--- a/test/shell/prometheus-4.sh
+++ b/test/shell/prometheus-4.sh
@@ -7,7 +7,7 @@ if [[ $(uname) == "Darwin" ]] ; then
 fi
 
 # run a graph, with prometheus support
-$timeout --kill-after=60s 55s ./mgmt run --tmp-prefix --no-pgp --prometheus --yaml prometheus-4.yaml &
+$timeout --kill-after=60s 55s "$MGMT" run --tmp-prefix --no-pgp --prometheus --yaml prometheus-4.yaml &
 pid=$!
 sleep 15s	# let it converge
 

--- a/test/shell/sema-1.sh
+++ b/test/shell/sema-1.sh
@@ -2,7 +2,7 @@
 
 # should take at least 55s, but fail if we block this
 # TODO: it would be nice to make sure this test doesn't exit too early!
-$timeout --kill-after=120s 110s ./mgmt run --yaml sema-1.yaml --sema 2 --converged-timeout=5 --no-watch --no-pgp --tmp-prefix &
+$timeout --kill-after=120s 110s "$MGMT" run --yaml sema-1.yaml --sema 2 --converged-timeout=5 --no-watch --no-pgp --tmp-prefix &
 pid=$!
 wait $pid	# get exit status
 exit $?

--- a/test/shell/t1.sh
+++ b/test/shell/t1.sh
@@ -9,7 +9,7 @@
 set -o errexit
 set -o pipefail
 
-$timeout --kill-after=3s 1s ./mgmt --help # hello world!
+$timeout --kill-after=3s 1s "$MGMT" --help # hello world!
 pid=$!
 wait $pid	# get exit status
 exit $?

--- a/test/shell/t2.sh
+++ b/test/shell/t2.sh
@@ -7,7 +7,7 @@ if env | grep -q -e '^TRAVIS=true$'; then
 fi
 
 # run till completion
-$timeout --kill-after=15s 10s ./mgmt run --yaml t2.yaml --converged-timeout=5 --no-watch --tmp-prefix &
+$timeout --kill-after=15s 10s "$MGMT" run --yaml t2.yaml --converged-timeout=5 --no-watch --tmp-prefix &
 pid=$!
 wait $pid	# get exit status
 e=$?

--- a/test/shell/t3.sh
+++ b/test/shell/t3.sh
@@ -10,11 +10,11 @@ fi
 mkdir -p "${MGMT_TMPDIR}"mgmt{A..C}
 
 # run till completion
-$timeout --kill-after=15s 10s ./mgmt run --yaml t3-a.yaml --converged-timeout=5 --no-watch --tmp-prefix &
+$timeout --kill-after=15s 10s "$MGMT" run --yaml t3-a.yaml --converged-timeout=5 --no-watch --tmp-prefix &
 pid1=$!
-$timeout --kill-after=15s 10s ./mgmt run --yaml t3-b.yaml --converged-timeout=5 --no-watch --tmp-prefix &
+$timeout --kill-after=15s 10s "$MGMT" run --yaml t3-b.yaml --converged-timeout=5 --no-watch --tmp-prefix &
 pid2=$!
-$timeout --kill-after=15s 10s ./mgmt run --yaml t3-c.yaml --converged-timeout=5 --no-watch --tmp-prefix &
+$timeout --kill-after=15s 10s "$MGMT" run --yaml t3-c.yaml --converged-timeout=5 --no-watch --tmp-prefix &
 pid3=$!
 
 wait $pid1	# get exit status

--- a/test/shell/t5.sh
+++ b/test/shell/t5.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # should take slightly more than 35s, but fail if we take much longer)
-$timeout --kill-after=55s 50s ./mgmt run --yaml t5.yaml --converged-timeout=5 --no-watch --no-pgp --tmp-prefix &
+$timeout --kill-after=55s 50s "$MGMT" run --yaml t5.yaml --converged-timeout=5 --no-watch --no-pgp --tmp-prefix &
 pid=$!
 wait $pid	# get exit status
 exit $?

--- a/test/shell/t5b.sh
+++ b/test/shell/t5b.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # should take slightly more than 35s, but fail if we take much longer)
-$timeout --kill-after=55s 50s ./mgmt run --yaml t5b.yaml --converged-timeout=5 --no-watch --no-pgp --tmp-prefix &
+$timeout --kill-after=55s 50s "$MGMT" run --yaml t5b.yaml --converged-timeout=5 --no-watch --no-pgp --tmp-prefix &
 pid=$!
 wait $pid	# get exit status
 exit $?

--- a/test/shell/t6.sh
+++ b/test/shell/t6.sh
@@ -7,7 +7,7 @@ if env | grep -q -e '^TRAVIS=true$'; then
 fi
 
 # run till completion
-$timeout --kill-after=60s 55s ./mgmt run --yaml t6.yaml --no-watch --tmp-prefix &
+$timeout --kill-after=60s 55s "$MGMT" run --yaml t6.yaml --no-watch --tmp-prefix &
 pid=$!
 sleep 10s	# let it converge
 test -e /tmp/mgmt/f1

--- a/test/shell/t7.sh
+++ b/test/shell/t7.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # run empty graph
-$timeout --kill-after=45s 35s ./mgmt run --tmp-prefix --no-pgp &
+$timeout --kill-after=45s 35s "$MGMT" run --tmp-prefix --no-pgp &
 pid=$!
 sleep 10s	# let it converge
 $(sleep 3s && killall -SIGINT mgmt)&	# send ^C to exit mgmt

--- a/test/shell/t8.sh
+++ b/test/shell/t8.sh
@@ -3,11 +3,11 @@
 exit 0	# XXX: test temporarily disabled till etcd or mgmt regression is fixed.
 
 # run empty graphs, we're just testing etcd clustering
-$timeout --kill-after=180s 120s ./mgmt run --hostname h1 --tmp-prefix &
+$timeout --kill-after=180s 120s "$MGMT" run --hostname h1 --tmp-prefix &
 pid1=$!
 sleep 15s	# let it startup
 
-$timeout --kill-after=180s 120s ./mgmt run --hostname h2 --seeds http://127.0.0.1:2379 --client-urls http://127.0.0.1:2381 --server-urls http://127.0.0.1:2382 --tmp-prefix &
+$timeout --kill-after=180s 120s "$MGMT" run --hostname h2 --seeds http://127.0.0.1:2379 --client-urls http://127.0.0.1:2381 --server-urls http://127.0.0.1:2382 --tmp-prefix &
 pid2=$!
 sleep 15s
 

--- a/test/shell/yaml-change1.sh
+++ b/test/shell/yaml-change1.sh
@@ -14,7 +14,7 @@ fi
 
 # set the config file
 cp -a yaml-change1a.yaml /tmp/mgmt/yaml-change.yaml
-$timeout --kill-after=30s 20s ./mgmt run --yaml /tmp/mgmt/yaml-change.yaml --tmp-prefix &
+$timeout --kill-after=30s 20s "$MGMT" run --yaml /tmp/mgmt/yaml-change.yaml --tmp-prefix &
 pid=$!
 sleep 5s	# let it converge
 grep -q 'hello world' /tmp/mgmt/change1	# check contents are correct

--- a/test/test-bashfmt.sh
+++ b/test/test-bashfmt.sh
@@ -28,4 +28,4 @@ bad_files=$(
 if [[ -n "${bad_files}" ]]; then
 	fail_test "The following bash files are not properly formatted: ${bad_files}"
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-commit-message.sh
+++ b/test/test-commit-message.sh
@@ -107,4 +107,4 @@ then
 		test_commit_message_common_bugs $commit
 	done
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-crossbuild.sh
+++ b/test/test-crossbuild.sh
@@ -16,10 +16,10 @@ make crossbuild &> "$log"
 
 RET=$?
 if [ ! $RET -eq 0 ]; then
-	echo 'FAIL'
+	redb 'FAIL'
 	cat "$log"
 else
-	echo 'PASS'
+	greenb 'PASS'
 fi
 rm -rf "$tmpdir"
 exit $RET

--- a/test/test-examples.sh
+++ b/test/test-examples.sh
@@ -32,10 +32,10 @@ cd ..
 rmdir "$tmpdir"	# cleanup
 
 if [[ -n "$failures" ]]; then
-	echo 'FAIL'
+	redb 'FAIL'
 	echo "The following tests (in: ${linkto}) have failed:"
 	echo -e "$failures"
 	echo
 	exit 1
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-gofmt.sh
+++ b/test/test-gofmt.sh
@@ -33,4 +33,4 @@ bad_files=$(find_files | xargs $GOFMT -l)
 if [[ -n "${bad_files}" ]]; then
 	fail_test "The following golang files are not properly formatted (goimports -l): ${bad_files}"
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-golint.sh
+++ b/test/test-golint.sh
@@ -26,7 +26,9 @@ if [ "$COMMITS" != "" ] && [ "$COMMITS" -gt "1" ]; then
 	HACK="yes"
 fi
 
-LINT=`find . -maxdepth 3 -iname '*.go' -not -path './old/*' -not -path './tmp/*' -not -path './bindata/*' -exec golint {} \;`	# current golint output
+# find all go files, exluding temporary directories and generated files
+LINT=$(find * -maxdepth 5 -iname '*.go' -not -path 'old/*' -not -path 'tmp/*' -not -path 'bindata/*' -not -path 'lang/y.go' -not -path 'lang/lexer.nn.go' -not -path 'vendor/*' -exec golint {} \;)	# current golint output
+
 COUNT=`echo -e "$LINT" | wc -l`	# number of golint problems in current branch
 [ "$LINT" = "" ] && echo PASS && exit	# everything is "perfect"
 echo "$LINT"	# display the issues
@@ -53,7 +55,7 @@ while read -r line; do
 done <<< "$NUMSTAT1"	# three < is the secret to putting a variable into read
 
 git checkout "$PREVIOUS" &>/dev/null	# previous commit
-LINT1=`find . -maxdepth 3 -iname '*.go' -not -path './old/*' -not -path './tmp/*' -not -path './bindata/*' -exec golint {} \;`
+LINT1=$(find * -maxdepth 5 -iname '*.go' -not -path 'old/*' -not -path 'tmp/*' -not -path 'bindata/*' -not -path 'lang/y.go' -not -path 'lang/lexer.nn.go' -not -path 'vendor/*' -exec golint {} \;)
 COUNT1=`echo -e "$LINT1" | wc -l`	# number of golint problems in older branch
 
 # clean up

--- a/test/test-golint.sh
+++ b/test/test-golint.sh
@@ -70,4 +70,4 @@ if [ "$DELTA" -gt "$THRESHOLD" ]; then
 	echo "Maximum threshold is: $THRESHOLD %"
 	fail_test "`golint` - FAILED"
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-gometalinter.sh
+++ b/test/test-gometalinter.sh
@@ -66,10 +66,10 @@ for dir in `find * -maxdepth 5 -type d -not -path 'old/*' -not -path 'old' -not 
 done
 
 if [[ -n "$failures" ]]; then
-	echo 'FAIL'
+	redb 'FAIL'
 	echo 'The following tests have failed:'
 	echo -e "$failures"
 	echo
 	exit 1
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-gotest.sh
+++ b/test/test-gotest.sh
@@ -27,11 +27,11 @@ for pkg in `go list ./... | grep -v "^${base}/vendor/" | grep -v "^${base}/examp
 done
 
 if [[ -n "$failures" ]]; then
-	echo 'FAIL'
+	redb 'FAIL'
 	cat "$log"
 	echo 'The following `go test` runs have failed:'
 	echo -e "$failures"
 	echo
 	exit 1
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-govet.sh
+++ b/test/test-govet.sh
@@ -56,10 +56,10 @@ for file in `find . -maxdepth 3 -type f -name '*.go' -not -path './old/*' -not -
 done
 
 if [[ -n "$failures" ]]; then
-	echo 'FAIL'
+	redb 'FAIL'
 	echo 'The following tests have failed:'
 	echo -e "$failures"
 	echo
 	exit 1
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-headerfmt.sh
+++ b/test/test-headerfmt.sh
@@ -30,4 +30,4 @@ bad_files=$(
 if [[ -n "${bad_files}" ]]; then
 	fail_test "The following file headers are not properly formatted: ${bad_files}"
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-misc.sh
+++ b/test/test-misc.sh
@@ -20,10 +20,10 @@ start=$(($(grep -n '^[[:space:]]*$' AUTHORS | awk -F ':' '{print $1}' | head -1)
 run-test diff <(tail -n +$start AUTHORS | sort) <(tail -n +$start AUTHORS)
 
 if [[ -n "$failures" ]]; then
-	echo 'FAIL'
+	redb 'FAIL'
 	echo "The following tests have failed:"
 	echo -e "$failures"
 	echo
 	exit 1
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-omv.sh
+++ b/test/test-omv.sh
@@ -19,7 +19,7 @@ done
 # return to original dir
 cd "$CWD" >/dev/null
 if [ ! $RET -eq 0 ]; then
-	echo 'FAIL'
+	redb 'FAIL'
 	exit $RET
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-reproducible.sh
+++ b/test/test-reproducible.sh
@@ -31,9 +31,9 @@ make clean
 
 # display errors
 if [[ -n "${failures}" ]]; then
-	echo 'FAIL'
+	redb 'FAIL'
 	echo 'The following tests failed:'
 	echo "${failures}"
 	exit 1
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-shell.sh
+++ b/test/test-shell.sh
@@ -21,8 +21,6 @@ fi
 LINE=$(printf '=%.0s' `seq -s ' ' $(tput cols)`)	# a terminal width string
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"	# dir!
 cd "$DIR" >/dev/null	# work from main mgmt directory
-MGMT="$DIR/test/shell/mgmt"
-cp -a "$DIR/mgmt" "$MGMT"	# put a copy there
 failures=""
 count=0
 

--- a/test/test-shell.sh
+++ b/test/test-shell.sh
@@ -70,9 +70,9 @@ fi
 
 # display errors
 if [[ -n "${failures}" ]]; then
-	echo 'FAIL'
+	redb 'FAIL'
 	echo 'The following tests failed:'
 	echo "${failures}"
 	exit 1
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/test-yamlfmt.sh
+++ b/test/test-yamlfmt.sh
@@ -62,4 +62,4 @@ bad_files=$(
 if [[ -n "${bad_files}" ]]; then
 	fail_test "The following yaml files are not properly formatted: ${bad_files}"
 fi
-echo 'PASS'
+greenb 'PASS'

--- a/test/util.sh
+++ b/test/util.sh
@@ -2,6 +2,12 @@
 
 # common settings and functions for test scripts
 
+# get the fully expanded path of the project directory
+ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE}")")/..")"
+
+# absolute location to freshly build binary to be used for testing
+export MGMT="$ROOT/mgmt"
+
 if [[ $(uname) == "Darwin" ]] ; then
 	export timeout="gtimeout"
 	export mktemp="gmktemp"

--- a/test/util.sh
+++ b/test/util.sh
@@ -18,7 +18,7 @@ fi
 
 fail_test()
 {
-	echo "FAIL: $@"
+	redb "FAIL: " "$@"
 	exit 1
 }
 
@@ -26,3 +26,27 @@ function run-test()
 {
 	"$@" || failures=$( [ -n "$failures" ] && echo "$failures\\n$@" || echo "$@" )
 }
+
+# enable colors if we run in a colorful terminal (ie: xterm-256color, xterm-color)
+# overwritable by setting environment variable ENABLE_COLORS empty `export ENABLE_COLORS=`
+if [[ "$TERM" =~ .*color.* ]];then
+	colors="${ENABLE_COLORS-1}"
+else
+	colors=""
+fi
+
+# colours https://gist.github.com/daytonn/8677243
+end="\033[0m"
+red="\033[0;31m"
+redb="\033[1;31m"
+green="\033[0;32m"
+greenb="\033[1;32m"
+yellow="\033[0;33m"
+blue="\033[0;34m"
+
+function red { test -z "$colors" && echo "${1}" || echo -e "${red}${1}${end}"; }
+function redb { test -z "$colors" && echo "${1}" || echo -e "${redb}${1}${end}"; }
+function green { test -z "$colors" && echo "${1}" || echo -e "${green}${1}${end}"; }
+function greenb { test -z "$colors" && echo "${1}" || echo -e "${greenb}${1}${end}"; }
+function yellow { test -z "$colors" && echo "${1}" || echo -e "${yellow}${1}${end}"; }
+function blue { test -z "$colors" && echo "${1}" || echo -e "${blue}${1}${end}"; }


### PR DESCRIPTION
This change aims to streamline the integrationtest suite and reduce friction when running (parts of) test suites. 

Changes:
- add `test-testname` to makefile to easily run one suite
- made skipping tests first class citizen in test.sh (all available testsuites and the reasons they are skipped are now better exposed and discovered)
- suppress some output of gotest unless there is an error
- no longer build binary for examples and gotest suites
- removed .SILENT from makefile as it being applied to only some targets makes it feel weird (I just learned about this option btw, feel free to comment on this change)
- move individual tests out of `test.sh` and into `test-misc.sh`
- introduced the concept of testsuites to `test.sh`

Points for discussion:
- started effort to make scripts shellcheck compatible (might be to much unrelated changes in one PR, might take these out)
