### PR TITLE
build: Relocate time command to the front for readability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ GOARCH=$(lastword $(subst -, ,$*))
 build/mgmt-%: $(GO_FILES) | bindata lang
 	@echo "Building: $(PROGRAM), os/arch: $*, version: $(SVERSION)..."
 	@# reassigning GOOS and GOARCH to make build command copy/pastable
-	env GOOS=${GOOS} GOARCH=${GOARCH} time go build -i -ldflags "-X main.program=$(PROGRAM) -X main.version=$(SVERSION) ${LDFLAGS}" -o $@ $(BUILD_FLAGS);
+	time env GOOS=${GOOS} GOARCH=${GOARCH} go build -i -ldflags "-X main.program=$(PROGRAM) -X main.version=$(SVERSION) ${LDFLAGS}" -o $@ $(BUILD_FLAGS);
 
 # create a list of binary file names to use as make targets
 crossbuild_targets = $(addprefix build/mgmt-,$(subst /,-,${GOOSARCHES}))


### PR DESCRIPTION
This makes the output more readable in my terminal.