### PR TITLE
Add Arch mapping 'any' for Arch Linux compatibility

### DIFF
--- a/engine/resources/packagekit/packagekit.go
+++ b/engine/resources/packagekit/packagekit.go
@@ -56,6 +56,7 @@ var (
 		// TODO: add more values
 		// noarch
 		"noarch": "ANY", // special value "ANY" (noarch as seen in Fedora)
+		"any":    "ANY", // special value "ANY" ('any' as seen in ArchLinux)
 		"all":    "ANY", // special value "ANY" ('all' as seen in Debian)
 		// fedora
 		"x86_64":  "amd64",


### PR DESCRIPTION
Arch Linux uses the mapping architecture name 'any'. This mapping was
missing from mgmt resulting in an error stating that arch 'any' did not
exist. Adding this mapping allows successful installation of packages
under Arch Linux.