### PR TITLE
Use more fields if they are there

### DIFF
--- a/test/test-commit-message.sh
+++ b/test/test-commit-message.sh
@@ -130,7 +130,7 @@ then
 		ref=${GITHUB_BASE_REF}
 		head=${GITHUB_SHA}
 	else
-		ref=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+		ref=$(echo $GITHUB_REF | cut -d/ -f3-)
 		head=""
 	fi
 	commits=$(git log --no-merges --format=%H origin/${ref}..${head})


### PR DESCRIPTION
It would work in case of `refs/heads/master` but in case of `refs/heads/feat/unify-functions` would return just `feat`, which doesn't match what we need. This should fix this.