### PR TITLE
lang: Prevent struct types with duplicate field names

### DIFF
--- a/lang/interpret_test/TestAstFunc2/struct-duplicate4.output
+++ b/lang/interpret_test/TestAstFunc2/struct-duplicate4.output
@@ -1,0 +1,1 @@
+# err: err1: parser: `syntax error: unexpected $end, expecting EQUALS` @1:6

--- a/lang/interpret_test/TestAstFunc2/struct-duplicate4/main.mcl
+++ b/lang/interpret_test/TestAstFunc2/struct-duplicate4/main.mcl
@@ -1,0 +1,1 @@
+$d []struct{x int;x float}

--- a/lang/parser.y
+++ b/lang/parser.y
@@ -1180,14 +1180,14 @@ type:
 		strs := []string{}
 		for _, arg := range $3.args {
 			s := fmt.Sprintf("%s %s", arg.Name, arg.Type.String())
-			if _, exists := names[s]; exists {
+			if _, exists := names[arg.Name]; exists {
 				// duplicate field name used
 				err := fmt.Errorf("duplicate struct field of `%s`", s)
 				// this will ultimately cause a parser error to occur...
 				yylex.Error(fmt.Sprintf("%s: %+v", ErrParseSetType, err))
 				break // we must skip, because code continues!
 			}
-			names[s] = struct{}{}
+			names[arg.Name] = struct{}{}
 			strs = append(strs, s)
 		}
 


### PR DESCRIPTION
The previous fix for #591 in 70eecd5 didn't address all issues
concerning duplicate struct field names. It still crashed for inputs
like `$d []struct{x int; x float}`. Note the different types but
duplicate names.