### PR TITLE
test: Ensure branches are also testable

### DIFF
--- a/test/test-commit-message.sh
+++ b/test/test-commit-message.sh
@@ -123,7 +123,17 @@ then
 	done
 elif [[ -n "$GITHUB_SHA" ]]
 then
-	commits=$(git log --no-merges --format=%H origin/${GITHUB_BASE_REF}..${GITHUB_SHA})
+	# GITHUB_SHA is the HEAD of the branch
+	# GITHUB_REF: The branch or tag ref that triggered the workflow. For example, refs/heads/feature-branch-1. If neither a branch or tag is available for the event type, the variable will not exist.
+	# GITHUB_BASE_REF: Only set for pull request events. The name of the base branch.
+	if [[ -n "${GITHUB_BASE_REF}" ]]; then
+		ref=${GITHUB_BASE_REF}
+		head=${GITHUB_SHA}
+	else
+		ref=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+		head=""
+	fi
+	commits=$(git log --no-merges --format=%H origin/${ref}..${head})
 	[[ -n "$commits" ]]
 
 	for commit in $commits


### PR DESCRIPTION
test-commit-message runs on PR, but also on push in other branches
which aren't PRs. We need to test those too.

This is fixed by ensuring the same kind of behaviour than travis CI:
When a patch is put on a branch, it's using the branchname for
testing [1].

[1]:
https://docs-staging.travis-ci.com/user/environment-variables/#default-environment-variables
