### PR TITLE
misc: Replace go-bindata with maintained fork

### DIFF
--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -154,7 +154,7 @@ go get golang.org/x/tools/cmd/goyacc			# formerly `go tool yacc`
 go get golang.org/x/tools/cmd/stringer			# for automatic stringer-ing
 go get golang.org/x/lint/golint				# for `golint`-ing
 go get golang.org/x/tools/cmd/goimports		# for fmt
-go get github.com/tmthrgd/go-bindata/go-bindata	# for compiling in non golang files
+go get github.com/kevinburke/go-bindata/go-bindata	# for compiling in non golang files
 go get github.com/dvyukov/go-fuzz/go-fuzz		# for fuzzing the mcl lang bits
 if in_ci; then
 	go get -u gopkg.in/alecthomas/gometalinter.v1 && \


### PR DESCRIPTION
As per [1] go-bindata was removed from GitHub and later replaced by the
community. jteeuwen/go-bindata has since been archived to represent this
state and now most communities use kevinburke/go-bindata instead as it
is more actively maintained.

[1]: https://github.com/jteeuwen/go-bindata/issues/5

Signed-off-by: Joe Groocock <me@frebib.net>