### PR TITLE
lang: Improve cli input handling for files/directories and `metadata.yaml`

### DIFF
--- a/lang/inputs/inputs.go
+++ b/lang/inputs/inputs.go
@@ -160,7 +160,8 @@ func inputStdin(s string, fs engine.Fs) (*ParsedInput, error) {
 // inputMetadata checks to see if we have a metadata file path.
 func inputMetadata(s string, fs engine.Fs) (*ParsedInput, error) {
 	// we've got a metadata.yaml file
-	if !strings.HasSuffix(s, "/"+interfaces.MetadataFilename) {
+	if !(s == interfaces.MetadataFilename ||
+		strings.HasSuffix(s, "/"+interfaces.MetadataFilename)) {
 		return nil, nil // not us, but no error
 	}
 	var err error


### PR DESCRIPTION
- lang: correctly handle stat(2) errors on directories/files

    Differentiate between ENOENT and other errors returned by stat(2) to
    prevent confusing parse errors when the path provided is a directory
    path. ENOENT is silently ignored as file or directory absence can be
    expected depending on the specified input from the user.

    Handle directory paths without trailing slashes from the user input on
    the command line, correctly disambiguating directories from files with
    the stat(2) result.

    This fixes the rather confusing situation where mgmt would report a
    parse error on the input string of the directory name as if it didn't
    exist, but instead stat(2) just returned another error such as EACCES or
    otherwise. Now correctly report errors that aren't ENOENT.

    Before:

        $ mgmt run lang files
        2020-11-24 20:48:33.350321 I | cli: lang: input from code source: files
        2020-11-24 20:48:33.350389 I | cli: lang: lexing/parsing...
        2020-11-24 20:48:33.350528 I | run: error: cli parse error: could not generate AST: parser: `syntax error: unexpected $end` @1:1

    After:

        $ mgmt run lang files
        2020-11-24 20:53:35.500436 I | run: error: cli parse error: could not activate an input parser: stat /home/frebib/mgmt/files/metadata.yaml: permission denied

    Signed-off-by: Joe Groocock <me@frebib.net>

- lang: allow 'mgmt lang run metadata.yaml'

    Handle the case of passing 'metadata.yaml' as an input source to the
    input selector and parse the relative path to the file the same way as
    it would be handled if it were a relative path with a directory
    component, or an absolute path.

    Signed-off-by: Joe Groocock <me@frebib.net>