### PR TITLE
make: deps: gometalinter: Use latest stable release

### DIFF
--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -103,7 +103,9 @@ go get golang.org/x/tools/cmd/goyacc			# formerly `go tool yacc`
 go get golang.org/x/tools/cmd/stringer			# for automatic stringer-ing
 go get golang.org/x/lint/golint				# for `golint`-ing
 go get github.com/tmthrgd/go-bindata/go-bindata	# for compiling in non golang files
-go get -u gopkg.in/alecthomas/gometalinter.v1 && mv "$(dirname $(command -v gometalinter.v1))/gometalinter.v1" "$(dirname $(command -v gometalinter.v1))/gometalinter" && gometalinter --install	# bonus
+if env | grep -q -e '^TRAVIS=true$' -e '^JENKINS_URL=' -e '^BUILD_TAG=jenkins'; then
+	go get -u gopkg.in/alecthomas/gometalinter.v1 && mv "$(dirname $(command -v gometalinter.v1))/gometalinter.v1" "$(dirname $(command -v gometalinter.v1))/gometalinter" && gometalinter --install	# bonus
+fi
 command -v mdl &>/dev/null || gem install mdl --no-ri --no-rdoc || true	# for linting markdown files
 command -v fpm &>/dev/null || gem install fpm --no-ri --no-rdoc || true	# for cross distro packaging
 cd "$XPWD" >/dev/null

--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -104,7 +104,7 @@ go get golang.org/x/tools/cmd/stringer			# for automatic stringer-ing
 go get golang.org/x/lint/golint				# for `golint`-ing
 go get github.com/tmthrgd/go-bindata/go-bindata	# for compiling in non golang files
 if env | grep -q -e '^TRAVIS=true$' -e '^JENKINS_URL=' -e '^BUILD_TAG=jenkins'; then
-	go get -u gopkg.in/alecthomas/gometalinter.v1 && mv "$(dirname $(command -v gometalinter.v1))/gometalinter.v1" "$(dirname $(command -v gometalinter.v1))/gometalinter" && gometalinter --install	# bonus
+	curl -L https://git.io/vp6lP | sh # install latest stable gometalinter release
 fi
 command -v mdl &>/dev/null || gem install mdl --no-ri --no-rdoc || true	# for linting markdown files
 command -v fpm &>/dev/null || gem install fpm --no-ri --no-rdoc || true	# for cross distro packaging

--- a/test/test-gometalinter.sh
+++ b/test/test-gometalinter.sh
@@ -4,6 +4,9 @@
 
 echo running "$0"
 
+# ensure gometalinter is available
+command -v gometalinter >/dev/null 2>&1 || { echo >&2 "gometalinter not found"; exit 1; }
+
 #ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"	# dir!
 ROOT=$(dirname "${BASH_SOURCE}")/..
 cd "${ROOT}"


### PR DESCRIPTION
Gometalinter no longer supports the `--install` flag, and fails
to install some of the linters if it is used. This change employs
the supported installation method to ensure all linters are
successfully installed.

see: https://github.com/alecthomas/gometalinter/issues/552
and: https://github.com/alecthomas/gometalinter#installing