### PR TITLE
langpuppet: Fix Cli method invocations for wrapped GAPIs

### DIFF
--- a/langpuppet/gapi.go
+++ b/langpuppet/gapi.go
@@ -123,13 +123,13 @@ func (obj *GAPI) Cli(cliInfo *gapi.CliInfo) (*gapi.Deploy, error) {
 	var langDeploy *gapi.Deploy
 	var puppetDeploy *gapi.Deploy
 	langCliInfo := &gapi.CliInfo{
-		CliContext: cli.NewContext(c.App, flagSet, nil),
+		CliContext: cli.NewContext(c.App, flagSet, c.Parent()),
 		Fs:         fs,
 		Debug:      debug,
 		Logf:       logf, // TODO: wrap logf?
 	}
 	puppetCliInfo := &gapi.CliInfo{
-		CliContext: cli.NewContext(c.App, flagSet, nil),
+		CliContext: cli.NewContext(c.App, flagSet, c.Parent()),
 		Fs:         fs,
 		Debug:      debug,
 		Logf:       logf, // TODO: wrap logf?


### PR DESCRIPTION
Since the langpuppet GAPI creates fresh new CliContext objects,
it has to make sure to provide the original parent context, because
the child GAPIs expect to be able to access its data.
