### PR TITLE
engine: resources: Add a test case for resource owner check

### DIFF
--- a/engine/resources/resources_test.go
+++ b/engine/resources/resources_test.go
@@ -174,7 +174,7 @@ func FileExpect(p, s string) Step { // path & string
 	}
 }
 
-// FileExpect takes a path and a string to write to that file, and builds a Step
+// FileWrite takes a path and a string to write to that file, and builds a Step
 // that does that to them.
 func FileWrite(p, s string) Step { // path & string
 	return &manualStep{


### PR DESCRIPTION
This adds FileOwnerExpect as a new Step which allows validating if the owner was set properly on a resource.