### PR TITLE
added unit test in pgraph_test.go for GetName function

### DIFF
--- a/pgraph/pgraph_test.go
+++ b/pgraph/pgraph_test.go
@@ -934,3 +934,11 @@ func TestSetValue(t *testing.T) {
 		t.Errorf("expecting value of %s at %s position, got %v", value, key, v)
 	}
 }
+
+func TestGetName(t *testing.T) {
+	G, _ := NewGraph("g9")
+	graph := G.GetName()
+	if graph == nil {
+		t.Errorf("Empty graph returned, expecting graph: %v", graph)
+		}
+}


### PR DESCRIPTION
##Notes:

* Included unit test for pgraph_test.go for GetName function of pgraph

``func TestGetName(t *testing.T) {
	G, _ := NewGraph("g9")
	graph := G.GetName()
	if graph == "" {
		t.Errorf("Empty graph returned, expecting graph: %v", graph)
		}
}``