### PR TITLE
make: Speed up the build by skipping gem docs

### DIFF
--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -104,6 +104,6 @@ go get golang.org/x/tools/cmd/stringer			# for automatic stringer-ing
 go get golang.org/x/lint/golint				# for `golint`-ing
 go get github.com/tmthrgd/go-bindata/go-bindata	# for compiling in non golang files
 go get -u gopkg.in/alecthomas/gometalinter.v1 && mv "$(dirname $(command -v gometalinter.v1))/gometalinter.v1" "$(dirname $(command -v gometalinter.v1))/gometalinter" && gometalinter --install	# bonus
-command -v mdl &>/dev/null || gem install mdl || true	# for linting markdown files
-command -v fpm &>/dev/null || gem install fpm || true	# for cross distro packaging
+command -v mdl &>/dev/null || gem install mdl --no-ri --no-rdoc || true	# for linting markdown files
+command -v fpm &>/dev/null || gem install fpm --no-ri --no-rdoc || true	# for cross distro packaging
 cd "$XPWD" >/dev/null


### PR DESCRIPTION
Per default, the Ruby gems renerate documentation in two distinct formats
during installation. By passing --no-ri and --no-rdoc, gem is instructed
to skip this step for both formats.

If the user needs documentation for any of the gems after all, they can
manually generate the docs themselves.