### PR TITLE
cli: Log errors return by Run functions

### DIFF
--- a/lib/cli.go
+++ b/lib/cli.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"reflect"
 	"sort"
 	"syscall"
 
@@ -164,7 +165,7 @@ func run(c *cli.Context) error {
 	}()
 
 	if err := obj.Run(); err != nil {
-		//return cli.NewExitError(err.Error(), 1) // TODO: ?
+		log.Printf("%s: %s", reflect.TypeOf(obj).Elem().String(), err.Error())
 		return cli.NewExitError("", 1)
 	}
 	return nil


### PR DESCRIPTION
Currently cli drops error messages returned by Run in lib.Main instead of providing it to the user.

This change turns problems of not running as root or using --tmp-prefix from:
```
$ ./mgmt run
00:44:15 hello.go:46: This is: mgmt, version: 0.0.14-30-ge3a2648
00:44:15 hello.go:47: Main: Start: 1518738255855525279
$
```

Into

```
$ ./mgmt run
01:07:02 hello.go:46: This is: mgmt, version: 0.0.14-30-ge3a2648-dirty
01:07:02 hello.go:47: Main: Start: 1518739622517652739
01:07:02 cli.go:167: lib.Main: can't create prefix
$
```

Of course the `lib.` needs to be dropped. What do you think of this approach?
