### PR TITLE
bugfix: Check that lang != nil before calling lang.Stream()

### DIFF
--- a/lang/gapi.go
+++ b/lang/gapi.go
@@ -228,7 +228,7 @@ func (obj *GAPI) Next() chan gapi.Next {
 
 					if obj.data.NoStreamWatch { // TODO: do we want to allow this for the lang?
 						streamChan = nil
-					} else {
+					} else if obj.lang != nil {
 						// stream for lang events
 						streamChan = obj.lang.Stream() // update stream
 					}


### PR DESCRIPTION
When a signal interrupt was caught during init, gapi.LangClose() would
set lang = nil before gapi.Next() called lang.Stream(). This patch checks
that lang != nil before calling the method so it doesn't panic.