### PR TITLE
uptime_fact_posix.go: Remove deprecated syscall import

### DIFF
--- a/lang/funcs/core/sys/uptime_fact_posix.go
+++ b/lang/funcs/core/sys/uptime_fact_posix.go
@@ -20,12 +20,12 @@
 package coresys
 
 import (
-	"syscall"
+	"golang.org/x/sys/unix"
 )
 
 func uptime() (int64, error) {
-	var sysinfo syscall.Sysinfo_t
-	if err := syscall.Sysinfo(&sysinfo); err != nil {
+	var sysinfo unix.Sysinfo_t
+	if err := unix.Sysinfo(&sysinfo); err != nil {
 		return 0, err
 	}
 	return sysinfo.Uptime, nil


### PR DESCRIPTION
According to https://godoc.org/syscall the `syscall` package is deprecated, and points to using https://godoc.org/golang.org/x/sys instead.

I stumbled into looking at the `syscall` package in the first place due to #493. 

I've updated the import in a single file for now to see what your thoughts are on it and if it should be done with the other `syscall` imports or not.