### PR TITLE
engine: resources: file: Fix bug preventing use of source

### DIFF
--- a/engine/resources/file.go
+++ b/engine/resources/file.go
@@ -608,7 +608,7 @@ func (obj *FileRes) contentCheckApply(apply bool) (checkOK bool, _ error) {
 	}
 
 	// content is not defined, leave it alone...
-	if obj.Content == nil {
+	if obj.Content == nil && obj.Source == "" {
 		return true, nil
 	}
 

--- a/test/shell/file-source.mcl
+++ b/test/shell/file-source.mcl
@@ -1,0 +1,4 @@
+file "/tmp/mgmt/file-source.txt" {
+	source => "file-source.txt",
+	state => "exists",
+}

--- a/test/shell/file-source.sh
+++ b/test/shell/file-source.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+# vim: noet:ts=8:sts=8:sw=8
+
+set -x
+
+if ! timeout 1s sudo -A true; then
+	echo "sudo disabled: not checking file owner and group"
+	exit
+fi
+
+# run till completion
+$timeout --kill-after=30s 25s sudo -A "$MGMT" run --lang file-source.mcl --converged-timeout=5 --no-watch --tmp-prefix &
+pid=$!
+wait $pid	# get exit status
+e=$?
+
+ls -l /tmp/mgmt
+
+test -e /tmp/mgmt/file-source.txt
+cmp --silent file-source.txt /tmp/mgmt/file-source.txt || exit 1
+
+exit $e

--- a/test/shell/file-source.txt
+++ b/test/shell/file-source.txt
@@ -1,0 +1,6 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
This patch fixes a previously undiscovered bug which prevented
the use of the source field in the file resource. CheckApply was
returning early if obj.Content was nil. It is also necessary to
check that obj.Source is empty before returning, otherwise
syncCheckApply never runs.