### PR TITLE
Make-deps checks if go vet cmd is present

### DIFF
--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -125,11 +125,6 @@ go get -v -t -d ./...	# get all the go dependencies
 echo "done running 'go get -v -t -d ./...'"
 
 [ -e "$GOBIN/mgmt" ] && rm -f "$GOBIN/mgmt"	# the `go get` version has no -X
-# vet is built-in in go 1.6 - we check for go vet command
-go vet 1> /dev/null 2>&1
-if [[ $? != 0 ]]; then
-	go get golang.org/x/tools/cmd/vet      # add in `go vet` for travis
-fi
 go get github.com/blynn/nex				# for lexing
 go get golang.org/x/tools/cmd/goyacc			# formerly `go tool yacc`
 go get golang.org/x/tools/cmd/stringer			# for automatic stringer-ing


### PR DESCRIPTION
While the code comment says to check if go vet command is present,
it actually tests if go vet command returns properly.

This is a problem, as if go vet is _not_ returning 0 due to a
failure, but go vet is present, it will still try to install the
legacy go vet.

This fixes it by using the help command instead, which should
return an error if the subcommand doesn't exist.
