### PR TITLE
Removed obsolete no-watch-config flag

### DIFF
--- a/gapi/gapi.go
+++ b/gapi/gapi.go
@@ -73,7 +73,6 @@ type Data struct {
 	Hostname      string // uuid for the host, required for GAPI
 	World         engine.World
 	Noop          bool
-	NoConfigWatch bool
 	NoStreamWatch bool
 	Prefix        string
 	Debug         bool

--- a/langpuppet/gapi.go
+++ b/langpuppet/gapi.go
@@ -167,7 +167,6 @@ func (obj *GAPI) Init(data *gapi.Data) error {
 		Hostname:      obj.data.Hostname,
 		World:         obj.data.World,
 		Noop:          obj.data.Noop,
-		NoConfigWatch: obj.data.NoConfigWatch,
 		NoStreamWatch: obj.data.NoStreamWatch,
 		Debug:         obj.data.Debug,
 		Logf: func(format string, v ...interface{}) {
@@ -179,7 +178,6 @@ func (obj *GAPI) Init(data *gapi.Data) error {
 		Hostname:      obj.data.Hostname,
 		World:         obj.data.World,
 		Noop:          obj.data.Noop,
-		NoConfigWatch: obj.data.NoConfigWatch,
 		NoStreamWatch: obj.data.NoStreamWatch,
 		Debug:         obj.data.Debug,
 		Logf: func(format string, v ...interface{}) {

--- a/lib/cli.go
+++ b/lib/cli.go
@@ -73,10 +73,6 @@ func CLI(program, version string, flags Flags) error {
 			Usage: "do not update graph under any switch events",
 		},
 		cli.BoolFlag{
-			Name:  "no-config-watch",
-			Usage: "do not update graph on config switch events",
-		},
-		cli.BoolFlag{
 			Name:  "no-stream-watch",
 			Usage: "do not update graph on stream switch events",
 		},

--- a/lib/main.go
+++ b/lib/main.go
@@ -75,7 +75,6 @@ type Main struct {
 	DeployFs engine.Fs    // used for static deploys
 
 	NoWatch       bool // do not change graph under any circumstances
-	NoConfigWatch bool // do not update graph due to config changes
 	NoStreamWatch bool // do not update graph due to stream changes
 	NoDeployWatch bool // do not change deploys after an initial deploy
 
@@ -140,9 +139,8 @@ func (obj *Main) Init() error {
 	// if we've turned off watching, then be explicit and disable them all!
 	// if all the watches are disabled, then it's equivalent to no watching
 	if obj.NoWatch {
-		obj.NoConfigWatch = true
 		obj.NoStreamWatch = true
-	} else if obj.NoConfigWatch && obj.NoStreamWatch {
+	} else if obj.NoStreamWatch {
 		obj.NoWatch = true
 	}
 
@@ -554,7 +552,6 @@ func (obj *Main) Run() error {
 					Noop:     mainDeploy.Noop,
 					// FIXME: should the below flags come from the deploy struct?
 					//NoWatch:  obj.NoWatch,
-					NoConfigWatch: obj.NoConfigWatch,
 					NoStreamWatch: obj.NoStreamWatch,
 					Prefix:        fmt.Sprintf("%s/", path.Join(prefix, "gapi")),
 					Debug:         obj.Flags.Debug,

--- a/lib/run.go
+++ b/lib/run.go
@@ -87,7 +87,6 @@ func run(c *cli.Context, name string, gapiObj gapi.GAPI) error {
 	}
 
 	obj.NoWatch = cliContext.Bool("no-watch")
-	obj.NoConfigWatch = cliContext.Bool("no-config-watch")
 	obj.NoStreamWatch = cliContext.Bool("no-stream-watch")
 	obj.NoDeployWatch = cliContext.Bool("no-deploy-watch")
 

--- a/puppet/gapi.go
+++ b/puppet/gapi.go
@@ -294,8 +294,6 @@ func (obj *GAPI) Next() chan gapi.Next {
 		close(startChan)                 // kick it off!
 
 		var pChan <-chan time.Time
-		// NOTE: we don't look at obj.data.NoConfigWatch since emulating
-		// puppet means we do not switch graphs on code changes anyways.
 		if obj.data.NoStreamWatch {
 			pChan = nil
 		} else {


### PR DESCRIPTION
I removed the "no-watch-config" flag, since it was only ever written and never read.
Having it around creates the expectation that by default mgmt will put a watch on the config.

The test suite still passes locally.

@purpleidea let me know what you think.