### PR TITLE
travis: Build on Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
   - tip
 go_import_path: github.com/purpleidea/mgmt
 sudo: true
-dist: trusty
+dist: xenial
 # travis requires that you update manually, and provides this key to trigger it
 apt:
   update: true


### PR DESCRIPTION
Builds were failing on Trusty due to broken GPG keys, and upgrading
the build environment to Xenial Xerus solves the problem.