### PR TITLE
lang: Implement Value.Into() to reflect.Value representations

### DIFF
--- a/engine/util/util.go
+++ b/engine/util/util.go
@@ -37,8 +37,6 @@ import (
 )
 
 const (
-	// StructTag is the key we use in struct field names for key mapping.
-	StructTag = "lang"
 	// DBusInterface is the dbus interface that contains genereal methods.
 	DBusInterface = "org.freedesktop.DBus"
 	// DBusAddMatch is the dbus method to receive a subset of dbus broadcast
@@ -133,7 +131,7 @@ func StructTagToFieldName(stptr interface{}) (map[string]string, error) {
 		field := st.Field(i)
 		name := field.Name
 		// if !ok, then nothing is found
-		if alias, ok := field.Tag.Lookup(StructTag); ok { // golang 1.7+
+		if alias, ok := field.Tag.Lookup(types.StructTag); ok { // golang 1.7+
 			if val, exists := result[alias]; exists {
 				return nil, fmt.Errorf("field `%s` uses the same key `%s` as field `%s`", name, alias, val)
 			}

--- a/examples/lang/virt2.mcl
+++ b/examples/lang/virt2.mcl
@@ -29,26 +29,24 @@ virt "mgmt4" {
 	state => "running",
 	transient => false,
 	boot => ["hd", ],
-	# can't add this part until we fix the unification bug
-	#disk => [
-	#	struct{
-	#		source => "~/.local/share/libvirt/images/fedora-23-scratch.qcow2",
-	#		type => "qcow2",
-	#	},
-	#],
-	# add the rest for unification bug
-	#osinit => "",
-	#cdrom => [
-	#],
-	#network => [
-	#],
-	#filesystem => [
-	#],
-	#auth => struct{
-	#	username => "",
-	#	password => "",
-	#},
-	#hotcpus => true,	# this is the default
-	#restartondiverge => "",
-	#restartonrefresh => false,
+	disk => [
+		struct{
+			source => "~/.local/share/libvirt/images/fedora-23-scratch.qcow2",
+			type => "qcow2",
+		},
+	],
+	osinit => "",
+	cdrom => [
+	],
+	network => [
+	],
+	filesystem => [
+	],
+	auth => struct{
+		username => "",
+		password => "",
+	},
+	hotcpus => true,	# this is the default
+	restartondiverge => "",
+	restartonrefresh => false,
 }

--- a/lang/types/type.go
+++ b/lang/types/type.go
@@ -25,6 +25,11 @@ import (
 	"github.com/purpleidea/mgmt/util/errwrap"
 )
 
+const (
+	// StructTag is the key we use in struct field names for key mapping.
+	StructTag = "lang"
+)
+
 // Basic types defined here as a convenience for use with Type.Cmp(X).
 var (
 	TypeBool    = NewType("bool")

--- a/lang/types/type.go
+++ b/lang/types/type.go
@@ -150,9 +150,16 @@ func TypeOf(t reflect.Type) (*Type, error) {
 				return nil, err
 			}
 			// TODO: should we skip over fields with field.Anonymous ?
-			m[field.Name] = tt
-			ord = append(ord, field.Name) // in order
-			// NOTE: we discard the field.Tag data
+
+			// TODO: make struct field name lookup consistent with a helper function
+			// if struct field has a `lang:""` tag, use that instead of the struct field name
+			fieldName := field.Name
+			if alias, ok := field.Tag.Lookup(StructTag); ok {
+				fieldName = alias
+			}
+
+			m[fieldName] = tt
+			ord = append(ord, fieldName) // in order
 		}
 
 		return &Type{

--- a/lang/types/type_test.go
+++ b/lang/types/type_test.go
@@ -1474,4 +1474,5 @@ func TestComplexCmp0(t *testing.T) {
 
 func TestTypeOf0(t *testing.T) {
 	// TODO: implement testing of the TypeOf function
+	// TODO: implement testing TypeOf for struct field name mappings
 }

--- a/lang/types/util.go
+++ b/lang/types/util.go
@@ -1,0 +1,64 @@
+// Mgmt
+// Copyright (C) 2013-2021+ James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// nextPowerOfTwo gets the lowest number higher than v that is a power of two.
+func nextPowerOfTwo(v uint32) uint32 {
+	v--
+	v |= v >> 1
+	v |= v >> 2
+	v |= v >> 4
+	v |= v >> 8
+	v |= v >> 16
+	v++
+	return v
+}
+
+// TypeStructTagToFieldName returns a mapping from recommended alias to actual
+// field name. It returns an error if it finds a collision. It uses the `lang`
+// tags. It must be passed a reflect.Type representation of a struct or it will
+// error.
+// TODO: This is a copy of engineUtil.StructTagToFieldName taking a reflect.Type
+func TypeStructTagToFieldName(st reflect.Type) (map[string]string, error) {
+	if k := st.Kind(); k != reflect.Struct { // this should be a struct now
+		return nil, fmt.Errorf("input doesn't point to a struct, got: %+v", k)
+	}
+
+	result := make(map[string]string) // `lang` field tag -> field name
+
+	for i := 0; i < st.NumField(); i++ {
+		field := st.Field(i)
+		name := field.Name
+		// if !ok, then nothing is found
+		if alias, ok := field.Tag.Lookup(StructTag); ok { // golang 1.7+
+			if val, exists := result[alias]; exists {
+				return nil, fmt.Errorf("field `%s` uses the same key `%s` as field `%s`", name, alias, val)
+			}
+			// empty string ("") is a valid value
+			if alias != "" {
+				result[alias] = name
+			}
+		}
+	}
+	return result, nil
+}

--- a/lang/types/util_test.go
+++ b/lang/types/util_test.go
@@ -1,0 +1,35 @@
+// Mgmt
+// Copyright (C) 2013-2021+ James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import "testing"
+
+func TestNextPowerOfTwo(t *testing.T) {
+	testCases := map[uint32]uint32{
+		1: 1,
+		2: 2,
+		3: 4,
+		5: 8,
+	}
+
+	for v, exp := range testCases {
+		if pow := nextPowerOfTwo(v); pow != exp {
+			t.Errorf("function NextPowerOfTwo of `%d` did not match expected: `%d`", pow, exp)
+		}
+	}
+}


### PR DESCRIPTION
Into() mutates a given reflect.Value and sets the data represented by
the types.Value into the storage represented by the reflect.Value.

Into() is the opposite to ValueOf() which converts reflect.Value into
types.Value, and in theory they should (almost) bijective with some edge
case exceptions where the conversion is lossy.

Simply, it replaces reflect.Value.Set() in the broad case, giving finer
control of how the reflect.Value is modified and how the data is set.
types.Value.Value() is now also a redundant function that achieves the
same outcome as Into(), but with less type specificity.

---

lang: convert StmtRes to engine.Res with types.Into()

Replace existing field-mapping code with calls to types.Into() to
reflect the mcl data into the Go resource struct with finer granularity
and accuracy, and less reliance on the magic reflect.Set() function.o

One major advantage over reflect.Value.Set() is Into() allows tailoring
the data that is set, specifically when coercing mcl struct values into
Golang struct values, the fields can be appropriately mapped based on
the lang tag on the struct field. With reflect.Value.Set() this was not
at all possible as there was a contradiction of logic given the
following rules:

- mcl struct fields must have lowercase names
- Golang struct fields with lowercase names are unexported
- Golang reflection does not allow modifying unexported fields

Prior to this change, it was impossible to map an mcl inline struct in a
resource to the matched Golang counterpart, even if the lang tag was
present on the struct field. This can be demonstrated with the following
trivial example:

```perl
test "name" {
    key => struct{
        name => "hello",
    },
}
```

and the accompanying Golang resource definition:

```go
type TestRes struct {
    traits.Base
    traits.Edgeable

    Key struct {
        Name string `lang:"name"`
    } `lang:"key"`
}
```

Due to the mismatch in field names in the embedded struct, the type
unifier failed and refused to match mcl 'name' to Go 'Name' due to the
missing mapping logic.

---

lang: map Go struct fields using `lang` struct tag

Converting a reflect.Type of KindStruct did not respect the `lang` tag
on struct fields incidating how fields from mcl structs should be mapped
even though resource field names did. This patch should allow structs
with mapped fields to be respected.

Signed-off-by: Joe Groocock <me@frebib.net>