### PR TITLE
map/lists in mcl that are empty cause the engine to hang

### DIFF
--- a/lang/funcs/engine.go
+++ b/lang/funcs/engine.go
@@ -498,6 +498,15 @@ func (obj *Engine) Run() error {
 			}
 			// no more output values are coming...
 			obj.Logf("func `%s` stopped", node)
+
+			// nodes that never loaded will cause the engine to hang
+			if !node.loaded {
+				select {
+				case obj.ag <- fmt.Errorf("func `%s` stopped before it was loaded", node):
+				case <-obj.closeChan:
+					return
+				}
+			}
 		}(vertex)
 	}
 

--- a/lang/interpret_test.go
+++ b/lang/interpret_test.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/purpleidea/mgmt/engine"
 	"github.com/purpleidea/mgmt/engine/graph/autoedge"
@@ -1490,9 +1491,15 @@ func TestAstFunc2(t *testing.T) {
 			defer funcs.Close() // cleanup
 
 			// wait for some activity
+			const streamTimeout = time.Second
 			logf("stream...")
 			stream := funcs.Stream()
 			select {
+			case <-time.After(streamTimeout):
+				t.Errorf("test #%d: FAIL", index)
+				t.Errorf("test #%d: Stream() produced no results after %s", index, streamTimeout)
+				return
+
 			case err, ok := <-stream:
 				if !ok {
 					t.Errorf("test #%d: FAIL", index)

--- a/lang/interpret_test/TestAstFunc2/empty-collections.output
+++ b/lang/interpret_test/TestAstFunc2/empty-collections.output
@@ -1,0 +1,1 @@
+Vertex: test[name]

--- a/lang/interpret_test/TestAstFunc2/empty-collections/main.mcl
+++ b/lang/interpret_test/TestAstFunc2/empty-collections/main.mcl
@@ -1,0 +1,6 @@
+# empty lists/maps must return at least one value during Stream()
+
+test "name" {
+	slicestring => [],
+	mapintfloat => {},
+}


### PR DESCRIPTION
* lang: funcs: Add CompositeFunc Stream() test

    A bug in the CompositeFunc.Stream() implementation causes these elements
    to emit no data when they are empty. Empty map and list functions
    terminate before ever emitting any output via the Stream() call, causing
    the engine to hang. These tests ensure that the functions provide some
    output within a more than reasonable amount of time, after which it is
    assumed they will never provide any output and are buggy.

    Signed-off-by: Joe Groocock <me@frebib.net>

* lang: funcs: Funcs that never load are fatal

    If there is a programming error in any func Stream() implementation then
    the node could never output anything, causing the engine to hang
    indefinitely waiting for an initial value that will never come,

    Nodes keep track of whether they are loaded, so testing for this
    occurence is pretty simple. Any nodes that do not return output at least
    once before they close their output channel can be considered a fatal
    error on which the engine will exit.

    Signed-off-by: Joe Groocock <me@frebib.net>