### PR TITLE
engine: resources: docker: Replace deprecated NewClient() with NewClientWithOpts()

### DIFF
--- a/engine/resources/docker_container.go
+++ b/engine/resources/docker_container.go
@@ -148,7 +148,7 @@ func (obj *DockerContainerRes) Init(init *engine.Init) error {
 	defer cancel()
 
 	// Initialize the docker client.
-	obj.client, err = client.NewClient(client.DefaultDockerHost, obj.APIVersion, nil, nil)
+	obj.client, err = client.NewClientWithOpts(client.WithVersion(obj.APIVersion))
 	if err != nil {
 		return errwrap.Wrapf(err, "error creating docker client")
 	}

--- a/engine/resources/docker_image.go
+++ b/engine/resources/docker_image.go
@@ -109,7 +109,7 @@ func (obj *DockerImageRes) Init(init *engine.Init) error {
 	defer cancel()
 
 	// Initialize the docker client.
-	obj.client, err = client.NewClient(client.DefaultDockerHost, obj.APIVersion, nil, nil)
+	obj.client, err = client.NewClientWithOpts(client.WithVersion(obj.APIVersion))
 	if err != nil {
 		return errwrap.Wrapf(err, "error creating docker client")
 	}


### PR DESCRIPTION
docker/client.NewClient() is deprecated in favour of NewClientWithOpts()
which takes a series of client.Opt functions to configure the API
client. As mgmt only passes the API version through, this simplifies the
NewClient() calls.

Signed-off-by: Joe Groocock <me@frebib.net>