### PR TITLE
add flake for easier build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/mgmt-*
 mgmt.iml
 rpmbuild/
 releases/
+result
 # vim swap files
 .*.sw[op]
 # prevent `echo foo 2>1` typo errors by making this file read-only

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667077288,
+        "narHash": "sha256-bdC8sFNDpT0HK74u9fUkpbf1MEzVYJ+ka7NXCdgBoaA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1667339541,
+        "narHash": "sha256-0SfqYB+WznB7IRsSxlkX7Iys85/h6j08Edkq7JLbrXw=",
+        "owner": "urandom2",
+        "repo": "nixpkgs",
+        "rev": "1115389bcdc919f92204f0d3b0514c4e44e25891",
+        "type": "github"
+      },
+      "original": {
+        "owner": "urandom2",
+        "ref": "mgmt",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "Next generation distributed, event-driven, parallel config management!";
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:urandom2/nixpkgs/mgmt";
+  };
+  outputs = {
+    flake-utils,
+    nixpkgs,
+    self,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      buildInputs = with pkgs; [
+        augeas
+        libvirt
+        libxml2
+      ];
+      nativeBuildInputs = with pkgs; [
+        gotools
+        nex
+        pkg-config
+        ragel
+      ];
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      devShells.default = pkgs.mkShell {
+        inherit buildInputs nativeBuildInputs;
+        packages = [pkgs.go];
+      };
+      packages.default = let
+        pname = "mgmt";
+        version = "0.0.22";
+      in
+        pkgs.buildGoModule {
+          inherit pname version buildInputs nativeBuildInputs;
+          ldflags = [
+            "-X main.program=${pname}"
+            "-X main.version=${version}"
+          ];
+          meta = {
+            description = "Next generation distributed, event-driven, parallel config management!";
+            homepage = "https://mgmtconfig.com";
+            license = pkgs.lib.licenses.gpl3;
+          };
+          preBuild = ''
+            substituteInPlace Makefile --replace "/usr/bin/env " ""
+            substituteInPlace lang/Makefile --replace "/usr/bin/env " ""
+            substituteInPlace lang/types/Makefile --replace "/usr/bin/env " ""
+            substituteInPlace lang/types/Makefile --replace "unset GOCACHE &&" ""
+            patchShebangs .
+            make lang funcgen
+          '';
+          src = ./.;
+          subPackages = ["."];
+          vendorHash = "sha256-Dtqy4TILN+7JXiHKHDdjzRTsT8jZYG5sPudxhd8znXY=";
+        };
+    });
+}


### PR DESCRIPTION
This change adds support for nix flake based builds. This includes a dev shell required for running make targets like code generation or testing, and a package target for the output mgmt binary. We have also .gitignored the default output location, result.