### PR TITLE
Add separator before revisions

### DIFF
--- a/test/test-commit-message.sh
+++ b/test/test-commit-message.sh
@@ -133,7 +133,7 @@ then
 		ref=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
 		head=""
 	fi
-	commits=$(git log --no-merges --format=%H origin/${ref}..${head})
+	commits=$(git log --no-merges --format=%H -- origin/${ref}..${head})
 	if [[ -n "$commits" ]]; then
 		for commit in $commits
 		do


### PR DESCRIPTION
Error message suggests doing so, and with this it seems the tests pass
