### PR TITLE
lang: Split FuncValue into FuncValue and SimpleFn

### DIFF
--- a/lang/ast/structs.go
+++ b/lang/ast/structs.go
@@ -6536,10 +6536,10 @@ type ExprFunc struct {
 
 	// Values represents a list of simple functions. This means this can be
 	// polymorphic if more than one was specified!
-	Values []*types.FuncValue
+	Values []*types.SimpleFn
 
 	// XXX: is this necessary?
-	V func([]types.Value) (types.Value, error)
+	V func([]pgraph.Vertex) (pgraph.Vertex, error)
 }
 
 // String returns a short representation of this expression.
@@ -6839,7 +6839,7 @@ func (obj *ExprFunc) SetScope(scope *interfaces.Scope) error {
 		// TODO: if interfaces.Func grows a SetScope method do it here
 	}
 	if len(obj.Values) > 0 {
-		// TODO: if *types.FuncValue grows a SetScope method do it here
+		// TODO: if *types.SimpleFn grows a SetScope method do it here
 	}
 
 	return nil
@@ -6872,7 +6872,7 @@ func (obj *ExprFunc) SetType(typ *types.Type) error {
 			return errwrap.Wrapf(err, "could not build values func")
 		}
 		// TODO: build the function here for later use if that is wanted
-		//fn := obj.Values[index].Copy().(*types.FuncValue)
+		//fn := obj.Values[index].Copy()
 		//fn.T = typ.Copy() // overwrites any contained "variant" type
 	}
 
@@ -7274,7 +7274,7 @@ func (obj *ExprFunc) Func() (interfaces.Func, error) {
 	}
 	// build
 	// TODO: this could probably be done in SetType and cached in the struct
-	fn := obj.Values[index].Copy().(*types.FuncValue)
+	fn := obj.Values[index].Copy()
 	fn.T = typ.Copy() // overwrites any contained "variant" type
 
 	return &structs.FunctionFunc{

--- a/lang/ast/util.go
+++ b/lang/ast/util.go
@@ -39,14 +39,14 @@ func FuncPrefixToFunctionsScope(prefix string) map[string]interfaces.Expr {
 	for name, f := range fns {
 
 		x := f() // inspect
-		// We can pass in Fns []*types.FuncValue for the simple and
+		// We can pass in Fns []*types.SimpleFn for the simple and
 		// simplepoly API's and avoid the double wrapping from the
 		// simple/simplepoly API's to the main function api and back.
 		if st, ok := x.(*simple.WrappedFunc); simple.DirectInterface && ok {
 			fn := &ExprFunc{
 				Title: name,
 
-				Values: []*types.FuncValue{st.Fn}, // just one!
+				Values: []*types.SimpleFn{st.Fn}, // just one!
 			}
 			// XXX: should we run fn.SetType(st.Fn.Type()) ?
 			exprs[name] = fn
@@ -197,14 +197,15 @@ func ValueToExpr(val types.Value) (interfaces.Expr, error) {
 		}
 
 	case *types.FuncValue:
-		// TODO: this particular case is particularly untested!
-		expr = &ExprFunc{
-			Title: "<func from ValueToExpr>", // TODO: change this?
-			// TODO: symmetrically, it would have used x.Func() here
-			Values: []*types.FuncValue{
-				x, // just one!
-			},
-		}
+		panic("TODO [SimpleFn]: should ExprFunc use FuncValue or SimpleFn?")
+		//// TODO: this particular case is particularly untested!
+		//expr = &ExprFunc{
+		//	Title: "<func from ValueToExpr>", // TODO: change this?
+		//	// TODO: symmetrically, it would have used x.Func() here
+		//	Values: []*types.SimpleFn{
+		//		x, // just one!
+		//	},
+		//}
 
 	case *types.VariantValue:
 		// TODO: should this be allowed, or should we unwrap them?

--- a/lang/funcs/core/convert/to_float.go
+++ b/lang/funcs/core/convert/to_float.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "to_float", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "to_float", &types.SimpleFn{
 		T: types.NewType("func(a int) float"),
 		V: ToFloat,
 	})

--- a/lang/funcs/core/convert/to_int.go
+++ b/lang/funcs/core/convert/to_int.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "to_int", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "to_int", &types.SimpleFn{
 		T: types.NewType("func(a float) int"),
 		V: ToInt,
 	})

--- a/lang/funcs/core/datetime/format_func.go
+++ b/lang/funcs/core/datetime/format_func.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "format", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "format", &types.SimpleFn{
 		T: types.NewType("func(a int, b str) str"),
 		V: Format,
 	})

--- a/lang/funcs/core/datetime/hour_func.go
+++ b/lang/funcs/core/datetime/hour_func.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "hour", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "hour", &types.SimpleFn{
 		T: types.NewType("func(a int) int"),
 		V: Hour,
 	})

--- a/lang/funcs/core/datetime/print_func.go
+++ b/lang/funcs/core/datetime/print_func.go
@@ -27,7 +27,7 @@ import (
 
 func init() {
 	// FIXME: consider renaming this to printf, and add in a format string?
-	simple.ModuleRegister(ModuleName, "print", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "print", &types.SimpleFn{
 		T: types.NewType("func(a int) str"),
 		V: func(input []types.Value) (types.Value, error) {
 			epochDelta := input[0].Int()

--- a/lang/funcs/core/datetime/weekday_func.go
+++ b/lang/funcs/core/datetime/weekday_func.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "weekday", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "weekday", &types.SimpleFn{
 		T: types.NewType("func(a int) str"),
 		V: Weekday,
 	})

--- a/lang/funcs/core/example/answer_func.go
+++ b/lang/funcs/core/example/answer_func.go
@@ -26,7 +26,7 @@ import (
 const Answer = 42
 
 func init() {
-	simple.ModuleRegister(ModuleName, "answer", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "answer", &types.SimpleFn{
 		T: types.NewType("func() int"),
 		V: func([]types.Value) (types.Value, error) {
 			return &types.IntValue{V: Answer}, nil

--- a/lang/funcs/core/example/errorbool_func.go
+++ b/lang/funcs/core/example/errorbool_func.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "errorbool", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "errorbool", &types.SimpleFn{
 		T: types.NewType("func(a bool) str"),
 		V: func(input []types.Value) (types.Value, error) {
 			if input[0].Bool() {

--- a/lang/funcs/core/example/int2str_func.go
+++ b/lang/funcs/core/example/int2str_func.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "int2str", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "int2str", &types.SimpleFn{
 		T: types.NewType("func(a int) str"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.StrValue{

--- a/lang/funcs/core/example/nested/hello_func.go
+++ b/lang/funcs/core/example/nested/hello_func.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(coreexample.ModuleName+"/"+ModuleName, "hello", &types.FuncValue{
+	simple.ModuleRegister(coreexample.ModuleName+"/"+ModuleName, "hello", &types.SimpleFn{
 		T: types.NewType("func() str"),
 		V: Hello,
 	})

--- a/lang/funcs/core/example/plus_func.go
+++ b/lang/funcs/core/example/plus_func.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "plus", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "plus", &types.SimpleFn{
 		T: types.NewType("func(y str, z str) str"),
 		V: Plus,
 	})

--- a/lang/funcs/core/example/str2int_func.go
+++ b/lang/funcs/core/example/str2int_func.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "str2int", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "str2int", &types.SimpleFn{
 		T: types.NewType("func(a str) int"),
 		V: func(input []types.Value) (types.Value, error) {
 			var i int64

--- a/lang/funcs/core/iter/map_func.go
+++ b/lang/funcs/core/iter/map_func.go
@@ -552,68 +552,69 @@ func (obj *MapFunc) Init(init *interfaces.Init) error {
 
 // Stream returns the changing values that this func has over time.
 func (obj *MapFunc) Stream() error {
-	defer close(obj.init.Output) // the sender closes
-	rtyp := types.NewType(fmt.Sprintf("[]%s", obj.RType.String()))
-	for {
-		select {
-		case input, ok := <-obj.init.Input:
-			if !ok {
-				obj.init.Input = nil // don't infinite loop back
-				continue             // no more inputs, but don't return!
-			}
-			//if err := input.Type().Cmp(obj.Info().Sig.Input); err != nil {
-			//	return errwrap.Wrapf(err, "wrong function input")
-			//}
+	panic("TODO [SimpleFn]: every time the FuncValue or the length of the list changes, recreate the subgraph, by calling the FuncValue N times on N nodes which extract each of the N values in the list")
+	//defer close(obj.init.Output) // the sender closes
+	//rtyp := types.NewType(fmt.Sprintf("[]%s", obj.RType.String()))
+	//for {
+	//	select {
+	//	case input, ok := <-obj.init.Input:
+	//		if !ok {
+	//			obj.init.Input = nil // don't infinite loop back
+	//			continue             // no more inputs, but don't return!
+	//		}
+	//		//if err := input.Type().Cmp(obj.Info().Sig.Input); err != nil {
+	//		//	return errwrap.Wrapf(err, "wrong function input")
+	//		//}
 
-			if obj.last != nil && input.Cmp(obj.last) == nil {
-				continue // value didn't change, skip it
-			}
-			obj.last = input // store for next
+	//		if obj.last != nil && input.Cmp(obj.last) == nil {
+	//			continue // value didn't change, skip it
+	//		}
+	//		obj.last = input // store for next
 
-			function := input.Struct()[argNameFunction].Func() // func([]Value) (Value, error)
-			//if function == obj.function { // TODO: how can we cmp?
-			//	continue // nothing changed
-			//}
-			obj.function = function
+	//		function := input.Struct()[argNameFunction].Func() // func([]Value) (Value, error)
+	//		//if function == obj.function { // TODO: how can we cmp?
+	//		//	continue // nothing changed
+	//		//}
+	//		obj.function = function
 
-			inputs := input.Struct()[argNameInputs]
-			if obj.inputs != nil && obj.inputs.Cmp(inputs) == nil {
-				continue // nothing changed
-			}
-			obj.inputs = inputs
+	//		inputs := input.Struct()[argNameInputs]
+	//		if obj.inputs != nil && obj.inputs.Cmp(inputs) == nil {
+	//			continue // nothing changed
+	//		}
+	//		obj.inputs = inputs
 
-			// run the function on each index
-			output := []types.Value{}
-			for ix, v := range inputs.List() { // []Value
-				args := []types.Value{v} // only one input arg!
-				x, err := function(args)
-				if err != nil {
-					return errwrap.Wrapf(err, "error running map function on index %d", ix)
-				}
+	//		// run the function on each index
+	//		output := []types.Value{}
+	//		for ix, v := range inputs.List() { // []Value
+	//			args := []types.Value{v} // only one input arg!
+	//			x, err := function(args)
+	//			if err != nil {
+	//				return errwrap.Wrapf(err, "error running map function on index %d", ix)
+	//			}
 
-				output = append(output, x)
-			}
-			result := &types.ListValue{
-				V: output,
-				T: rtyp,
-			}
+	//			output = append(output, x)
+	//		}
+	//		result := &types.ListValue{
+	//			V: output,
+	//			T: rtyp,
+	//		}
 
-			if obj.result != nil && obj.result.Cmp(result) == nil {
-				continue // result didn't change
-			}
-			obj.result = result // store new result
+	//		if obj.result != nil && obj.result.Cmp(result) == nil {
+	//			continue // result didn't change
+	//		}
+	//		obj.result = result // store new result
 
-		case <-obj.closeChan:
-			return nil
-		}
+	//	case <-obj.closeChan:
+	//		return nil
+	//	}
 
-		select {
-		case obj.init.Output <- obj.result: // send
-			// pass
-		case <-obj.closeChan:
-			return nil
-		}
-	}
+	//	select {
+	//	case obj.init.Output <- obj.result: // send
+	//		// pass
+	//	case <-obj.closeChan:
+	//		return nil
+	//	}
+	//}
 }
 
 // Close runs some shutdown code for this function and turns off the stream.

--- a/lang/funcs/core/len_func.go
+++ b/lang/funcs/core/len_func.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	simplepoly.Register("len", []*types.FuncValue{
+	simplepoly.Register("len", []*types.SimpleFn{
 		{
 			T: types.NewType("func(str) int"),
 			V: Len,

--- a/lang/funcs/core/math/fortytwo_func.go
+++ b/lang/funcs/core/math/fortytwo_func.go
@@ -27,7 +27,7 @@ import (
 func init() {
 	typInt := types.NewType("func() int")
 	typFloat := types.NewType("func() float")
-	simplepoly.ModuleRegister(ModuleName, "fortytwo", []*types.FuncValue{
+	simplepoly.ModuleRegister(ModuleName, "fortytwo", []*types.SimpleFn{
 		{
 			T: typInt,
 			V: fortyTwo(typInt), // generate the correct function here

--- a/lang/funcs/core/math/mod_func.go
+++ b/lang/funcs/core/math/mod_func.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	simplepoly.ModuleRegister(ModuleName, "mod", []*types.FuncValue{
+	simplepoly.ModuleRegister(ModuleName, "mod", []*types.SimpleFn{
 		{
 			T: types.NewType("func(int, int) int"),
 			V: Mod,

--- a/lang/funcs/core/math/pow_func.go
+++ b/lang/funcs/core/math/pow_func.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "pow", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "pow", &types.SimpleFn{
 		T: types.NewType("func(x float, y float) float"),
 		V: Pow,
 	})

--- a/lang/funcs/core/math/sqrt_func.go
+++ b/lang/funcs/core/math/sqrt_func.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "sqrt", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "sqrt", &types.SimpleFn{
 		T: types.NewType("func(x float) float"),
 		V: Sqrt,
 	})

--- a/lang/funcs/core/net/cidr_to_ip_func.go
+++ b/lang/funcs/core/net/cidr_to_ip_func.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "cidr_to_ip", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "cidr_to_ip", &types.SimpleFn{
 		T: types.NewType("func(a str) str"),
 		V: CidrToIP,
 	})

--- a/lang/funcs/core/net/macfmt_func.go
+++ b/lang/funcs/core/net/macfmt_func.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "macfmt", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "macfmt", &types.SimpleFn{
 		T: types.NewType("func(a str) str"),
 		V: MacFmt,
 	})

--- a/lang/funcs/core/os/family_func.go
+++ b/lang/funcs/core/os/family_func.go
@@ -26,15 +26,15 @@ import (
 
 func init() {
 	// TODO: Create a family method that will return a giant struct.
-	simple.ModuleRegister(ModuleName, "is_debian", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "is_debian", &types.SimpleFn{
 		T: types.NewType("func() bool"),
 		V: IsDebian,
 	})
-	simple.ModuleRegister(ModuleName, "is_redhat", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "is_redhat", &types.SimpleFn{
 		T: types.NewType("func() bool"),
 		V: IsRedHat,
 	})
-	simple.ModuleRegister(ModuleName, "is_archlinux", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "is_archlinux", &types.SimpleFn{
 		T: types.NewType("func() bool"),
 		V: IsArchLinux,
 	})

--- a/lang/funcs/core/regexp/match_func.go
+++ b/lang/funcs/core/regexp/match_func.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "match", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "match", &types.SimpleFn{
 		T: types.NewType("func(pattern str, s str) bool"),
 		V: Match,
 	})

--- a/lang/funcs/core/strings/split_func.go
+++ b/lang/funcs/core/strings/split_func.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "split", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "split", &types.SimpleFn{
 		T: types.NewType("func(a str, b str) []str"),
 		V: Split,
 	})

--- a/lang/funcs/core/strings/to_lower_func.go
+++ b/lang/funcs/core/strings/to_lower_func.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "to_lower", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "to_lower", &types.SimpleFn{
 		T: types.NewType("func(a str) str"),
 		V: ToLower,
 	})

--- a/lang/funcs/core/sys/env_func.go
+++ b/lang/funcs/core/sys/env_func.go
@@ -26,19 +26,19 @@ import (
 )
 
 func init() {
-	simple.ModuleRegister(ModuleName, "getenv", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "getenv", &types.SimpleFn{
 		T: types.NewType("func(str) str"),
 		V: GetEnv,
 	})
-	simple.ModuleRegister(ModuleName, "defaultenv", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "defaultenv", &types.SimpleFn{
 		T: types.NewType("func(str, str) str"),
 		V: DefaultEnv,
 	})
-	simple.ModuleRegister(ModuleName, "hasenv", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "hasenv", &types.SimpleFn{
 		T: types.NewType("func(str) bool"),
 		V: HasEnv,
 	})
-	simple.ModuleRegister(ModuleName, "env", &types.FuncValue{
+	simple.ModuleRegister(ModuleName, "env", &types.SimpleFn{
 		T: types.NewType("func() map{str: str}"),
 		V: Env,
 	})

--- a/lang/funcs/core/template_func.go
+++ b/lang/funcs/core/template_func.go
@@ -559,7 +559,7 @@ func safename(name string) string {
 // function API with what is expected from the reflection API. It returns a
 // version that includes the optional second error return value so that our
 // functions can return errors without causing a panic.
-func wrap(name string, fn *types.FuncValue) interface{} {
+func wrap(name string, fn *types.SimpleFn) interface{} {
 	if fn.T.Map == nil {
 		panic("malformed func type")
 	}

--- a/lang/funcs/funcgen/templates/generated_funcs.go.tpl
+++ b/lang/funcs/funcgen/templates/generated_funcs.go.tpl
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-{{ range $i, $func := .Functions }}	simple.ModuleRegister("{{$func.MgmtPackage}}", "{{$func.MclName}}", &types.FuncValue{
+{{ range $i, $func := .Functions }}	simple.ModuleRegister("{{$func.MgmtPackage}}", "{{$func.MclName}}", &types.SimpleFn{
 		T: types.NewType("{{$func.Signature}}"),
 		V: {{$func.InternalName}},
 	})

--- a/lang/funcs/operator_polyfunc.go
+++ b/lang/funcs/operator_polyfunc.go
@@ -40,7 +40,7 @@ const (
 
 func init() {
 	// concatenation
-	RegisterOperator("+", &types.FuncValue{
+	RegisterOperator("+", &types.SimpleFn{
 		T: types.NewType("func(a str, b str) str"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.StrValue{
@@ -49,7 +49,7 @@ func init() {
 		},
 	})
 	// addition
-	RegisterOperator("+", &types.FuncValue{
+	RegisterOperator("+", &types.SimpleFn{
 		T: types.NewType("func(a int, b int) int"),
 		V: func(input []types.Value) (types.Value, error) {
 			//if l := len(input); l != 2 {
@@ -62,7 +62,7 @@ func init() {
 		},
 	})
 	// floating-point addition
-	RegisterOperator("+", &types.FuncValue{
+	RegisterOperator("+", &types.SimpleFn{
 		T: types.NewType("func(a float, b float) float"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.FloatValue{
@@ -72,7 +72,7 @@ func init() {
 	})
 
 	// subtraction
-	RegisterOperator("-", &types.FuncValue{
+	RegisterOperator("-", &types.SimpleFn{
 		T: types.NewType("func(a int, b int) int"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.IntValue{
@@ -81,7 +81,7 @@ func init() {
 		},
 	})
 	// floating-point subtraction
-	RegisterOperator("-", &types.FuncValue{
+	RegisterOperator("-", &types.SimpleFn{
 		T: types.NewType("func(a float, b float) float"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.FloatValue{
@@ -91,7 +91,7 @@ func init() {
 	})
 
 	// multiplication
-	RegisterOperator("*", &types.FuncValue{
+	RegisterOperator("*", &types.SimpleFn{
 		T: types.NewType("func(a int, b int) int"),
 		V: func(input []types.Value) (types.Value, error) {
 			// FIXME: check for overflow?
@@ -101,7 +101,7 @@ func init() {
 		},
 	})
 	// floating-point multiplication
-	RegisterOperator("*", &types.FuncValue{
+	RegisterOperator("*", &types.SimpleFn{
 		T: types.NewType("func(a float, b float) float"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.FloatValue{
@@ -112,7 +112,7 @@ func init() {
 
 	// don't add: `func(int, float) float` or: `func(float, int) float`
 	// division
-	RegisterOperator("/", &types.FuncValue{
+	RegisterOperator("/", &types.SimpleFn{
 		T: types.NewType("func(a int, b int) float"),
 		V: func(input []types.Value) (types.Value, error) {
 			divisor := input[1].Int()
@@ -125,7 +125,7 @@ func init() {
 		},
 	})
 	// floating-point division
-	RegisterOperator("/", &types.FuncValue{
+	RegisterOperator("/", &types.SimpleFn{
 		T: types.NewType("func(a float, b float) float"),
 		V: func(input []types.Value) (types.Value, error) {
 			divisor := input[1].Float()
@@ -139,7 +139,7 @@ func init() {
 	})
 
 	// string equality
-	RegisterOperator("==", &types.FuncValue{
+	RegisterOperator("==", &types.SimpleFn{
 		T: types.NewType("func(a str, b str) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -148,7 +148,7 @@ func init() {
 		},
 	})
 	// bool equality
-	RegisterOperator("==", &types.FuncValue{
+	RegisterOperator("==", &types.SimpleFn{
 		T: types.NewType("func(a bool, b bool) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -157,7 +157,7 @@ func init() {
 		},
 	})
 	// int equality
-	RegisterOperator("==", &types.FuncValue{
+	RegisterOperator("==", &types.SimpleFn{
 		T: types.NewType("func(a int, b int) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -166,7 +166,7 @@ func init() {
 		},
 	})
 	// floating-point equality
-	RegisterOperator("==", &types.FuncValue{
+	RegisterOperator("==", &types.SimpleFn{
 		T: types.NewType("func(a float, b float) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			// TODO: should we do an epsilon check?
@@ -177,7 +177,7 @@ func init() {
 	})
 
 	// string in-equality
-	RegisterOperator("!=", &types.FuncValue{
+	RegisterOperator("!=", &types.SimpleFn{
 		T: types.NewType("func(a str, b str) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -186,7 +186,7 @@ func init() {
 		},
 	})
 	// bool in-equality
-	RegisterOperator("!=", &types.FuncValue{
+	RegisterOperator("!=", &types.SimpleFn{
 		T: types.NewType("func(a bool, b bool) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -195,7 +195,7 @@ func init() {
 		},
 	})
 	// int in-equality
-	RegisterOperator("!=", &types.FuncValue{
+	RegisterOperator("!=", &types.SimpleFn{
 		T: types.NewType("func(a int, b int) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -204,7 +204,7 @@ func init() {
 		},
 	})
 	// floating-point in-equality
-	RegisterOperator("!=", &types.FuncValue{
+	RegisterOperator("!=", &types.SimpleFn{
 		T: types.NewType("func(a float, b float) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			// TODO: should we do an epsilon check?
@@ -215,7 +215,7 @@ func init() {
 	})
 
 	// less-than
-	RegisterOperator("<", &types.FuncValue{
+	RegisterOperator("<", &types.SimpleFn{
 		T: types.NewType("func(a int, b int) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -224,7 +224,7 @@ func init() {
 		},
 	})
 	// floating-point less-than
-	RegisterOperator("<", &types.FuncValue{
+	RegisterOperator("<", &types.SimpleFn{
 		T: types.NewType("func(a float, b float) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			// TODO: should we do an epsilon check?
@@ -234,7 +234,7 @@ func init() {
 		},
 	})
 	// greater-than
-	RegisterOperator(">", &types.FuncValue{
+	RegisterOperator(">", &types.SimpleFn{
 		T: types.NewType("func(a int, b int) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -243,7 +243,7 @@ func init() {
 		},
 	})
 	// floating-point greater-than
-	RegisterOperator(">", &types.FuncValue{
+	RegisterOperator(">", &types.SimpleFn{
 		T: types.NewType("func(a float, b float) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			// TODO: should we do an epsilon check?
@@ -253,7 +253,7 @@ func init() {
 		},
 	})
 	// less-than-equal
-	RegisterOperator("<=", &types.FuncValue{
+	RegisterOperator("<=", &types.SimpleFn{
 		T: types.NewType("func(a int, b int) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -262,7 +262,7 @@ func init() {
 		},
 	})
 	// floating-point less-than-equal
-	RegisterOperator("<=", &types.FuncValue{
+	RegisterOperator("<=", &types.SimpleFn{
 		T: types.NewType("func(a float, b float) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			// TODO: should we do an epsilon check?
@@ -272,7 +272,7 @@ func init() {
 		},
 	})
 	// greater-than-equal
-	RegisterOperator(">=", &types.FuncValue{
+	RegisterOperator(">=", &types.SimpleFn{
 		T: types.NewType("func(a int, b int) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -281,7 +281,7 @@ func init() {
 		},
 	})
 	// floating-point greater-than-equal
-	RegisterOperator(">=", &types.FuncValue{
+	RegisterOperator(">=", &types.SimpleFn{
 		T: types.NewType("func(a float, b float) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			// TODO: should we do an epsilon check?
@@ -294,7 +294,7 @@ func init() {
 	// logical and
 	// TODO: is there a way for the engine to have
 	// short-circuit operators, and does it matter?
-	RegisterOperator("&&", &types.FuncValue{
+	RegisterOperator("&&", &types.SimpleFn{
 		T: types.NewType("func(a bool, b bool) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -303,7 +303,7 @@ func init() {
 		},
 	})
 	// logical or
-	RegisterOperator("||", &types.FuncValue{
+	RegisterOperator("||", &types.SimpleFn{
 		T: types.NewType("func(a bool, b bool) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -313,7 +313,7 @@ func init() {
 	})
 
 	// logical not (unary operator)
-	RegisterOperator("!", &types.FuncValue{
+	RegisterOperator("!", &types.SimpleFn{
 		T: types.NewType("func(a bool) bool"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.BoolValue{
@@ -323,7 +323,7 @@ func init() {
 	})
 
 	// pi operator (this is an easter egg to demo a zero arg operator)
-	RegisterOperator("π", &types.FuncValue{
+	RegisterOperator("π", &types.SimpleFn{
 		T: types.NewType("func() float"),
 		V: func(input []types.Value) (types.Value, error) {
 			return &types.FloatValue{
@@ -336,14 +336,14 @@ func init() {
 }
 
 // OperatorFuncs maps an operator to a list of callable function values.
-var OperatorFuncs = make(map[string][]*types.FuncValue) // must initialize
+var OperatorFuncs = make(map[string][]*types.SimpleFn) // must initialize
 
 // RegisterOperator registers the given string operator and function value
 // implementation with the mini-database for this generalized, static,
 // polymorphic operator implementation.
-func RegisterOperator(operator string, fn *types.FuncValue) {
+func RegisterOperator(operator string, fn *types.SimpleFn) {
 	if _, exists := OperatorFuncs[operator]; !exists {
-		OperatorFuncs[operator] = []*types.FuncValue{} // init
+		OperatorFuncs[operator] = []*types.SimpleFn{} // init
 	}
 
 	for _, f := range OperatorFuncs[operator] {
@@ -467,7 +467,7 @@ func (obj *OperatorPolyFunc) argNames() ([]string, error) {
 
 // findFunc tries to find the first available registered operator function that
 // matches the Operator/Type pattern requested. If none is found it returns nil.
-func (obj *OperatorPolyFunc) findFunc(operator string) *types.FuncValue {
+func (obj *OperatorPolyFunc) findFunc(operator string) *types.SimpleFn {
 	fns, exists := OperatorFuncs[operator]
 	if !exists {
 		return nil
@@ -831,7 +831,7 @@ func (obj *OperatorPolyFunc) Init(init *interfaces.Init) error {
 // Stream returns the changing values that this func has over time.
 func (obj *OperatorPolyFunc) Stream() error {
 	var op, lastOp string
-	var fn *types.FuncValue
+	var fn *types.SimpleFn
 	defer close(obj.init.Output) // the sender closes
 	for {
 		select {

--- a/lang/funcs/simple/simple.go
+++ b/lang/funcs/simple/simple.go
@@ -34,11 +34,11 @@ const (
 )
 
 // RegisteredFuncs maps a function name to the corresponding static, pure func.
-var RegisteredFuncs = make(map[string]*types.FuncValue) // must initialize
+var RegisteredFuncs = make(map[string]*types.SimpleFn) // must initialize
 
 // Register registers a simple, static, pure function. It is easier to use than
 // the raw function API, but also limits you to simple, static, pure functions.
-func Register(name string, fn *types.FuncValue) {
+func Register(name string, fn *types.SimpleFn) {
 	if _, exists := RegisteredFuncs[name]; exists {
 		panic(fmt.Sprintf("a simple func named %s is already registered", name))
 	}
@@ -63,14 +63,14 @@ func Register(name string, fn *types.FuncValue) {
 
 // ModuleRegister is exactly like Register, except that it registers within a
 // named module. This is a helper function.
-func ModuleRegister(module, name string, fn *types.FuncValue) {
+func ModuleRegister(module, name string, fn *types.SimpleFn) {
 	Register(module+funcs.ModuleSep+name, fn)
 }
 
 // WrappedFunc is a scaffolding function struct which fulfills the boiler-plate
 // for the function API, but that can run a very simple, static, pure function.
 type WrappedFunc struct {
-	Fn *types.FuncValue
+	Fn *types.SimpleFn
 
 	init *interfaces.Init
 	last types.Value // last value received to use for diff

--- a/lang/funcs/simplepoly/simplepoly.go
+++ b/lang/funcs/simplepoly/simplepoly.go
@@ -44,7 +44,7 @@ const (
 )
 
 // RegisteredFuncs maps a function name to the corresponding static, pure funcs.
-var RegisteredFuncs = make(map[string][]*types.FuncValue) // must initialize
+var RegisteredFuncs = make(map[string][]*types.SimpleFn) // must initialize
 
 // Register registers a simple, static, pure, polymorphic function. It is easier
 // to use than the raw function API, but also limits you to small, finite
@@ -54,7 +54,7 @@ var RegisteredFuncs = make(map[string][]*types.FuncValue) // must initialize
 // not possible with this API. Implementing a function like `printf` would not
 // be possible. Implementing a function which counts the number of elements in a
 // list would be.
-func Register(name string, fns []*types.FuncValue) {
+func Register(name string, fns []*types.SimpleFn) {
 	if _, exists := RegisteredFuncs[name]; exists {
 		panic(fmt.Sprintf("a simple polyfunc named %s is already registered", name))
 	}
@@ -95,13 +95,13 @@ func Register(name string, fns []*types.FuncValue) {
 
 // ModuleRegister is exactly like Register, except that it registers within a
 // named module. This is a helper function.
-func ModuleRegister(module, name string, fns []*types.FuncValue) {
+func ModuleRegister(module, name string, fns []*types.SimpleFn) {
 	Register(module+funcs.ModuleSep+name, fns)
 }
 
 // consistentArgs returns the list of arg names across all the functions or
 // errors if one consistent list could not be found.
-func consistentArgs(fns []*types.FuncValue) ([]string, error) {
+func consistentArgs(fns []*types.SimpleFn) ([]string, error) {
 	if len(fns) == 0 {
 		return nil, fmt.Errorf("no functions specified for simple polyfunc")
 	}
@@ -131,9 +131,9 @@ func consistentArgs(fns []*types.FuncValue) ([]string, error) {
 // for the function API, but that can run a very simple, static, pure,
 // polymorphic function.
 type WrappedFunc struct {
-	Fns []*types.FuncValue // list of possible functions
+	Fns []*types.SimpleFn // list of possible functions
 
-	fn *types.FuncValue // the concrete version of our chosen function
+	fn *types.SimpleFn // the concrete version of our chosen function
 
 	init *interfaces.Init
 	last types.Value // last value received to use for diff
@@ -486,7 +486,7 @@ func (obj *WrappedFunc) Build(typ *types.Type) error {
 // buildFunction builds our concrete static function, from the potentially
 // abstract, possibly variant containing list of functions.
 func (obj *WrappedFunc) buildFunction(typ *types.Type, ix int) {
-	obj.fn = obj.Fns[ix].Copy().(*types.FuncValue)
+	obj.fn = obj.Fns[ix].Copy()
 	obj.fn.T = typ.Copy() // overwrites any contained "variant" type
 }
 

--- a/lang/funcs/structs/call.go
+++ b/lang/funcs/structs/call.go
@@ -109,68 +109,69 @@ func (obj *CallFunc) Init(init *interfaces.Init) error {
 // methods of the Expr, and returns the actual expected value as a stream based
 // on the changing inputs to that value.
 func (obj *CallFunc) Stream() error {
-	defer close(obj.init.Output) // the sender closes
-	for {
-		select {
-		case input, ok := <-obj.init.Input:
-			if !ok {
-				return nil // can't output any more
-			}
-			//if err := input.Type().Cmp(obj.Info().Sig.Input); err != nil {
-			//	return errwrap.Wrapf(err, "wrong function input")
-			//}
-			if obj.last != nil && input.Cmp(obj.last) == nil {
-				continue // value didn't change, skip it
-			}
-			obj.last = input // store for next
+	panic("TODO [SimpleFn]: every time the FuncValue changes, recreate the subgraph by calling the FuncValue")
+	//defer close(obj.init.Output) // the sender closes
+	//for {
+	//	select {
+	//	case input, ok := <-obj.init.Input:
+	//		if !ok {
+	//			return nil // can't output any more
+	//		}
+	//		//if err := input.Type().Cmp(obj.Info().Sig.Input); err != nil {
+	//		//	return errwrap.Wrapf(err, "wrong function input")
+	//		//}
+	//		if obj.last != nil && input.Cmp(obj.last) == nil {
+	//			continue // value didn't change, skip it
+	//		}
+	//		obj.last = input // store for next
 
-			st := input.(*types.StructValue) // must be!
+	//		st := input.(*types.StructValue) // must be!
 
-			// get the function
-			fn, exists := st.Lookup(obj.Edge)
-			if !exists {
-				return fmt.Errorf("missing expected input argument `%s`", obj.Edge)
-			}
+	//		// get the function
+	//		fn, exists := st.Lookup(obj.Edge)
+	//		if !exists {
+	//			return fmt.Errorf("missing expected input argument `%s`", obj.Edge)
+	//		}
 
-			// get the arguments to call the function
-			args := []types.Value{}
-			typ := obj.FuncType
-			for ix, key := range typ.Ord { // sig!
-				if obj.Indexed {
-					key = fmt.Sprintf("%d", ix)
-				}
-				value, exists := st.Lookup(key)
-				// TODO: replace with:
-				//value, exists := st.Lookup(fmt.Sprintf("arg:%s", key))
-				if !exists {
-					return fmt.Errorf("missing expected input argument `%s`", key)
-				}
-				args = append(args, value)
-			}
+	//		// get the arguments to call the function
+	//		args := []types.Value{}
+	//		typ := obj.FuncType
+	//		for ix, key := range typ.Ord { // sig!
+	//			if obj.Indexed {
+	//				key = fmt.Sprintf("%d", ix)
+	//			}
+	//			value, exists := st.Lookup(key)
+	//			// TODO: replace with:
+	//			//value, exists := st.Lookup(fmt.Sprintf("arg:%s", key))
+	//			if !exists {
+	//				return fmt.Errorf("missing expected input argument `%s`", key)
+	//			}
+	//			args = append(args, value)
+	//		}
 
-			// actually call it
-			result, err := fn.(*types.FuncValue).Call(args)
-			if err != nil {
-				return errwrap.Wrapf(err, "error calling function")
-			}
+	//		// actually call it
+	//		result, err := fn.(*types.SimpleFn).Call(args)
+	//		if err != nil {
+	//			return errwrap.Wrapf(err, "error calling function")
+	//		}
 
-			// skip sending an update...
-			if obj.result != nil && result.Cmp(obj.result) == nil {
-				continue // result didn't change
-			}
-			obj.result = result // store new result
+	//		// skip sending an update...
+	//		if obj.result != nil && result.Cmp(obj.result) == nil {
+	//			continue // result didn't change
+	//		}
+	//		obj.result = result // store new result
 
-		case <-obj.closeChan:
-			return nil
-		}
+	//	case <-obj.closeChan:
+	//		return nil
+	//	}
 
-		select {
-		case obj.init.Output <- obj.result: // send
-			// pass
-		case <-obj.closeChan:
-			return nil
-		}
-	}
+	//	select {
+	//	case obj.init.Output <- obj.result: // send
+	//		// pass
+	//	case <-obj.closeChan:
+	//		return nil
+	//	}
+	//}
 }
 
 // Close runs some shutdown code for this function and turns off the stream.

--- a/lang/funcs/structs/function.go
+++ b/lang/funcs/structs/function.go
@@ -20,10 +20,9 @@ package structs
 import (
 	"fmt"
 
-	"github.com/purpleidea/mgmt/lang/funcs"
+	//"github.com/purpleidea/mgmt/lang/funcs"
 	"github.com/purpleidea/mgmt/lang/interfaces"
 	"github.com/purpleidea/mgmt/lang/types"
-	"github.com/purpleidea/mgmt/util/errwrap"
 )
 
 // FunctionFunc is a function that passes through the function body it receives.
@@ -31,7 +30,7 @@ type FunctionFunc struct {
 	Type *types.Type // this is the type of the function that we hold
 	Edge string      // name of the edge used (typically "body")
 	Func interfaces.Func
-	Fn   *types.FuncValue
+	Fn   *types.SimpleFn
 
 	init   *interfaces.Init
 	last   types.Value // last value received to use for diff
@@ -41,24 +40,25 @@ type FunctionFunc struct {
 }
 
 // fn returns the function that wraps the Func interface if that API is used.
-func (obj *FunctionFunc) fn() (*types.FuncValue, error) {
-	fn := func(args []types.Value) (types.Value, error) {
-		// FIXME: can we run a recursive engine
-		// to support running non-pure functions?
-		if !obj.Func.Info().Pure {
-			return nil, fmt.Errorf("only pure functions can be used by value")
-		}
+func (obj *FunctionFunc) fn() (*types.SimpleFn, error) {
+	panic("TODO [SimpleFn]: should this use FuncValue or SimpleFn?")
+	//fn := func(args []types.Value) (types.Value, error) {
+	//	// FIXME: can we run a recursive engine
+	//	// to support running non-pure functions?
+	//	if !obj.Func.Info().Pure {
+	//		return nil, fmt.Errorf("only pure functions can be used by value")
+	//	}
 
-		// XXX: this might not be needed anymore...
-		return funcs.PureFuncExec(obj.Func, args)
-	}
+	//	// XXX: this might not be needed anymore...
+	//	return funcs.PureFuncExec(obj.Func, args)
+	//}
 
-	result := types.NewFunc(obj.Type) // new func
-	if err := result.Set(fn); err != nil {
-		return nil, errwrap.Wrapf(err, "can't build func from built-in")
-	}
+	//result := types.NewFunc(obj.Type) // new func
+	//if err := result.Set(fn); err != nil {
+	//	return nil, errwrap.Wrapf(err, "can't build func from built-in")
+	//}
 
-	return result, nil
+	//return result, nil
 }
 
 // Validate makes sure we've built our struct properly.
@@ -122,78 +122,110 @@ func (obj *FunctionFunc) Init(init *interfaces.Init) error {
 // methods of the Expr, and returns the actual expected value as a stream based
 // on the changing inputs to that value.
 func (obj *FunctionFunc) Stream() error {
-	defer close(obj.init.Output) // the sender closes
-	for {
-		select {
-		case input, ok := <-obj.init.Input:
-			if !ok {
-				if obj.Edge != "" { // then it's not a built-in
-					return nil // can't output any more
-				}
+	// TODO:
+	//
+	// In all three cases, we produce a single FuncValue and then close the
+	// stream to indicate that the value will not change anymore.
+	//
+	// If the function represents a lambda (Edge != nil):
+	//   The body of lambdas are no longer inlined at the call sites, so this
+	//   case is no longer possible. Instead, a Lambda is compiled to a node
+	//   with in-degree zero (could be a FunctionFunc, could be a new node
+	//   type called a ClosureFunc) which produces a single FuncValue, which
+	//   in turn takes the lambda's arguments and produces a sub-graph
+	//   consisting of the lambda's body.
+	//   Note that in
+	//
+	//       fn(x) {
+	//         fn (y) {
+	//           x + y
+	//         }
+	//       }
+	//
+	//   the inner lambda's node does not need to have the x node as an input,
+	//   because when x changes, it does not cause the shape of the sub-graph to
+	//   change, it merely changes which values flow through the plus node.
+	//   However, the inner lambda's FuncValue does need to store the x node, so
+	//   that it can generate a sub-graph in which the plus node is connected to
+	//   that x node.
+	// If the function represents ? (Func != nil):
+	//   Return Func.
+	// If the function represents a go function (Fn != nil):
+	//   Return a FuncValue which constructs a subgraph consisting of a single
+	//   node (let's call it PureFunc) which runs Fn.
+	panic("TODO [SimpleFn]: see comment above")
+	//defer close(obj.init.Output) // the sender closes
+	//for {
+	//	select {
+	//	case input, ok := <-obj.init.Input:
+	//		if !ok {
+	//			if obj.Edge != "" { // then it's not a built-in
+	//				return nil // can't output any more
+	//			}
 
-				var result *types.FuncValue
+	//			var result *types.SimpleFn
 
-				if obj.Fn != nil {
-					result = obj.Fn
-				} else {
-					var err error
-					result, err = obj.fn()
-					if err != nil {
-						return err
-					}
-				}
+	//			if obj.Fn != nil {
+	//				result = obj.Fn
+	//			} else {
+	//				var err error
+	//				result, err = obj.fn()
+	//				if err != nil {
+	//					return err
+	//				}
+	//			}
 
-				// if we never had input args, send the function
-				select {
-				case obj.init.Output <- result: // send
-					// pass
-				case <-obj.closeChan:
-					return nil
-				}
+	//			// if we never had input args, send the function
+	//			select {
+	//			case obj.init.Output <- result: // send
+	//				// pass
+	//			case <-obj.closeChan:
+	//				return nil
+	//			}
 
-				return nil
-			}
-			//if err := input.Type().Cmp(obj.Info().Sig.Input); err != nil {
-			//	return errwrap.Wrapf(err, "wrong function input")
-			//}
-			if obj.last != nil && input.Cmp(obj.last) == nil {
-				continue // value didn't change, skip it
-			}
-			obj.last = input // store for next
+	//			return nil
+	//		}
+	//		//if err := input.Type().Cmp(obj.Info().Sig.Input); err != nil {
+	//		//	return errwrap.Wrapf(err, "wrong function input")
+	//		//}
+	//		if obj.last != nil && input.Cmp(obj.last) == nil {
+	//			continue // value didn't change, skip it
+	//		}
+	//		obj.last = input // store for next
 
-			var result types.Value
+	//		var result types.Value
 
-			st := input.(*types.StructValue)     // must be!
-			value, exists := st.Lookup(obj.Edge) // single argName
-			if !exists {
-				return fmt.Errorf("missing expected input argument `%s`", obj.Edge)
-			}
+	//		st := input.(*types.StructValue)     // must be!
+	//		value, exists := st.Lookup(obj.Edge) // single argName
+	//		if !exists {
+	//			return fmt.Errorf("missing expected input argument `%s`", obj.Edge)
+	//		}
 
-			result = obj.Type.New() // new func
-			fn := func([]types.Value) (types.Value, error) {
-				return value, nil
-			}
-			if err := result.(*types.FuncValue).Set(fn); err != nil {
-				return errwrap.Wrapf(err, "can't build func with body")
-			}
+	//		result = obj.Type.New() // new func
+	//		fn := func([]types.Value) (types.Value, error) {
+	//			return value, nil
+	//		}
+	//		if err := result.(*types.SimpleFn).Set(fn); err != nil {
+	//			return errwrap.Wrapf(err, "can't build func with body")
+	//		}
 
-			// skip sending an update...
-			if obj.result != nil && result.Cmp(obj.result) == nil {
-				continue // result didn't change
-			}
-			obj.result = result // store new result
+	//		// skip sending an update...
+	//		if obj.result != nil && result.Cmp(obj.result) == nil {
+	//			continue // result didn't change
+	//		}
+	//		obj.result = result // store new result
 
-		case <-obj.closeChan:
-			return nil
-		}
+	//	case <-obj.closeChan:
+	//		return nil
+	//	}
 
-		select {
-		case obj.init.Output <- obj.result: // send
-			// pass
-		case <-obj.closeChan:
-			return nil
-		}
-	}
+	//	select {
+	//	case obj.init.Output <- obj.result: // send
+	//		// pass
+	//	case <-obj.closeChan:
+	//		return nil
+	//	}
+	//}
 }
 
 // Close runs some shutdown code for this function and turns off the stream.

--- a/lang/util/util.go
+++ b/lang/util/util.go
@@ -58,7 +58,7 @@ func HasDuplicateTypes(typs []*types.Type) error {
 // FnMatch is run to turn a polymorphic, undetermined list of functions, into a
 // specific statically typed version. It is usually run after Unify completes.
 // It returns the index of the matched function.
-func FnMatch(typ *types.Type, fns []*types.FuncValue) (int, error) {
+func FnMatch(typ *types.Type, fns []*types.SimpleFn) (int, error) {
 	// typ is the KindFunc signature we're trying to build...
 	if typ == nil {
 		return 0, fmt.Errorf("type of function must be specified")


### PR DESCRIPTION
Representing an MCL function value as a golang function from Value to Value was a mistake, it should be a function from Vertex to Vertex.

## Why this is a mistake

The output of a function like

    $f = fn(x) {
      Shell(Sprintf("seq %d", x))
    }

varies over time, while a single Value does not. Thus, code like

    Map($f, list(1, 2))

would first produce the value list("1", "1"), but then it would _not_ update to list("1", "2") when "seq 2" produces its second line. That's because with the mistaken design, when Map receives a new FuncValue or a new input list of N elements, Map calls the function from Value to Value N times and produces a single output list of N elements.

## Why the corrected design is better

Here's what happens with this new design when Map receives a new FuncValue or a new input list of N elements.

First, Map constructs N item-input nodes, each of which extracts a different entry from the list. Then, Map calls the function from Vertex to Vertex N times, once for each item-input node, and thus obtain N item-output nodes. Finally, Map constructs an item-collecting node which constructs a list out of all of its inputs, and Map connects the N item-output nodes to the item-collecting node. This item-collecting node is the output of Map.

The Vertex to Vertex function constructs and connects its own nodes; in this case, it constructs an Sprintf node and connects the item-input node to it, and then constructs a Shell node and connects the Sprintf node to it, and then returns the Shell node as the item-output node.

The two Shell node in this sub-graph emit a first value "1", which propagates to the item-collecting node and causes it to output a first value list("1", "1"). Then, the second Shell node emits a second value "2", which propagates to the item-collecting node and causes it to output a second value list("1", "2"), as desired.

## How this commit brings us closer to the above plan

Changing FuncValue throughout the codebase is a big change. One of the difficulties is that it is not just nodes which are emitting FuncValues, there are also many other places in the code where FuncValue is used to hold a golang function from Value to Value. Some of those places now need to hold a golang function from Vertex to Vertex, but other places still need to hold a golang function from Vertex to Vertex.

Thus, as a first step, we need to split FuncValue into two types.
This commit splits the old FuncValue into two types:

1. The new FuncValue will hold a function from Vertex to Vertex. FuncValue is a Value.
2. A new type named "SimpleFn" will hold a function from Value to Value. SimpleFn is not a Value.

This commit replaces occurrences of the old FuncValue with one of those two new types, as appropriate. This commit does not yet adapt the surrounding code to make use of the new representation; that will be done in future commits. I have annotated the missing parts with the following panic message in order to make it easy to find which parts still need to be implemented. The "..." part explains what needs to be implemented.

    panic("TODO [SimpleFn]: ...");

## Where I need help

One part of the code which is not clear to me are the parts which use reflection. I don't understand the purpose of that code well enough to explain what needs to be implemented. I have annotated those "known unknown" parts of the remaining work with the following panic message in order to make it easy to find which parts still need more thinking and planning:

    panic("TODO [SimpleFn] [Reflect]: ...");
