### PR TITLE
pgraph: Fix GraphCmp function

### DIFF
--- a/lang/interpret_test.go
+++ b/lang/interpret_test.go
@@ -335,38 +335,37 @@ func TestAstFunc0(t *testing.T) {
 			graph: graph,
 		})
 	}
-	//	// FIXME: blocked by: https://github.com/purpleidea/mgmt/issues/199
-	//{
-	//	graph, _ := pgraph.NewGraph("g")
-	//	v0 := vtex("bool(true)")
-	//	v1, v2 := vtex("str(hello)"), vtex("str(world)")
-	//	v3, v4 := vtex("var(x)"), vtex("var(x)") // different vertices!
-	//	v5, v6 := vtex("str(t1)"), vtex("str(t2)")
-	//
-	//	graph.AddVertex(&v0, &v1, &v2, &v3, &v4, &v5, &v6)
-	//	e1, e2 := edge("x"), edge("x")
-	//	graph.AddEdge(&v1, &v3, &e1)
-	//	graph.AddEdge(&v2, &v4, &e2)
-	//
-	//	testCases = append(testCases, test{
-	//		name: "variable shadowing both",
-	//		code: `
-	//			# this should be okay, because var is shadowed
-	//			$x = "hello"
-	//			if true {
-	//				$x = "world"	# shadowed
-	//				test "t2" {
-	//					stringptr => $x,
-	//				}
-	//			}
-	//			test "t1" {
-	//				stringptr => $x,
-	//			}
-	//		`,
-	//		fail: false,
-	//		graph: graph,
-	//	})
-	//}
+	{
+		graph, _ := pgraph.NewGraph("g")
+		v0 := vtex("bool(true)")
+		v1, v2 := vtex("str(hello)"), vtex("str(world)")
+		v3, v4 := vtex("var(x)"), vtex("var(x)") // different vertices!
+		v5, v6 := vtex("str(t1)"), vtex("str(t2)")
+
+		graph.AddVertex(&v0, &v1, &v2, &v3, &v4, &v5, &v6)
+		e1, e2 := edge("x"), edge("x")
+		graph.AddEdge(&v1, &v3, &e1)
+		graph.AddEdge(&v2, &v4, &e2)
+
+		testCases = append(testCases, test{
+			name: "variable shadowing both",
+			code: `
+				# this should be okay, because var is shadowed
+				$x = "hello"
+				if true {
+					$x = "world"	# shadowed
+					test "t2" {
+						stringptr => $x,
+					}
+				}
+				test "t1" {
+					stringptr => $x,
+				}
+			`,
+			fail:  false,
+			graph: graph,
+		})
+	}
 	{
 		testCases = append(testCases, test{
 			name: "variable re-declaration and type change error",

--- a/pgraph/pgraph_test.go
+++ b/pgraph/pgraph_test.go
@@ -667,18 +667,41 @@ func TestGraphCmp1(t *testing.T) {
 	}
 }
 
-// FIXME: i think we should allow equivalent elements in the graph to compare...
-// FIXME: currently this fails :(
-//func TestGraphCmp2(t *testing.T) {
-//	g1 := &Graph{}
-//	g2 := &Graph{}
-//	g1.AddVertex(NV("v1"), NV("v1"))
-//	g2.AddVertex(NV("v1"), NV("v1"))
-//
-//	if err := g1.GraphCmp(g2, strVertexCmpFn, strEdgeCmpFn); err != nil {
-//		t.Errorf("should have no error during GraphCmp, but got: %v", err)
-//	}
-//}
+func TestGraphCmp2(t *testing.T) {
+	g1 := &Graph{}
+	g2 := &Graph{}
+	g1.AddVertex(NV("v1"), NV("v1"))
+	g2.AddVertex(NV("v1"), NV("v1"))
+
+	if err := g1.GraphCmp(g2, strVertexCmpFn, strEdgeCmpFn); err != nil {
+		t.Errorf("should have no error during GraphCmp, but got: %v", err)
+	}
+}
+
+func TestGraphCmp3(t *testing.T) {
+	g1 := &Graph{}
+	g2 := &Graph{}
+
+	v1 := NV("v1")
+	v2 := NV("v2")
+
+	e1 := NE("e1")
+	e2 := NE("e2")
+
+	g1.AddEdge(v1, v2, e1)
+	g2.AddEdge(v2, v1, e2)
+
+	if err := g1.GraphCmp(g2, strVertexCmpFn, strEdgeCmpFn); err == nil {
+		t.Errorf("should have error during GraphCmp, but got: %v", err)
+	}
+
+	g1.AddEdge(v2, v1, e2)
+	g2.AddEdge(v1, v2, e1)
+
+	if err := g1.GraphCmp(g2, strVertexCmpFn, strEdgeCmpFn); err != nil {
+		t.Errorf("should have no error during GraphCmp, but got: %v", err)
+	}
+}
 
 func TestSort0(t *testing.T) {
 	vs := []Vertex{}


### PR DESCRIPTION
The previous algorithm would fail on the newly added tests due to the
fact that it would check for duplicate vertices. The newer algorithm
doesn't use any fancy isomorphism algorithms. It exploits the fact that
nodes can be expected to have the same label in the two graphs being
compared. This allows us to create a sorted list of vertices based on
the label of a node and the labels of its neighbors.

Once the two graphs are in sorted order, we simply use the vertexCmpFn
on vertices at the same index, and run the edgeCmpFn on each of the
vertices' respective edges.

Resolves #199