### PR TITLE
Add systemd service file to release packages

### DIFF
--- a/misc/fpm-pack.sh
+++ b/misc/fpm-pack.sh
@@ -119,5 +119,6 @@ fpm \
 	--package "${DIR}/${VERSION}/${DISTRO}/${OUTPUT}" \
 	${CHANGELOG} \
 	${DEPS} \
-	--prefix "$PREFIX" \
-	"$BINARY"
+	"$BINARY"="$PREFIX/mgmt" \
+	"misc/mgmt.service"="/usr/lib/systemd/system/mgmt.service"
+


### PR DESCRIPTION
According to [1] "/usr/lib/systemd/system/" is where systemd files from installed packages are stored in ArchLinux

Open question:
A] Does this change work for all distributions mgmt packages get build for?
B] Is the systemd unit file path for packages consistent across linux distros?

[1] https://wiki.archlinux.org/title/Systemd#Writing_unit_files