### PR TITLE
lang: Add struct field matching test case for #624

### DIFF
--- a/engine/resources/test.go
+++ b/engine/resources/test.go
@@ -82,6 +82,13 @@ type TestRes struct {
 	} `lang:"mixedstruct" yaml:"mixedstruct"`
 	Interface interface{} `lang:"interface" yaml:"interface"`
 
+	// See TestAstFunc2/struct-filename0
+	// https://github.com/purpleidea/mgmt/issues/624
+	NamedStruct struct {
+		// Go field name explicitly differs from lang/mcl tag
+		Named string `lang:"named" yaml:"named"`
+	} `lang:"namedstruct" yaml:"namedstruct"`
+
 	AnotherStr string `lang:"anotherstr" yaml:"anotherstr"`
 
 	ValidateBool  bool   `lang:"validatebool" yaml:"validate_bool"`   // set to true to cause a validate error

--- a/lang/interpret_test/TestAstFunc2/struct-fieldname0.output
+++ b/lang/interpret_test/TestAstFunc2/struct-fieldname0.output
@@ -1,0 +1,1 @@
+# err: err3: can't unify, invariant illogicality with equals: struct fields differ

--- a/lang/interpret_test/TestAstFunc2/struct-fieldname0/main.mcl
+++ b/lang/interpret_test/TestAstFunc2/struct-fieldname0/main.mcl
@@ -1,0 +1,5 @@
+test "test" {
+    namedstruct => struct {
+        named => "this is a value",
+    },
+}


### PR DESCRIPTION
Struct field matching between lowercase/uppercase names even with
`lang:"name"` tags highlighting the issue in #624, with the hope that it
is fixed so the test case can be updated.

Signed-off-by: Joe Groocock <me@frebib.net>