### PR TITLE
Support official builds on supported LTS Ubuntu/Debian releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 docker
+releases

--- a/Makefile
+++ b/Makefile
@@ -373,7 +373,7 @@ releases/$(VERSION)/deb/changelog: $(PROGRAM) releases/$(VERSION)/.mkdir
 
 $(DEB_PKG): releases/$(VERSION)/deb/changelog
 	@echo "Building: deb package..."
-	./misc/fpm-pack.sh deb $(VERSION) libvirt-dev libaugeas-dev
+	./misc/fpm-pack.sh deb $(VERSION) libvirt0 libaugeas0
 
 $(PACMAN_PKG): $(PROGRAM) releases/$(VERSION)/.mkdir
 	@echo "Building: pacman package..."

--- a/docker/Dockerfile.deb-release
+++ b/docker/Dockerfile.deb-release
@@ -1,0 +1,18 @@
+FROM debian:8
+
+# Create environment to build release .deb for supported LTS Debian/Ubuntu versions
+
+RUN apt-get update
+RUN apt-get install -yqq git make curl
+
+# install at least go1.9
+RUN curl -sSL https://dl.google.com/go/go1.12.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+
+ENV GOPATH /gopath
+ENV PATH $PATH:$GOPATH/bin:/usr/local/go/bin
+
+RUN mkdir -p $GOPATH/src/github.com/purpleidea/
+COPY . $GOPATH/src/github.com/purpleidea/mgmt/
+
+WORKDIR $GOPATH/src/github.com/purpleidea/mgmt
+RUN make deps

--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -84,8 +84,8 @@ if [ $travis -eq 0 ]; then
 fi
 
 # if golang is too old, we don't want to fail with an obscure error later
-if go version | grep 'go1\.[012345]\.'; then
-	echo "mgmt requires go1.6 or higher."
+if go version | grep 'go1\.[012345678]\.'; then
+	echo "mgmt requires go1.9 or higher."
 	exit 1
 fi
 

--- a/test/test-deb-releases.sh
+++ b/test/test-deb-releases.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# test if .deb package installs and mgmt runs on supported LTS Debian/Ubuntu
+
+set -o errexit
+set -o pipefail
+
+releases=(ubuntu:18.04 debian:9 ubuntu:16.04 debian:8 )
+
+. "$(dirname "$0")/util.sh"
+
+version=$(git describe --match '[0-9]*\.[0-9]*\.[0-9]*' --tags --abbrev=0)
+release_deb="releases/$version/deb/mgmt_${version}_amd64.deb"
+testcmd="set -x; apt-get update >/dev/null && \
+	dpkg -i /$release_deb 2>/dev/null; \
+	apt-get install -yqqf >/dev/null && \
+	mgmt --version"
+
+# test if release build is available
+if ! test -f "$release_deb"; then
+	fail_test "Release file to test ($release_deb) is not available!"
+fi
+
+failures=""
+
+for release in "${releases[@]}";do
+	echo "Testing: $release"
+	if ! docker run -ti --rm \
+			-v "$PWD/releases/:/releases/" \
+			"$release" /bin/sh -c "$testcmd";
+	then
+		failures="$failures $release"
+	fi
+done
+
+if [[ -n "${failures}" ]]; then
+	echo 'FAIL'
+	echo 'The following tests failed:'
+	echo "${failures}"
+	exit 1
+fi
+echo 'PASS'


### PR DESCRIPTION
These are the current LTS releases of Debian/Ubunutu (https://wiki.debian.org/LTS/, https://wiki.ubuntu.com/Releases): Debian 8, Debian 9, Ubuntu 16.04, Ubuntu 18.04.

I think it would be nice if mgmt would support these with the official builds. The current build in Github releases does not work on any of these OS releases because it is linked against libraries not available on these systems [0].

This PR adds a test script to verify if a `.deb` release build under `releases/` will install and run on these supported LTS releases.

You can run tests using: 

     git tag -f 0.0.0; make releases/0.0.0/deb/mgmt_0.0.0_amd64.deb; test/test-deb-releases.sh 

There is also a change to the build scripting included which allows to build the `.deb` release in a Debian 8 system which ensures it will install and run in all OS releases mentioned above. 

A branch with only the test scripting is available at: https://github.com/aequitas/mgmt/tree/deb-test

[0]
```
$ wget https://github.com/purpleidea/mgmt/releases/download/0.0.19/mgmt_0.0.19_amd64.deb
$ mv mgmt_0.0.19_amd64.deb releases/0.0.19/deb/ 
$ test/test-deb-releases.sh
Testing: ubuntu:19.04
+ apt-get update
+ dpkg -i /releases/0.0.19/deb/mgmt_0.0.19_amd64.deb
Selecting previously unselected package mgmt.
(Reading database ... 4058 files and directories currently installed.)
Preparing to unpack .../deb/mgmt_0.0.19_amd64.deb ...
Unpacking mgmt (0.0.19) ...
+ apt-get install -yqqf
debconf: delaying package configuration, since apt-utils is not installed
+ mgmt --version
mgmt version 0.0.19
Testing: ubuntu:18.04
+ apt-get update
+ dpkg -i /releases/0.0.19/deb/mgmt_0.0.19_amd64.deb
Selecting previously unselected package mgmt.
(Reading database ... 4038 files and directories currently installed.)
Preparing to unpack .../deb/mgmt_0.0.19_amd64.deb ...
Unpacking mgmt (0.0.19) ...
+ apt-get install -yqqf
debconf: delaying package configuration, since apt-utils is not installed
+ mgmt --version
mgmt: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_4.1.0' not found (required by mgmt)
Testing: debian:9
+ apt-get update
+ dpkg -i /releases/0.0.19/deb/mgmt_0.0.19_amd64.deb
Selecting previously unselected package mgmt.
(Reading database ... 6498 files and directories currently installed.)
Preparing to unpack .../deb/mgmt_0.0.19_amd64.deb ...
Unpacking mgmt (0.0.19) ...
+ apt-get install -yqqf
debconf: delaying package configuration, since apt-utils is not installed
+ mgmt --version
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_4.1.0' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_3.9.0' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_3.7.0' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_3.1.0' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_3.4.0' not found (required by mgmt)
Testing: ubuntu:16.04
+ apt-get update
+ dpkg -i /releases/0.0.19/deb/mgmt_0.0.19_amd64.deb
Selecting previously unselected package mgmt.
(Reading database ... 4768 files and directories currently installed.)
Preparing to unpack .../deb/mgmt_0.0.19_amd64.deb ...
Unpacking mgmt (0.0.19) ...
+ apt-get install -yqqf
debconf: delaying package configuration, since apt-utils is not installed
+ mgmt --version
mgmt: /usr/lib/x86_64-linux-gnu/libvirt-lxc.so.0: version `LIBVIRT_LXC_2.0.0' not found (required by mgmt)
mgmt: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_2.2.0' not found (required by mgmt)
mgmt: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_4.1.0' not found (required by mgmt)
mgmt: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_3.9.0' not found (required by mgmt)
mgmt: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_3.7.0' not found (required by mgmt)
mgmt: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_3.1.0' not found (required by mgmt)
mgmt: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_3.0.0' not found (required by mgmt)
mgmt: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_3.4.0' not found (required by mgmt)
mgmt: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_1.3.3' not found (required by mgmt)
mgmt: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_2.0.0' not found (required by mgmt)
Testing: debian:8
+ apt-get update
+ dpkg -i /releases/0.0.19/deb/mgmt_0.0.19_amd64.deb
Selecting previously unselected package mgmt.
(Reading database ... 7627 files and directories currently installed.)
Preparing to unpack .../deb/mgmt_0.0.19_amd64.deb ...
Unpacking mgmt (0.0.19) ...
+ apt-get install -yqqf
debconf: delaying package configuration, since apt-utils is not installed
+ mgmt --version
mgmt: /usr/lib/libvirt-lxc.so.0: version `LIBVIRT_LXC_2.0.0' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_2.2.0' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_1.2.11' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_1.2.12' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_4.1.0' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_3.9.0' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_1.2.16' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_3.7.0' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_3.1.0' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_1.2.15' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_1.2.19' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_1.2.14' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_3.0.0' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_3.4.0' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_1.3.3' not found (required by mgmt)
mgmt: /usr/lib/libvirt.so.0: version `LIBVIRT_2.0.0' not found (required by mgmt)
FAIL
The following tests failed:
 ubuntu:18.04 debian:9 ubuntu:16.04 debian:8
```