### PR TITLE
lang: funcs: structs: Register these properly

### DIFF
--- a/lang/funcs/structs/call.go
+++ b/lang/funcs/structs/call.go
@@ -20,6 +20,7 @@ package structs
 import (
 	"fmt"
 
+	"github.com/purpleidea/mgmt/lang/funcs"
 	"github.com/purpleidea/mgmt/lang/interfaces"
 	"github.com/purpleidea/mgmt/lang/types"
 	"github.com/purpleidea/mgmt/util/errwrap"
@@ -29,6 +30,10 @@ const (
 	// CallFuncName is the unique name identifier for this function.
 	CallFuncName = "call"
 )
+
+func init() {
+	funcs.ModuleRegister(ModuleName, CallFuncName, func() interfaces.Func { return &CallFunc{} })
+}
 
 // CallFunc is a function that takes in a function and all the args, and passes
 // through the results of running the function call.

--- a/lang/funcs/structs/composite.go
+++ b/lang/funcs/structs/composite.go
@@ -20,6 +20,7 @@ package structs
 import (
 	"fmt"
 
+	"github.com/purpleidea/mgmt/lang/funcs"
 	"github.com/purpleidea/mgmt/lang/interfaces"
 	"github.com/purpleidea/mgmt/lang/types"
 	"github.com/purpleidea/mgmt/util/errwrap"
@@ -29,6 +30,10 @@ const (
 	// CompositeFuncName is the unique name identifier for this function.
 	CompositeFuncName = "composite"
 )
+
+func init() {
+	funcs.ModuleRegister(ModuleName, CompositeFuncName, func() interfaces.Func { return &CompositeFunc{} })
+}
 
 // CompositeFunc is a function that passes through the value it receives. It is
 // used to take a series of inputs to a list, map or struct, and return that

--- a/lang/funcs/structs/const.go
+++ b/lang/funcs/structs/const.go
@@ -20,6 +20,7 @@ package structs
 import (
 	"fmt"
 
+	"github.com/purpleidea/mgmt/lang/funcs"
 	"github.com/purpleidea/mgmt/lang/interfaces"
 	"github.com/purpleidea/mgmt/lang/types"
 )
@@ -28,6 +29,10 @@ const (
 	// ConstFuncName is the unique name identifier for this function.
 	ConstFuncName = "const"
 )
+
+func init() {
+	funcs.ModuleRegister(ModuleName, ConstFuncName, func() interfaces.Func { return &ConstFunc{} })
+}
 
 // ConstFunc is a function that returns the constant value passed to Value.
 type ConstFunc struct {

--- a/lang/funcs/structs/function.go
+++ b/lang/funcs/structs/function.go
@@ -31,6 +31,10 @@ const (
 	FunctionFuncName = "function"
 )
 
+func init() {
+	funcs.ModuleRegister(ModuleName, FunctionFuncName, func() interfaces.Func { return &FunctionFunc{} })
+}
+
 // FunctionFunc is a function that passes through the function body it receives.
 type FunctionFunc struct {
 	Type *types.Type // this is the type of the function that we hold

--- a/lang/funcs/structs/if.go
+++ b/lang/funcs/structs/if.go
@@ -20,6 +20,7 @@ package structs
 import (
 	"fmt"
 
+	"github.com/purpleidea/mgmt/lang/funcs"
 	"github.com/purpleidea/mgmt/lang/interfaces"
 	"github.com/purpleidea/mgmt/lang/types"
 )
@@ -28,6 +29,10 @@ const (
 	// IfFuncName is the unique name identifier for this function.
 	IfFuncName = "if"
 )
+
+func init() {
+	funcs.ModuleRegister(ModuleName, IfFuncName, func() interfaces.Func { return &IfFunc{} })
+}
 
 // IfFunc is a function that passes through the value of the correct branch
 // based on the conditional value it gets.

--- a/lang/funcs/structs/structs.go
+++ b/lang/funcs/structs/structs.go
@@ -1,0 +1,23 @@
+// Mgmt
+// Copyright (C) 2013-2022+ James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package structs
+
+const (
+	// ModuleName is the prefix given to all the functions in this module.
+	ModuleName = "structs"
+)

--- a/lang/funcs/structs/var.go
+++ b/lang/funcs/structs/var.go
@@ -20,6 +20,7 @@ package structs
 import (
 	"fmt"
 
+	"github.com/purpleidea/mgmt/lang/funcs"
 	"github.com/purpleidea/mgmt/lang/interfaces"
 	"github.com/purpleidea/mgmt/lang/types"
 	//"github.com/purpleidea/mgmt/util/errwrap"
@@ -29,6 +30,10 @@ const (
 	// VarFuncName is the unique name identifier for this function.
 	VarFuncName = "var"
 )
+
+func init() {
+	funcs.ModuleRegister(ModuleName, VarFuncName, func() interfaces.Func { return &VarFunc{} })
+}
 
 // VarFunc is a function that passes through a function that came from a bind
 // lookup. It exists so that the reactive function engine type checks correctly.


### PR DESCRIPTION
If these are registered in the normal function system, perhaps we won't
have future import cycles when we try and use them. Not sure if it can
be made to work, but worth a try.