### PR TITLE
Improve CI build time and reduce needless failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 os:
   - linux
-  - osx
 go:
   - 1.9.x
   - 1.10.x
@@ -21,6 +20,10 @@ matrix:
     - go: 1.10.x
     - go: tip
     - os: osx
+  # include only one build for osx for a quicker build as the nr. of these runners are sparse
+  include:
+    - os: osx
+      go: 1.9.x
 
 # the "secure" channel value is the result of running: ./misc/travis-encrypt.sh
 # with a value of: irc.freenode.net#mgmtconfig to eliminate noise from forks...

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ go_import_path: github.com/purpleidea/mgmt
 sudo: true
 dist: trusty
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo apt update; fi
+  # apt update tends to be flaky in travis, retry up to 3 times on failure
+  # https://docs.travis-ci.com/user/common-build-problems/#travis_retry
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then travis_retry sudo apt update; fi
   - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
   - git fetch --unshallow
 install: 'make deps'


### PR DESCRIPTION
Only build 1 OSX environment as these are sparse so these build potentially spend a long time in the queue.

Retry the initial apt update as travis is often having troubles with it. 