### PR TITLE
make: Use gem --no-document instead of deprecated flags.

### DIFF
--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -106,6 +106,6 @@ go get github.com/tmthrgd/go-bindata/go-bindata	# for compiling in non golang fi
 if env | grep -q -e '^TRAVIS=true$' -e '^JENKINS_URL=' -e '^BUILD_TAG=jenkins'; then
 	go get -u gopkg.in/alecthomas/gometalinter.v1 && mv "$(dirname $(command -v gometalinter.v1))/gometalinter.v1" "$(dirname $(command -v gometalinter.v1))/gometalinter" && gometalinter --install	# bonus
 fi
-command -v mdl &>/dev/null || gem install mdl --no-ri --no-rdoc || true	# for linting markdown files
-command -v fpm &>/dev/null || gem install fpm --no-ri --no-rdoc || true	# for cross distro packaging
+command -v mdl &>/dev/null || gem install mdl --no-document || true	# for linting markdown files
+command -v fpm &>/dev/null || gem install fpm --no-document || true	# for cross distro packaging
 cd "$XPWD" >/dev/null


### PR DESCRIPTION
Signed-off-by: Lander Van den Bulcke <landervdb@inuits.eu>

The flags `--no-ri` and `--no-rdoc` for `gem install` have been deprecated since version 2.0.0 and have actually been removed in 3.x.x. `--no-document` should be used instead.
