### PR TITLE
lang: funcs: Add macfmt function

### DIFF
--- a/lang/funcs/core/net/macfmt_func.go
+++ b/lang/funcs/core/net/macfmt_func.go
@@ -15,21 +15,39 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package core
+package corenet
 
 import (
-	// import so the funcs register
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/convert"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/datetime"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/deploy"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/example"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/example/nested"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/fmt"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/math"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/net"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/os"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/regexp"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/strings"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/sys"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/world"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/purpleidea/mgmt/lang/funcs/simple"
+	"github.com/purpleidea/mgmt/lang/types"
 )
+
+func init() {
+	simple.ModuleRegister(ModuleName, "macfmt", &types.FuncValue{
+		T: types.NewType("func(a str) str"),
+		V: MacFmt,
+	})
+}
+
+// MacFmt takes a MAC address with hyphens and converts it to a format with
+// colons.
+func MacFmt(input []types.Value) (types.Value, error) {
+	mac := input[0].Str()
+
+	// Check if the MAC address is valid.
+	if len(mac) != len("00:00:00:00:00:00") {
+		return nil, fmt.Errorf("invalid MAC address length: %s", mac)
+	}
+	_, err := net.ParseMAC(mac)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.StrValue{
+		V: strings.Replace(mac, "-", ":", -1),
+	}, nil
+}

--- a/lang/funcs/core/net/macfmt_func_test.go
+++ b/lang/funcs/core/net/macfmt_func_test.go
@@ -1,0 +1,54 @@
+// Mgmt
+// Copyright (C) 2013-2020+ James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package corenet
+
+import (
+	"testing"
+
+	"github.com/purpleidea/mgmt/lang/types"
+)
+
+func TestMacFmt(t *testing.T) {
+	var tests = []struct {
+		name    string
+		in      string
+		out     string
+		wantErr bool
+	}{
+		{"Valid mac with hyphens", "01-23-45-67-89-AB", "01:23:45:67:89:AB", false},
+		{"Valid mac with colons", "01:23:45:67:89:AB", "01:23:45:67:89:AB", false},
+		{"Incorrect mac length with colons", "01:23:45:67:89:AB:01:23:45:67:89:AB", "01:23:45:67:89:AB:01:23:45:67:89:AB", true},
+		{"Invalid mac", "", "", true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := MacFmt([]types.Value{&types.StrValue{V: tt.in}})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("func MacFmt() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if m != nil {
+				if err := m.Cmp(&types.StrValue{V: tt.out}); err != nil {
+					t.Errorf("got %q, want %q", m.Value(), tt.out)
+				}
+			}
+		})
+	}
+}

--- a/lang/funcs/core/net/net.go
+++ b/lang/funcs/core/net/net.go
@@ -15,21 +15,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package core
+package corenet
 
-import (
-	// import so the funcs register
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/convert"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/datetime"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/deploy"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/example"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/example/nested"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/fmt"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/math"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/net"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/os"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/regexp"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/strings"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/sys"
-	_ "github.com/purpleidea/mgmt/lang/funcs/core/world"
+const (
+	// ModuleName is the prefix given to all the functions in this module.
+	ModuleName = "net"
 )


### PR DESCRIPTION
* Add new `net` package that implements `mcl` function related to networking.
* Add `mcl` function that takes a mac address with hyphens as an argument and converts it to a format with colons.