### PR TITLE
Update vagrant vm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure(2) do |config|
 	config.vm.synced_folder ".", "/vagrant", disabled: true
 
 	config.vm.define "mgmt-dev" do |instance|
-		instance.vm.box = "fedora/26-cloud-base"
+		instance.vm.box = "fedora/28-cloud-base"
 	end
 
 	config.vm.provider "virtualbox" do |v|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(2) do |config|
 	config.vm.provision "file", source: "~/.gitconfig", destination: ".gitconfig"
 
 	# copied from make-deps.sh (with added git)
-	config.vm.provision "shell", inline: "dnf install -y libvirt-devel golang golang-googlecode-tools-stringer hg git make"
+	config.vm.provision "shell", inline: "dnf install -y libvirt-devel golang golang-googlecode-tools-stringer hg git make gem"
 
 	# set up packagekit
 	config.vm.provision "shell" do |shell|

--- a/vagrant/motd
+++ b/vagrant/motd
@@ -9,6 +9,6 @@ To get started, try:
 
 $ cdmgmt
 $ make clean build
-$ ./mgmt run --tmp-prefix --yaml examples/exec1.yaml --converged-timeout 5
+$ ./mgmt run --tmp-prefix --yaml examples/yaml/exec1.yaml --converged-timeout 5
 
 Enjoy!


### PR DESCRIPTION
While checking out your interesting work, I noticed a few things:

- the go 1.8 release in fedora 26 seems to be too old to build mgmt, so I bumped the base image to fedora 28 which seems to work fine.
- the gem package manager seems to be needed during the build process but wasn't installed.
- the path to the example yaml file in motd changed, presumably when mgmt lang has been introduced.