### PR TITLE
Add systemd service file to release packages

### DIFF
--- a/misc/fpm-pack.sh
+++ b/misc/fpm-pack.sh
@@ -119,5 +119,5 @@ fpm \
 	--package "${DIR}/${VERSION}/${DISTRO}/${OUTPUT}" \
 	${CHANGELOG} \
 	${DEPS} \
-	--prefix "$PREFIX" \
-	"$BINARY"
+	"misc/mgmt.service"="/usr/lib/systemd/system/mgmt.service" \
+	"$BINARY"="$PREFIX/mgmt"


### PR DESCRIPTION
According to [1] "/usr/lib/systemd/system/" is where systemd files from installed packages are stored in Arch Linux


According to FPM docs, the '--prefix' flag configures the "path to prefix files with when building the target package" [2].

With this change the contains more than a single binary, replacing the prefix flag with an absolute path constructed from the same shell variable should be safe and reduce the risk of the prefix flag interferring with other files added to the package.


Open question:
A] Does this change work for all distributions mgmt packages get build for?
B] Is the systemd unit file path for packages consistent across linux distros?


[1] https://wiki.archlinux.org/title/Systemd#Writing_unit_files
[2] https://fpm.readthedocs.io/en/latest/cli-reference.html