### PR TITLE
engine: util: Skip unexported fields in struct field mapping

### DIFF
--- a/engine/util/util.go
+++ b/engine/util/util.go
@@ -276,6 +276,13 @@ func StructKindToFieldNameTypeMap(kind string) (map[string]*types.Type, error) {
 		//	continue
 		//}
 
+		// Skip unexported fields. These should never be mapped golang<->mcl.
+		// TODO: Use StructField.IsExported() in golang 1.17
+		//if !field.IsExported() {
+		if field.PkgPath != "" {
+			continue
+		}
+
 		typ, err := types.TypeOf(field.Type)
 		// some types (eg complex64) aren't convertible, so skip for now...
 		if err != nil {


### PR DESCRIPTION
Unexported fields should be ignored when mapping structs from Golang to
mcl, as this avoids issues where certain structs cannot be used in mcl
representation due to their structure that may be incompatible with
conversion. Disallowing private fields allows those to still be included
in the struct but ignored when mapping the types, allowing the mcl
representation of the type to stil be valid

Resolves: https://github.com/purpleidea/mgmt/issues/684
Signed-off-by: Joe Groocock <me@frebib.net>