### PR TITLE
test: Add guard when no commit needs testing

### DIFF
--- a/test/test-commit-message.sh
+++ b/test/test-commit-message.sh
@@ -134,12 +134,12 @@ then
 		head=""
 	fi
 	commits=$(git log --no-merges --format=%H origin/${ref}..${head})
-	[[ -n "$commits" ]]
-
-	for commit in $commits
-	do
-		test_commit_message $commit
-		test_commit_message_common_bugs $commit
-	done
+	if [[ -n "$commits" ]]; then
+		for commit in $commits
+		do
+			test_commit_message $commit
+			test_commit_message_common_bugs $commit
+		done
+	fi
 fi
 echo 'PASS'


### PR DESCRIPTION
Without this patch, github actions fail.

It's a temporary workaround until [1] is done.

[1]: https://github.com/purpleidea/mgmt/issues/643
