### PR TITLE
Ensure make test shell block can pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tmp/
 *WIP
 *_stringer.go
 bindata/*.go
+!bindata/doc.go
 mgmt
 mgmt.static
 # crossbuild artifacts

--- a/bindata/doc.go
+++ b/bindata/doc.go
@@ -1,0 +1,19 @@
+// Mgmt
+// Copyright (C) 2013-2019+ James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// This is to ensure there is go code at all times
+package bindata


### PR DESCRIPTION
Without this patch, TEST_BLOCK="shell" make test will fail in
CI, with  "no Go files in
go/src/github.com/purpleidea/mgmt/bindata".

This is a problem, as it will prevent us to move to github actions.

This should fix it, by creating an empty golang file.
