### PR TITLE
Update minimum go version to 1.13

### DIFF
--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -37,7 +37,7 @@ You'll need some dependencies, including `golang`, and some associated tools.
 
 #### Installing golang
 
-* You need golang version 1.11 or greater installed.
+* You need golang version 1.13 or greater installed.
 	* To install on rpm style systems: `sudo dnf install golang`
 	* To install on apt style systems: `sudo apt install golang`
 	* To install on macOS systems install [Homebrew](https://brew.sh)

--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -19,6 +19,14 @@ NEWAPT=`command -v apt 2>/dev/null`
 BREW=`command -v brew 2>/dev/null`
 PACMAN=`command -v pacman 2>/dev/null`
 
+# set minimum go version and installed go version
+mingoversion=13
+goversion=0
+if [ -x "$GO" ]; then
+	# capture the minor version number
+	goversion=$(go version | grep -o -P '(?<=go1\.)[0-9]*')
+fi
+
 # if DNF is available use it
 if [ -x "$DNF" ]; then
 	YUM=$DNF
@@ -97,7 +105,7 @@ if [ $travis -eq 0 ]; then
 fi
 
 # attempt to workaround old ubuntu
-if [ ! -z "$APT" ] && go version | grep -e 'go1\.[0123456789]\.' -e 'go1\.10\.'; then
+if [ ! -z "$APT" ] && [ "$goversion" -lt "$mingoversion" ]; then
 	echo "install golang from a ppa."
 	$sudo_command $APT remove -y golang
 	$sudo_command $APT install -y software-properties-common	# for add-apt-repository
@@ -107,8 +115,8 @@ if [ ! -z "$APT" ] && go version | grep -e 'go1\.[0123456789]\.' -e 'go1\.10\.';
 fi
 
 # if golang is too old, we don't want to fail with an obscure error later
-if go version | grep -e 'go1\.[0123456789]\.' -e 'go1\.10\.'; then
-	echo "mgmt recommends go1.11 or higher."
+if [ "$goversion" -lt "$mingoversion" ]; then
+	echo "mgmt recommends go1.$mingoversion or higher."
 	exit 1
 fi
 


### PR DESCRIPTION
I was running through the Quick Start and ran into a problem when trying to build from source using `go1.12`. One of the dependencies `github.com/hashicorp/go-multierror` is using `go1.13` new `errors` package methods `errors.Is` and `errors.As`

This PR addresses this by updating minimum required go version in the Quick Start Guide to `go1.13`. 

I have also upated the `make-deps.sh` script to check if the installed version of go is below the minimum required version. This check only applies to the minor version and ignores the major and patch versions.

The regex associated with capturing the installed version of go has also been updated to capture only the minor version `go1.14.2 -> 14` and will also capture the minor version even when the patch version is not output `go1.8 -> 8`
