### PR TITLE
lang: func: funcgen: Suppress informational messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -508,6 +508,6 @@ funcgen: lang/funcs/core/generated_funcs.go
 
 lang/funcs/core/generated_funcs.go: lang/funcs/funcgen/*.go lang/funcs/core/funcgen.yaml lang/funcs/funcgen/templates/generated_funcs.go.tpl
 	@echo "Generating: funcs..."
-	@go run `find lang/funcs/funcgen/ -maxdepth 1 -type f -name '*.go' -not -name '*_test.go'` -templates=lang/funcs/funcgen/templates/generated_funcs.go.tpl 2>/dev/null
+	@go run `find lang/funcs/funcgen/ -maxdepth 1 -type f -name '*.go' -not -name '*_test.go'` -templates=lang/funcs/funcgen/templates/generated_funcs.go.tpl >/dev/null
 
 # vim: ts=8

--- a/lang/funcs/funcgen/main.go
+++ b/lang/funcs/funcgen/main.go
@@ -20,6 +20,7 @@ package main
 import (
 	"flag"
 	"log"
+	"os"
 )
 
 var (
@@ -34,7 +35,10 @@ func main() {
 		log.Fatalf("No package passed!")
 	}
 
+	log.SetOutput(os.Stdout)
 	err := parsePkg(*pkg, *filename, *templates)
+	log.SetOutput(os.Stderr)
+
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Build failures from unclean build environments can happen at any time,
and if stderr is not presented to the user, it is unnecessarily hard to
find the cause.

Fixes #568