### PR TITLE
lang/types: Fail build if stringer run from GOROOT

### DIFF
--- a/lang/types/Makefile
+++ b/lang/types/Makefile
@@ -27,6 +27,10 @@ clean:
 
 kind_stringer.go: type.go
 	@echo "Generating: type kind strings..."
-	@# workaround `stringer` regression in golang 1.11
+	@# stringer fails if run from GOROOT.
 	@# see: https://github.com/golang/go/issues/31843
-	@unset GOCACHE && go generate # GOCACHE is returned to normal on exit...
+	@if which stringer | grep `go env GOROOT`; then \
+		echo "stringer cannot run from GOROOT"; \
+		exit 1; \
+	fi
+	@go generate


### PR DESCRIPTION
If stringer is run from GOROOT, it can't find any packages; same error as in https://go.dev/issue/31843. And since GOCACHE is always ignored (see issue above) we can have a bare go generate command.