### PR TITLE
Assert that 'metadata.yaml' is not parsed as raw mcl

### DIFF
--- a/lang/inputs.go
+++ b/lang/inputs.go
@@ -318,6 +318,12 @@ func inputCode(s string, fs engine.Fs) (*ParsedInput, error) {
 		}
 	}
 
+	// check if code is `metadata.yaml`, which is obviously not correct here
+	if s == interfaces.MetadataFilename {
+		return nil, fmt.Errorf("unexpected raw code '%s'. Did you mean './%s'?",
+			interfaces.MetadataFilename, interfaces.MetadataFilename)
+	}
+
 	wd, err := os.Getwd() // NOTE: not meaningful for stdin unless fs is an OsFs
 	if err != nil {
 		return nil, errwrap.Wrapf(err, "can't get working dir")


### PR DESCRIPTION
Contradictory to expectations, `mgmt run lang metadata.yaml` would
produce an error similar to the following, which is likely unexpected
from the user perspective:

    2020-11-24 12:24:08.330968 I | cli: lang: lexing/parsing...
    2020-11-24 12:24:08.331153 I | run: error: cli parse error: could not generate AST: parser: `syntax error: unexpected DOT` @1:1

Produce a user-friendly warning instead, hinting with the supported
usage:

    2020-11-24 13:15:01.686659 I | run: error: cli parse error: could not activate an input parser: unexpected raw code 'metadata.yaml'. Did you mean './metadata.yaml'?

Signed-off-by: Joe Groocock <me@frebib.net>