### PR TITLE
Fixes #336 - time package requirement

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,6 @@
-This is a list of authors/contributors to the mgmt project.
-If you're a core contributor, we might ask you to send a patch with your name.
-If you appreciate the work of one of the contributors, thank them a beverage!
+This is a list of core contributors to the mgmt project.
+If you're a core contributor, please send a patch with your name.
+If you appreciate the work of one of the core contributors, thank them a beverage!
 For a more exhaustive list please run: git log --format='%aN' | sort -u
 This list is sorted alphabetically by first name.
 

--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -29,11 +29,13 @@ fi
 
 if [ ! -z "$YUM" ]; then
 	$sudo_command $YUM install -y libvirt-devel
+	$sudo_command $YUM install -y time
 	$sudo_command $YUM install -y augeas-devel
 
 fi
 if [ ! -z "$APT" ]; then
 	$sudo_command $APT install -y libvirt-dev || true
+	$sudo_command $APT install -y time || true
 	$sudo_command $APT install -y libaugeas-dev || true
 	$sudo_command $APT install -y libpcap0.8-dev || true
 	# dependencies for building debian packages with `make deb`


### PR DESCRIPTION
  * docker images often only have the essential packages.
    When compiling mgmt, time is required so this adds the time
    package to the debian based make-deps.sh script


