### PR TITLE
lang: Fix wrong go-fuzz bin name

### DIFF
--- a/lang/fuzz/Makefile
+++ b/lang/fuzz/Makefile
@@ -24,4 +24,4 @@ fuzz:
 	mkdir -p corpus/
 	find ../.. -name \*.mcl -exec cp {} corpus/ \;
 	go-fuzz-build
-	go-fuzz -bin=./lang-fuzz.zip -workdir=.
+	go-fuzz -bin=./fuzz-fuzz.zip -workdir=.


### PR DESCRIPTION
I missed renaming this after moving the fuzz.go from the lang package
to its own fuzz package.