### PR TITLE
[WIP] engine: resources: timer: Add a systemd-timer resource

### DIFF
--- a/examples/lang/cron4.mcl
+++ b/examples/lang/cron4.mcl
@@ -1,0 +1,17 @@
+$home = getenv("HOME")
+
+cron "purpleidea-oneshot" {
+    state => "absent",
+    session => true,
+    trigger => "OnCalendar",
+    time => "*:*:0",
+}
+
+svc "purpleidea-oneshot" {
+    state => "stopped",
+    session => true,
+}
+
+file printf("%s/.config/systemd/user/purpleidea-oneshot.service", $home) {
+    state => "absent",
+}


### PR DESCRIPTION
For early feedback. Still have to ~~add autoedges to svc and~~ validate the time.

I didn't initially realize there was already a timer resource :P so I can rename this to something else, but is https://github.com/purpleidea/mgmt/blob/master/engine/resources/timer.go still useful given language functions?

Either way, I think it makes sense to call this resource 'timer' or 'systemd:timer' rather than cron.

Edit: also tests