### PR TITLE
util: afero: Use dst + base path for mkdir in walk

### DIFF
--- a/util/afero.go
+++ b/util/afero.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 
 	"github.com/spf13/afero"
 )
@@ -101,9 +100,12 @@ func CopyFs(srcFs, dstFs afero.Fs, src, dst string, force bool) error {
 		}
 		//perm := info.Perm()
 		perm := info.Mode() // TODO: is this correct?
-		p := path.Join(dst, filepath.Base(name))
+		p := name
+		if dst != "" {
+			p = path.Join(dst, name)
+		}
 		if info.IsDir() {
-			err := dstFs.Mkdir(p, perm)
+			err := dstFs.Mkdir(path.Join(dst, path.Base(p), src[:len(src)]), perm)
 			if os.IsExist(err) && (name == "/" || force) {
 				return nil
 			}


### PR DESCRIPTION
It seems that for etcdfs, the name parameter of walk is fed with
the absolute path instead of the base path. This change does not
solve that problem, but rather strips the parent path from name
and appends it to the destination path. For cases where the name
is already correct, we end up producing the same string again,
but where name has an untrimmed parent path, it will be removed
before appending name to dst. As a result, etcdfs now behaves
like any other filesystem for CopyFs.