### PR TITLE
test: Fix implicit test fail in test-markdownlint

### DIFF
--- a/test/test-markdownlint.sh
+++ b/test/test-markdownlint.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 # check for any markdown files that aren't in an ideal format
 
-echo running "$0 $@"
+echo running "$0 $*"
 set -o errexit
 set -o nounset
 set -o pipefail
 
 #ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"	# dir!
-ROOT=$(dirname "${BASH_SOURCE}")/..
-cd "${ROOT}"
+ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${ROOT}" || exit 1
 . test/util.sh
 
-MDL=`command -v mdl 2>/dev/null`
-if [ -z $MDL ]; then
+MDL=$(command -v mdl 2>/dev/null) || true
+if [ -z "$MDL" ]; then
 	fail_test "The 'mdl' utility can't be found."
 fi
 
 STYLE=$($mktemp)
 # styles that we ignore... if they're too onerous, we can exclude them here...
-cat << 'EOF' > $STYLE
+cat << 'EOF' > "$STYLE"
 all
 exclude_rule 'MD010'	# Hard tabs
 exclude_rule 'MD032'	# Lists should be surrounded by blank lines
@@ -60,7 +60,7 @@ bad_files=$(
 		fi
 
 		# check the markdown format with the linter
-		if ! $MDL --style "$STYLE" "$i" 1>&2; then
+		if ! "$MDL" --style "$STYLE" "$i" 1>&2; then
 			echo "$i"
 		fi
 	done


### PR DESCRIPTION
Fix the silent test failure by catching the uncaught error from
`command`, handling the failure gracefully.

    $ bash -x test/test-markdownlint.sh
    ...
    ++ command -v mdl
    + MDL=
    $ echo $?
    1

    $ bash -x test/test-markdownlint.sh
    ...
    ++ command -v mdl
    + MDL=
    + true
    + '[' -z '' ']'
    + fail_test 'The '\''mdl'\'' utility can'\''t be found.'
    + echo -e 'FAIL: The '\''mdl'\'' utility can'\''t be found.'
    FAIL: The 'mdl' utility can't be found.

Fix a couple of glaring shellcheck warnings and errors mostly
surrounding variable quoting.

Signed-off-by: Joe Groocock <me@frebib.net>
