### PR TITLE
Build mgmt from a Fedora container

### DIFF
--- a/docker/Dockerfile-fedora.build
+++ b/docker/Dockerfile-fedora.build
@@ -1,0 +1,20 @@
+FROM fedora:38
+LABEL org.opencontainers.image.authors="laurent.indermuehle@pm.me"
+
+ENV GOPATH=/root/gopath
+ENV PATH=/root/gopath/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/go/bin:/usr/local/bin
+ENV LD_LIBRARY_PATH=/usr/lib64
+ENV PKG_CONFIG_PATH=/usr/lib64/pkgconfig
+
+# This forces make-deps.sh to install Ragel 6.1 instead of 7.0
+ENV DOCKER=true
+
+RUN dnf -y install wget unzip git make which gcc gcc-c++ ruby golang
+
+RUN mkdir -p $GOPATH/src/github.com/purpleidea
+WORKDIR $GOPATH/src/github.com/purpleidea
+RUN git clone --recursive https://github.com/purpleidea/mgmt mgmt
+WORKDIR $GOPATH/src/github.com/purpleidea/mgmt
+RUN make deps
+RUN make build
+CMD ["/bin/bash"]

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -21,6 +21,8 @@ to build your own.
 
 ### Downloading a pre-built release:
 
+This method is not recommended because those packages are now very old.
+
 The latest releases can be found [here](https://github.com/purpleidea/mgmt/releases/).
 An alternate mirror is available [here](https://dl.fedoraproject.org/pub/alt/purpleidea/mgmt/releases/).
 
@@ -94,6 +96,21 @@ At the moment we have:
 
 Please contribute more and help improve these! We'd especially like to see a
 Debian package!
+
+### Building from a container:
+
+This method avoids polluting your workstation with the dependencies for the
+build. Here is an example using Fedora, Podman and Buildah:
+
+```shell
+git clone --recursive https://github.com/purpleidea/mgmt/ ~/mgmt/
+cd ~/mgmt/docker
+buildah build -f Dockerfile-fedora.build -t mgmt_build
+podman run -d -it --name mgmt_build localhost/mgmt_build
+podman cp mgmt_build:/src/github.com/purpleidea/mgmt/mgmt /tmp/mgmt
+sudo mv /tmp/mgmt /usr/local/bin  # be sure this is in your $PATH
+sudo chown root:root /usr/local/bin/mgmt
+```
 
 ## Running mgmt
 

--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -50,7 +50,10 @@ if [ -n "$YUM" ]; then
 	$sudo_command $YUM install -y augeas-devel
 	$sudo_command $YUM install -y ruby-devel rubygems
 	$sudo_command $YUM install -y time
-	$sudo_command $YUM install -y ragel
+	if ! in_env; then
+		$sudo_command $YUM install -y ragel
+	fi
+
 	# dependencies for building packages with fpm
 	$sudo_command $YUM install -y gcc make rpm-build libffi-devel bsdtar mkosi || true
 	$sudo_command $YUM install -y graphviz || true # for debugging
@@ -61,7 +64,10 @@ if [ -n "$APT" ]; then
 	$sudo_command $APT install -y libaugeas-dev || true
 	$sudo_command $APT install -y ruby ruby-dev || true
 	$sudo_command $APT install -y libpcap0.8-dev || true
-	$sudo_command $APT install -y ragel || true
+	if ! in_env; then
+		$sudo_command $APT install -y ragel || true
+	fi
+
 	# dependencies for building packages with fpm
 	$sudo_command $APT install -y build-essential rpm bsdtar || true
 	# `realpath` is a more universal alternative to `readlink -f` for absolute path resolution
@@ -84,7 +90,7 @@ if [ -n "$PACMAN" ]; then
 fi
 fold_end "Install dependencies"
 
-if ! in_ci; then
+if ! in_env; then
 	if [ -n "$YUM" ]; then
 		if [ -z "$GO" ]; then
 			$sudo_command $YUM install -y golang golang-googlecode-tools-stringer || $sudo_command $YUM install -y golang-bin # centos-7 epel
@@ -107,7 +113,7 @@ if ! in_ci; then
 	fi
 fi
 
-if in_ci; then
+if in_env; then
 	# TODO: consider bumping to new package manager version
 	RAGEL_VERSION='6.10'	# current stable version
 	RAGEL_TMP='/tmp/ragel/'
@@ -150,7 +156,7 @@ cd / && go install golang.org/x/tools/cmd/stringer@latest	# for automatic string
 cd / && go install golang.org/x/lint/golint@latest		# for `golint`-ing
 cd / && go install golang.org/x/tools/cmd/goimports@latest	# for fmt
 cd / && go install github.com/dvyukov/go-fuzz/go-fuzz@latest	# for fuzzing the mcl lang bits
-if in_ci; then
+if in_env; then
 	go get -u gopkg.in/alecthomas/gometalinter.v1 && \
 	mv "$(dirname $(command -v gometalinter.v1))/gometalinter.v1" "$(dirname $(command -v gometalinter.v1))/gometalinter" && \
 	gometalinter --install	# bonus

--- a/test.sh
+++ b/test.sh
@@ -78,7 +78,7 @@ fi
 # run-test ./test/test-crossbuild.sh
 
 # do these longer tests only when running on ci
-if in_ci; then
+if in_env; then
 	if label-block "shell"; then
 		run-testsuite ./test/test-shell.sh
 	fi

--- a/test/shell/etcd-three-hosts-reversed.sh
+++ b/test/shell/etcd-three-hosts-reversed.sh
@@ -2,7 +2,7 @@
 
 . "$(dirname "$0")/../util.sh"
 
-if in_ci github; then
+if in_env github; then
 	# TODO: consider debugging this
 	echo "This is failing in github, skipping test!"
 	exit

--- a/test/shell/etcd-three-hosts.sh
+++ b/test/shell/etcd-three-hosts.sh
@@ -2,7 +2,7 @@
 
 . "$(dirname "$0")/../util.sh"
 
-if in_ci github; then
+if in_env github; then
 	# TODO: consider debugging this
 	echo "This is failing in github, skipping test!"
 	exit

--- a/test/shell/etcd-two-hosts-reversed.sh
+++ b/test/shell/etcd-two-hosts-reversed.sh
@@ -2,7 +2,7 @@
 
 . "$(dirname "$0")/../util.sh"
 
-if in_ci github; then
+if in_env github; then
 	# TODO: consider debugging this (flaky)
 	echo "This is failing in github, skipping test!"
 	exit

--- a/test/shell/etcd-two-hosts.sh
+++ b/test/shell/etcd-two-hosts.sh
@@ -2,7 +2,7 @@
 
 . "$(dirname "$0")/../util.sh"
 
-if in_ci github; then
+if in_env github; then
 	# TODO: consider debugging this (flaky)
 	echo "This is failing in github, skipping test!"
 	exit

--- a/test/shell/exchange.sh
+++ b/test/shell/exchange.sh
@@ -2,7 +2,7 @@
 
 . "$(dirname "$0")/../util.sh"
 
-if in_ci github; then
+if in_env github; then
 	# TODO: consider debugging this
 	echo "This is failing in github, skipping test!"
 	exit

--- a/test/shell/exec-usergroup.sh
+++ b/test/shell/exec-usergroup.sh
@@ -2,7 +2,7 @@
 
 . "$(dirname "$0")/../util.sh"
 
-if in_ci github; then
+if in_env github; then
 	# TODO: consider debugging this
 	echo "This is failing in github, skipping test!"
 	exit

--- a/test/shell/ipv6-localhost.sh
+++ b/test/shell/ipv6-localhost.sh
@@ -10,7 +10,7 @@ if ! ifconfig lo | grep 'inet6 ::1' >/dev/null; then
 	exit 0
 fi
 
-if in_ci github; then
+if in_env github; then
 	# TODO: consider debugging this
 	echo "This is failing in github, skipping test!"
 	exit

--- a/test/shell/net.sh
+++ b/test/shell/net.sh
@@ -2,13 +2,13 @@
 
 . "$(dirname "$0")/../util.sh"
 
-if in_ci travis; then
+if in_env travis; then
 	# this often fails in travis with: `address already in use`
 	echo "Travis gives wonky results here, skipping test!"
 	exit
 fi
 
-if in_ci github; then
+if in_env github; then
 	# TODO: consider debugging this
 	echo "This is failing in github, skipping test!"
 	exit

--- a/test/shell/no-network.sh
+++ b/test/shell/no-network.sh
@@ -2,7 +2,7 @@
 
 . "$(dirname "$0")/../util.sh"
 
-if in_ci github; then
+if in_env github; then
 	# TODO: consider debugging this (flaky)
 	echo "This is failing in github, skipping test!"
 	exit

--- a/test/shell/t2.sh
+++ b/test/shell/t2.sh
@@ -2,7 +2,7 @@
 
 . "$(dirname "$0")/../util.sh"
 
-if in_ci github; then
+if in_env github; then
 	# TODO: consider debugging this
 	echo "This is failing in github, skipping test!"
 	exit

--- a/test/shell/t3.sh
+++ b/test/shell/t3.sh
@@ -2,13 +2,13 @@
 
 . "$(dirname "$0")/../util.sh"
 
-if in_ci travis jenkins; then
+if in_env travis jenkins; then
 	# inotify doesn't seem to work properly on travis
 	echo "Travis and Jenkins give wonky results here, skipping test!"
 	exit
 fi
 
-if in_ci github; then
+if in_env github; then
 	# TODO: consider debugging this
 	echo "This is failing in github, skipping test!"
 	exit

--- a/test/shell/yaml-change1.sh
+++ b/test/shell/yaml-change1.sh
@@ -4,7 +4,7 @@
 
 exit 0	# TODO: this test needs to be updated to use deploys instead
 
-#if in_ci; then
+#if in_env; then
 #	# inotify doesn't seem to work properly on travis
 #	echo "Travis and Jenkins give wonky results here, skipping test!"
 #	exit

--- a/test/test-gotest.sh
+++ b/test/test-gotest.sh
@@ -8,7 +8,7 @@ cd "${ROOT}"
 . test/util.sh
 
 # travis is slow for some reason
-if in_ci travis; then
+if in_env travis; then
 	export GO_TEST_TIMEOUT_SCALE=3
 fi
 

--- a/test/test-yamlfmt.sh
+++ b/test/test-yamlfmt.sh
@@ -13,7 +13,7 @@ ROOT=$(dirname "${BASH_SOURCE}")/..
 cd "${ROOT}"
 . test/util.sh
 
-#if in_ci travis jenkins; then
+#if in_env travis jenkins; then
 #	echo "Travis and Jenkins give wonky results here, skipping test!"
 #	exit 0
 #fi

--- a/test/util.sh
+++ b/test/util.sh
@@ -20,9 +20,9 @@ fi
 
 TIMEOUT="$timeout --kill-after=360s --signal=QUIT 300s"
 
-in_ci() {
+in_env() {
 	if [ $# -eq 0 ]; then
-		test -n "$CI" -o -n "$GITHUB_ACTION" -o -n "$TRAVIS" -o -n "$JENKINS_URL"
+		test -n "$CI" -o -n "$GITHUB_ACTION" -o -n "$TRAVIS" -o -n "$JENKINS_URL" -o -n "$DOCKER"
 		return $?
 	fi
 
@@ -34,6 +34,8 @@ in_ci() {
 			test "$TRAVIS" = "true" && return 0;;
 		jenkins)
 			test -n "$JENKINS_URL" && return 0;;
+		docker)
+			test -n "$DOCKER" && return 0;;
 		*)
 			continue;;
 		esac
@@ -42,7 +44,7 @@ in_ci() {
 }
 
 fail_test() {
-	if in_ci github; then
+	if in_env github; then
 		echo "::error::$@"
 	else
 		echo -e "FAIL: $@"
@@ -57,16 +59,16 @@ function run-test() {
 # travis expander helpers from:
 # https://github.com/travis-ci/travis-rubies/blob/build/build.sh
 fold_start() {
-	if in_ci travis; then
+	if in_env travis; then
 		echo -e "travis_fold:start:$1\033[33;1m${@:2}\033[0m"
-	elif in_ci github; then
+	elif in_env github; then
 		echo "::group::$@"
 	fi
 }
 fold_end() {
-	if in_ci travis; then
+	if in_env travis; then
 		echo -e "\ntravis_fold:end:$1\r"
-	elif in_ci github; then
+	elif in_env github; then
 		echo "::endgroup::"
 	fi
 }


### PR DESCRIPTION
This PR provides a way to build mgmt for Fedora using a container.
When following the [quick start guide](https://github.com/purpleidea/mgmt/blob/master/docs/quick-start-guide.md) for the first time, none of the offered methods to build mgmt worked.

To ensure regel 6.1 is installed instead of the 7.0, I had to refactor test/util.sh and misc/make-deps.sh. This is why the `in_ci` method became `in_env`.

Maybe it would have been better to just rebuild the RPM for latest version of Fedora. But I prefer to use a container to keep my workstation clean. Another idea would be to use github action. 

In the meantime this provide a solution, today, for newcomers.