### PR TITLE
travis: Bump to golang 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 os:
   - linux
 go:
-  - 1.9.x
   - 1.10.x
+  - 1.11.x
   - tip
 go_import_path: github.com/purpleidea/mgmt
 sudo: true
@@ -26,13 +26,13 @@ script: 'make test'
 matrix:
   fast_finish: false
   allow_failures:
-    - go: 1.10.x
+    - go: 1.11.x
     - go: tip
     - os: osx
   # include only one build for osx for a quicker build as the nr. of these runners are sparse
   include:
     - os: osx
-      go: 1.9.x
+      go: 1.10.x
 
 # the "secure" channel value is the result of running: ./misc/travis-encrypt.sh
 # with a value of: irc.freenode.net#mgmtconfig to eliminate noise from forks...

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -13,7 +13,7 @@ Once you're familiar with the general idea, please start hacking...
 
 ### Installing golang
 
-* You need golang version 1.9 or greater installed.
+* You need golang version 1.10 or greater installed.
 	* To install on rpm style systems: `sudo dnf install golang`
 	* To install on apt style systems: `sudo apt install golang`
 	* To install on macOS systems install [Homebrew](https://brew.sh)
@@ -89,7 +89,7 @@ required for running the _test_ suite.
 
 ### Build
 
-* `golang` 1.9 or higher (required, available in some distros and distributed
+* `golang` 1.10 or higher (required, available in some distros and distributed
 as a binary officially by [golang.org](https://golang.org/dl/))
 
 ### Runtime

--- a/examples/lib/exec-send-recv.go
+++ b/examples/lib/exec-send-recv.go
@@ -60,9 +60,7 @@ func (obj *MyGAPI) Cli(c *cli.Context, fs engine.Fs) (*gapi.Deploy, error) {
 			Name: obj.Name,
 			Noop: c.GlobalBool("noop"),
 			Sema: c.GlobalInt("sema"),
-			GAPI: &MyGAPI{
-			// TODO: add properties here...
-			},
+			GAPI: &MyGAPI{},
 		}, nil
 	}
 	return nil, nil // we weren't activated!

--- a/examples/lib/libmgmt-subgraph0.go
+++ b/examples/lib/libmgmt-subgraph0.go
@@ -65,9 +65,7 @@ func (obj *MyGAPI) Cli(c *cli.Context, fs engine.Fs) (*gapi.Deploy, error) {
 			Name: obj.Name,
 			Noop: c.GlobalBool("noop"),
 			Sema: c.GlobalInt("sema"),
-			GAPI: &MyGAPI{
-			// TODO: add properties here...
-			},
+			GAPI: &MyGAPI{},
 		}, nil
 	}
 	return nil, nil // we weren't activated!

--- a/examples/lib/libmgmt-subgraph1.go
+++ b/examples/lib/libmgmt-subgraph1.go
@@ -60,9 +60,7 @@ func (obj *MyGAPI) Cli(c *cli.Context, fs engine.Fs) (*gapi.Deploy, error) {
 			Name: obj.Name,
 			Noop: c.GlobalBool("noop"),
 			Sema: c.GlobalInt("sema"),
-			GAPI: &MyGAPI{
-			// TODO: add properties here...
-			},
+			GAPI: &MyGAPI{},
 		}, nil
 	}
 	return nil, nil // we weren't activated!

--- a/examples/lib/libmgmt2.go
+++ b/examples/lib/libmgmt2.go
@@ -62,9 +62,7 @@ func (obj *MyGAPI) Cli(c *cli.Context, fs engine.Fs) (*gapi.Deploy, error) {
 			Name: obj.Name,
 			Noop: c.GlobalBool("noop"),
 			Sema: c.GlobalInt("sema"),
-			GAPI: &MyGAPI{
-			// TODO: add properties here...
-			},
+			GAPI: &MyGAPI{},
 		}, nil
 	}
 	return nil, nil // we weren't activated!

--- a/examples/lib/libmgmt3.go
+++ b/examples/lib/libmgmt3.go
@@ -60,9 +60,7 @@ func (obj *MyGAPI) Cli(c *cli.Context, fs engine.Fs) (*gapi.Deploy, error) {
 			Name: obj.Name,
 			Noop: c.GlobalBool("noop"),
 			Sema: c.GlobalInt("sema"),
-			GAPI: &MyGAPI{
-			// TODO: add properties here...
-			},
+			GAPI: &MyGAPI{},
 		}, nil
 	}
 	return nil, nil // we weren't activated!

--- a/lang/funcs/core/template_polyfunc.go
+++ b/lang/funcs/core/template_polyfunc.go
@@ -170,19 +170,19 @@ func (obj *TemplateFunc) run(templateText string, vars types.Value) (string, err
 	// see: https://golang.org/pkg/text/template/#FuncMap for more info
 	// note: we can override any other functions by adding them here...
 	funcMap := map[string]interface{}{
-	//"test1": func(in interface{}) (interface{}, error) { // ok
-	//	return fmt.Sprintf("got(%T): %+v", in, in), nil
-	//},
-	//"test2": func(in interface{}) interface{} { // NOT ok
-	//	panic("panic") // a panic here brings down everything!
-	//},
-	//"test3": func(foo int64) (string, error) { // ok, but errors
-	//	return "", fmt.Errorf("i am an error")
-	//},
-	//"test4": func(in1, in2 reflect.Value) (reflect.Value, error) { // ok
-	//	s := fmt.Sprintf("got: %+v and: %+v", in1, in2)
-	//	return reflect.ValueOf(s), nil
-	//},
+		//"test1": func(in interface{}) (interface{}, error) { // ok
+		//	return fmt.Sprintf("got(%T): %+v", in, in), nil
+		//},
+		//"test2": func(in interface{}) interface{} { // NOT ok
+		//	panic("panic") // a panic here brings down everything!
+		//},
+		//"test3": func(foo int64) (string, error) { // ok, but errors
+		//	return "", fmt.Errorf("i am an error")
+		//},
+		//"test4": func(in1, in2 reflect.Value) (reflect.Value, error) { // ok
+		//	s := fmt.Sprintf("got: %+v and: %+v", in1, in2)
+		//	return reflect.ValueOf(s), nil
+		//},
 	}
 
 	// FIXME: should we do this once in init() instead, or in the Register

--- a/lang/structs.go
+++ b/lang/structs.go
@@ -1722,10 +1722,10 @@ func (obj *ExprStr) String() string { return fmt.Sprintf("str(%s)", obj.V) }
 // itself.
 func (obj *ExprStr) Interpolate() (interfaces.Expr, error) {
 	pos := &Pos{
-	// column/line number, starting at 1
-	//Column: -1, // TODO
-	//Line: -1, // TODO
-	//Filename: "", // optional source filename, if known
+		// column/line number, starting at 1
+		//Column: -1, // TODO
+		//Line: -1, // TODO
+		//Filename: "", // optional source filename, if known
 	}
 	result, err := InterpolateStr(obj.V, pos)
 	if err != nil {

--- a/test/test-gofmt.sh
+++ b/test/test-gofmt.sh
@@ -11,12 +11,6 @@ ROOT=$(dirname "${BASH_SOURCE}")/..
 cd "${ROOT}"
 . test/util.sh
 
-#GO_VERSION=($(go version))
-#
-#if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.2|go1.3|go1.4|go1.5|go1.6|go1.7|go1.8|go1.9|devel') ]]; then
-#	fail_test "Unknown go version '${GO_VERSION[2]}', failing gofmt."
-#fi
-
 find_files() {
 	git ls-files | grep '\.go$'
 }


### PR DESCRIPTION
This requires breaking changes in gofmt. This also moves to the latest stable etcd.

I'm planning to rebase and push this patch around July 31st when golang 1.11 comes out. Earlier if we need it for something specific. I'm hacking with 1.10 now.