### PR TITLE
misc: Incorrect dependency path for dvyukov/go-fuzz

### DIFF
--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -128,7 +128,7 @@ go get golang.org/x/tools/cmd/stringer			# for automatic stringer-ing
 go get golang.org/x/lint/golint				# for `golint`-ing
 go get golang.org/x/tools/cmd/goimports		# for fmt
 go get github.com/tmthrgd/go-bindata/go-bindata	# for compiling in non golang files
-go get golang.org/dvyukov/go-fuzz		# for fuzzing the mcl lang bits
+go get github.com/dvyukov/go-fuzz		# for fuzzing the mcl lang bits
 if env | grep -q -e '^TRAVIS=true$' -e '^JENKINS_URL=' -e '^BUILD_TAG=jenkins'; then
 	go get -u gopkg.in/alecthomas/gometalinter.v1 && mv "$(dirname $(command -v gometalinter.v1))/gometalinter.v1" "$(dirname $(command -v gometalinter.v1))/gometalinter" && gometalinter --install	# bonus
 fi


### PR DESCRIPTION
Fix the dependency path for dvyukov/go-fuzz to github.com from golang.org.

Fixes #601

## Tips:

* please read the style guide before submitting your patch:
[docs/style-guide.md](../docs/style-guide.md)

* commit message titles must be in the form:

```topic: Capitalized message with no trailing period```

or:

```topic, topic2: Capitalized message with no trailing period```

* golang code must be formatted according to the standard, please run:

```
make gofmt		# formats the entire project correctly
```

or format a single golang file correctly:

```
gofmt -w yourcode.go
```

* please rebase your patch against current git master:

```
git checkout master
git pull origin master
git checkout your-feature
git rebase master
git push your-remote your-feature
hub pull-request	# or submit with the github web ui
```

* after a patch review, please ping @purpleidea so we know to re-review:

```
# make changes based on reviews...
git add -p		# add new changes
git commit --amend	# combine with existing commit
git push your-remote your-feature -f
# now ping @purpleidea in the github PR since it doesn't notify us automatically
```

## Thanks for contributing to mgmt and welcome to the team!
