### PR TITLE
misc: Add github CONTRIBUTING support

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -1,0 +1,1 @@
+Please see .github/PULL_REQUEST_TEMPLATE.md


### PR DESCRIPTION
Without this patch, there is no CONTRIBUTING.{md,txt,rst}
file.

This is a problem as it might not be obvious, for a first time
contributor, to check in .github/ for the PR template to know
how to contribute.

This fixes it by creating a CONTRIBUTING.txt file, which simply
points to the necessary existing documentation.
