### PR TITLE
Lang: don't panic if more arguments are past to an function than expected

### DIFF
--- a/lang/unification/simplesolver.go
+++ b/lang/unification/simplesolver.go
@@ -281,6 +281,10 @@ func SimpleInvariantSolver(invariants []interfaces.Invariant, logf func(format s
 
 				if typ, exists := solved[eq.Expr1]; exists {
 					// wow, now known, so tell the partials!
+					if len(eq.Expr2Ord) != len(typ.Ord) {
+						// TODO: a little more clear than a panic, but still offers no help in debugging mcl
+						return nil, fmt.Errorf("func arg count differs")
+					}
 					for i, name := range eq.Expr2Ord {
 						expr := eq.Expr2Map[name]                            // assume key exists
 						structPartials[eq.Expr1][expr] = typ.Map[typ.Ord[i]] // assume key exists
@@ -351,6 +355,10 @@ func SimpleInvariantSolver(invariants []interfaces.Invariant, logf func(format s
 
 				if typ, exists := solved[eq.Expr1]; exists {
 					// wow, now known, so tell the partials!
+					if len(eq.Expr2Ord) != len(typ.Ord) {
+						// TODO: a little more clear than a panic, but still offers no help in debugging mcl
+						return nil, fmt.Errorf("func arg count differs")
+					}
 					for i, name := range eq.Expr2Ord {
 						expr := eq.Expr2Map[name]                          // assume key exists
 						funcPartials[eq.Expr1][expr] = typ.Map[typ.Ord[i]] // assume key exists


### PR DESCRIPTION
Given the following mcl:
```
$x = getenv("TEST", "321")
```

This change will turn this:
```
00:28:50 lang.go:126: lang: Running Type Unification...
panic: runtime error: index out of range

goroutine 161 [running]:
github.com/purpleidea/mgmt/lang/unification.SimpleInvariantSolver(0xc4202f0780, 0x1e, 0x28, 0xc42052f970, 0xc4202e3300, 0xc42016e550, 0xc4202f0780)
	/Users/johan/.gopath/src/github.com/purpleidea/mgmt/lang/unification/simplesolver.go:356 +0x770c
github.com/purpleidea/mgmt/lang/unification.SimpleInvariantSolverLogger.func1(0xc4202f0780, 0x1e, 0x28, 0x28, 0x0, 0x0)
	/Users/johan/.gopath/src/github.com/purpleidea/mgmt/lang/unification/simplesolver.go:40 +0x48
github.com/purpleidea/mgmt/lang/unification.Unify(0x5ef8840, 0xc42032a6a0, 0xc42052f980, 0x1, 0x1)
	/Users/johan/.gopath/src/github.com/purpleidea/mgmt/lang/unification/unification.go:51 +0x8f
github.com/purpleidea/mgmt/lang.(*Lang).Init(0xc4202aa3f0, 0xc4202aa3f0, 0x207)
	/Users/johan/.gopath/src/github.com/purpleidea/mgmt/lang/lang.go:127 +0x6e0
github.com/purpleidea/mgmt/lang.(*GAPI).LangInit(0xc4202be880, 0x0, 0x0)
	/Users/johan/.gopath/src/github.com/purpleidea/mgmt/lang/gapi.go:142 +0x1f4
github.com/purpleidea/mgmt/lang.(*GAPI).Next.func1(0xc4202be880, 0xc420264300)
	/Users/johan/.gopath/src/github.com/purpleidea/mgmt/lang/gapi.go:220 +0x4af
created by github.com/purpleidea/mgmt/lang.(*GAPI).Next
	/Users/johan/.gopath/src/github.com/purpleidea/mgmt/lang/gapi.go:176 +0x8b
```

Into this:
```
00:28:13 lang.go:126: lang: Running Type Unification...
...
00:28:16 etcd.go:798: Etcd: Exiting callback loop!
00:28:16 etcd.go:960: Etcd: Exiting loop!
00:28:16 main.go:841: Main: Error: can't init the lang: could not unify types: func arg count differs
00:28:16 main.go:843: Goodbye!
00:28:16 cli.go:168: Main: Error: can't init the lang: could not unify types: func arg count differs
```