### PR TITLE
[WIP] OpenBSD port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ REMOTE_PATH = 'pub/alt/$(USERNAME)/$(PROGRAM)'
 ifneq ($(GOTAGS),)
 	BUILD_FLAGS = -tags '$(GOTAGS)'
 endif
-GOOSARCHES ?= linux/amd64 linux/ppc64 linux/ppc64le linux/arm64 darwin/amd64
+GOOSARCHES ?= linux/amd64 linux/ppc64 linux/ppc64le linux/arm64 darwin/amd64 openbsd/amd64
 
 GOHOSTOS = $(shell go env GOHOSTOS)
 GOHOSTARCH = $(shell go env GOHOSTARCH)

--- a/misc/header.sh
+++ b/misc/header.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/local/bin/bash
 
 if [ "$1" = "" ] || [ "$1" = "--help" ]; then
 	echo "usage: append standard header to file"


### PR DESCRIPTION
This is a very basic, non functioning port to OpenBSD 6.6-current, related to issue #567 

Before trying to build, you will need to install the following dependencies

	pkg_add go
	pkg_add augeas
	pkg_add ruby

I am unsure of the importance of the ruby dependency, but follow
their respective pkg_readmes to set them up.

The following list of go packages should all be installed, but I'm
not yet sure if some of these are optional.

	go get $pkg

github.com/aws/aws-sdk-go/aws
github.com/aws/aws-sdk-go/aws/awserr
github.com/aws/aws-sdk-go/aws/request
github.com/aws/aws-sdk-go/aws/session
github.com/aws/aws-sdk-go/service/cloudwatchevents
github.com/aws/aws-sdk-go/service/ec2
github.com/aws/aws-sdk-go/service/sns
github.com/coreos/bbolt
github.com/coreos/go-semver/semver
github.com/coreos/go-systemd/dbus
github.com/coreos/go-systemd/journal
github.com/coreos/go-systemd/machine1
github.com/coreos/go-systemd/unit
github.com/coreos/go-systemd/util
github.com/coreos/pkg/capnslog
github.com/deniswernert/go-fstab
github.com/dgrijalva/jwt-go
github.com/ghodss/yaml
github.com/godbus/dbus
github.com/gogo/protobuf/gogoproto
github.com/gogo/protobuf/proto
github.com/golang/protobuf/jsonpb
github.com/golang/protobuf/proto
github.com/golang/protobuf/ptypes
github.com/google/btree
github.com/hashicorp/consul/api
github.com/hashicorp/go-multierror
github.com/hashicorp/hil
github.com/hashicorp/hil/ast
github.com/iancoleman/strcase
github.com/jonboulle/clockwork
github.com/pborman/uuid
github.com/pkg/errors
github.com/prometheus/client_golang/prometheus
github.com/prometheus/client_golang/prometheus/promhttp
github.com/soheilhy/cmux
github.com/spf13/afero
github.com/tmc/grpc-websocket-proxy/wsproxy
github.com/urfave/cli
github.com/vishvananda/netlink
github.com/xiang90/probing
go.uber.org/zap
golang.org/x/crypto/bcrypt
golang.org/x/crypto/openpgp
golang.org/x/crypto/openpgp/packet
golang.org/x/net/context
golang.org/x/net/http2
golang.org/x/net/http2/hpack
golang.org/x/net/trace
golang.org/x/sys/unix
golang.org/x/time/rate
google.golang.org/genproto/googleapis/rpc/status
gopkg.in/src-d/go-git.v4
gopkg.in/yaml.v2

Afterwards, you can try a build with

	GOTAGS='novirt nodocker' gmake build

Fair warning though, this does not work yet.

The dependency stuff could be moved over to the make deps
step, but I'm unsure this works well with OpenBSD porting guidelines
and I might need to make separate ports for every dependency. I
will have to look at other ports of go projects. Finally, it's probably
not a good idea to hardcode the path for bash in misc/header.sh,
but I'll cross that bridge later.

## Tips:

* please read the style guide before submitting your patch:
[docs/style-guide.md](../docs/style-guide.md)

* commit message titles must be in the form:

```topic: Capitalized message with no trailing period```

or:

```topic, topic2: Capitalized message with no trailing period```

* golang code must be formatted according to the standard, please run:

```
make gofmt		# formats the entire project correctly
```

or format a single golang file correctly:

```
gofmt -w yourcode.go
```

* please rebase your patch against current git master:

```
git checkout master
git pull origin master
git checkout your-feature
git rebase master
git push your-remote your-feature
hub pull-request	# or submit with the github web ui
```

* after a patch review, please ping @purpleidea so we know to re-review:

```
# make changes based on reviews...
git add -p		# add new changes
git commit --amend	# combine with existing commit
git push your-remote your-feature -f
# now ping @purpleidea in the github PR since it doesn't notify us automatically
```

## Thanks for contributing to mgmt and welcome to the team!
