### PR TITLE
test: Catch scenarios where we forgot to prefix the error with return

### DIFF
--- a/engine/resources/file_test.go
+++ b/engine/resources/file_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/purpleidea/mgmt/engine"
 	"github.com/purpleidea/mgmt/engine/graph/autoedge"
-	"github.com/purpleidea/mgmt/engine/util"
+	engineUtil "github.com/purpleidea/mgmt/engine/util"
 	"github.com/purpleidea/mgmt/pgraph"
 )
 
@@ -118,13 +118,13 @@ func TestMiscEncodeDecode2(t *testing.T) {
 		return
 	}
 
-	b64, err := util.ResToB64(input)
+	b64, err := engineUtil.ResToB64(input)
 	if err != nil {
 		t.Errorf("Can't encode: %v", err)
 		return
 	}
 
-	output, err := util.B64ToRes(b64)
+	output, err := engineUtil.B64ToRes(b64)
 	if err != nil {
 		t.Errorf("Can't decode: %v", err)
 		return

--- a/engine/resources/test_test.go
+++ b/engine/resources/test_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/purpleidea/mgmt/engine/util"
+	engineUtil "github.com/purpleidea/mgmt/engine/util"
 )
 
 func TestStructTagToFieldName0(t *testing.T) {
@@ -33,7 +33,7 @@ func TestStructTagToFieldName0(t *testing.T) {
 		Delta   int `lang:"surprise"`
 	}
 
-	mapping, err := util.StructTagToFieldName(&TestStruct{})
+	mapping, err := engineUtil.StructTagToFieldName(&TestStruct{})
 	if err != nil {
 		t.Errorf("failed: %+v", err)
 		return
@@ -62,7 +62,7 @@ func TestLowerStructFieldNameToFieldName0(t *testing.T) {
 		Delta     int
 	}
 
-	mapping, err := util.LowerStructFieldNameToFieldName(&TestStruct{})
+	mapping, err := engineUtil.LowerStructFieldNameToFieldName(&TestStruct{})
 	if err != nil {
 		t.Errorf("failed: %+v", err)
 		return
@@ -100,7 +100,7 @@ func TestLowerStructFieldNameToFieldName1(t *testing.T) {
 		Delta      int
 	}
 
-	mapping, err := util.LowerStructFieldNameToFieldName(&TestStruct{})
+	mapping, err := engineUtil.LowerStructFieldNameToFieldName(&TestStruct{})
 	if err == nil {
 		t.Errorf("expected failure, but passed with: %+v", mapping)
 		return
@@ -108,7 +108,7 @@ func TestLowerStructFieldNameToFieldName1(t *testing.T) {
 }
 
 func TestLowerStructFieldNameToFieldName2(t *testing.T) {
-	mapping, err := util.LowerStructFieldNameToFieldName(&TestRes{})
+	mapping, err := engineUtil.LowerStructFieldNameToFieldName(&TestRes{})
 	if err != nil {
 		t.Errorf("failed: %+v", err)
 		return


### PR DESCRIPTION
One of our contributors occasionally made this typo, and since core go
vet didn't (surprisingly) catch it, we should add a test!

/cc @jonathangold (present for you!)