### PR TITLE
lang: Remove Expr::SetValue()

### DIFF
--- a/lang/funcs/engine.go
+++ b/lang/funcs/engine.go
@@ -45,7 +45,7 @@ type State struct {
 	input  chan types.Value // the top level type must be a struct
 	output chan types.Value
 
-	mutex *sync.RWMutex // concurrency guard for modifying Expr with String/SetValue
+	mutex *sync.RWMutex // concurrency guard for accessing Expr.String()
 }
 
 // Init creates the function state if it can be found in the registered list.
@@ -450,10 +450,6 @@ func (obj *Engine) Run() error {
 				// XXX: maybe we can get rid of the table...
 				obj.table[vertex] = value // save the latest
 				node.mutex.Lock()
-				if err := node.Expr.SetValue(value); err != nil {
-					node.mutex.Unlock() // don't block node.String()
-					panic(fmt.Sprintf("could not set value for `%s`: %+v", node, err))
-				}
 				node.loaded = true // set *after* value is in :)
 				obj.Logf("func `%s` changed", node)
 				node.mutex.Unlock()

--- a/lang/interfaces/ast.go
+++ b/lang/interfaces/ast.go
@@ -126,10 +126,6 @@ type Expr interface {
 	// Func returns a function that represents this reactively.
 	Func() (Func, error)
 
-	// SetValue stores the result of the last computation of this expression
-	// node.
-	SetValue(types.Value) error
-
 	// Value returns the value of this expression in our type system.
 	Value() (types.Value, error)
 }

--- a/lang/interfaces/structs.go
+++ b/lang/interfaces/structs.go
@@ -29,7 +29,7 @@ import (
 type ExprAny struct {
 	typ *types.Type
 
-	V types.Value // stored value (set with SetValue)
+	V types.Value // stored value
 }
 
 // String returns a short representation of this expression.
@@ -153,25 +153,6 @@ func (obj *ExprAny) Func() (Func, error) {
 	//	}
 
 	return nil, fmt.Errorf("programming error using ExprAny") // this should not be called
-}
-
-// SetValue here is a no-op, because algorithmically when this is called from
-// the func engine, the child elements (the list elements) will have had this
-// done to them first, and as such when we try and retrieve the set value from
-// this expression by calling `Value`, it will build it from scratch!
-
-// SetValue here is used to store a value for this expression node. This value
-// is cached and can be retrieved by calling Value.
-func (obj *ExprAny) SetValue(value types.Value) error {
-	typ := value.Type()
-	if obj.typ != nil {
-		if err := obj.typ.Cmp(typ); err != nil {
-			return err
-		}
-	}
-	obj.typ = typ
-	obj.V = value
-	return nil
 }
 
 // Value returns the value of this expression in our type system. This will


### PR DESCRIPTION
The method is used by the function engine to store the latest value which was emitted by `Func::Stream()`, but this is redundant because the engine also stores that value in the engine's own `table[vertex]`.

Moreover, most of the `SetValue()` implementations have a comment indicating that the function is a no-op, or is never called and is only implemented for consistency.

`Expr::Value()` is still useful because it is used during unification. For example, `printf("%d", x)` can tell the type checker that `x` must be an `int`, but only if the format argument's value is statically known. So it is still useful to have a method for asking for that value if it is known.