### PR TITLE
make deps: Add golang version test to fix Ubuntu bug

### DIFF
--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -75,7 +75,7 @@ fi
 
 if [ $travis -eq 0 ]; then
 	if [ ! -z "$YUM" ]; then
-		if [ -z "$GO" ]; then
+		if [ -z "$GO" ] && [ go version | grep -e 'go1\.[0123456789]\.' -e 'go1\.10\.' ]; then
 			$sudo_command $YUM install -y golang golang-googlecode-tools-stringer
 		fi
 		# some go dependencies are stored in mercurial
@@ -83,7 +83,7 @@ if [ $travis -eq 0 ]; then
 	fi
 	if [ ! -z "$APT" ]; then
 		$sudo_command $APT update
-		if [ -z "$GO" ]; then
+		if [ -z "$GO" ] && [ go version | grep -e 'go1\.[0123456789]\.' -e 'go1\.10\.' ]; then
 			$sudo_command $APT install -y golang
 			# one of these two golang tools packages should work on debian
 			$sudo_command $APT install -y golang-golang-x-tools || true


### PR DESCRIPTION
Running make-deps for the first time on Ubuntu can erroneously lead to
installing outdated version of golang, even if a newer version is already
installed. A version check is now added to the relevant conditions.

## Tips:

* please read the style guide before submitting your patch:
[docs/style-guide.md](../docs/style-guide.md)

* commit message titles must be in the form:

```topic: Capitalized message with no trailing period```

or:

```topic, topic2: Capitalized message with no trailing period```

* golang code must be formatted according to the standard, please run:

```
make gofmt		# formats the entire project correctly
```

or format a single golang file correctly:

```
gofmt -w yourcode.go
```

* please rebase your patch against current git master:

```
git checkout master
git pull origin master
git checkout your-feature
git rebase master
git push your-remote your-feature
hub pull-request	# or submit with the github web ui
```

* after a patch review, please ping @purpleidea so we know to re-review:

```
# make changes based on reviews...
git add -p		# add new changes
git commit --amend	# combine with existing commit
git push your-remote your-feature -f
# now ping @purpleidea in the github PR since it doesn't notify us automatically
```

## Thanks for contributing to mgmt and welcome to the team!
