### PR TITLE
lang: Use `mcl` struct tag instead of `lang`

### DIFF
--- a/docs/resource-guide.md
+++ b/docs/resource-guide.md
@@ -75,8 +75,8 @@ type FooRes struct {
 
 	init *engine.Init
 
-	Whatever string `lang:"whatever" yaml:"whatever"` // you pick!
-	Baz      bool   `lang:"baz" yaml:"baz"`           // something else
+	Whatever string `mcl:"whatever" yaml:"whatever"` // you pick!
+	Baz      bool   `mcl:"baz" yaml:"baz"`           // something else
 
 	something string // some private field
 }

--- a/engine/resources/augeas.go
+++ b/engine/resources/augeas.go
@@ -50,24 +50,24 @@ type AugeasRes struct {
 	init *engine.Init
 
 	// File is the path to the file targeted by this resource.
-	File string `lang:"file" yaml:"file"`
+	File string `mcl:"file" yaml:"file"`
 
 	// Lens is the lens used by this resource. If specified, mgmt
 	// will lower the augeas overhead by only loading that lens.
-	Lens string `lang:"lens" yaml:"lens"`
+	Lens string `mcl:"lens" yaml:"lens"`
 
 	// Sets is a list of changes that will be applied to the file, in the
 	// form of ["path", "value"]. mgmt will run augeas.Get() before
 	// augeas.Set(), to prevent changing the file when it is not needed.
-	Sets []*AugeasSet `lang:"sets" yaml:"sets"`
+	Sets []*AugeasSet `mcl:"sets" yaml:"sets"`
 
 	recWatcher *recwatch.RecWatcher // used to watch the changed files
 }
 
 // AugeasSet represents a key/value pair of settings to be applied.
 type AugeasSet struct {
-	Path  string `lang:"path" yaml:"path"`   // The relative path to the value to be changed.
-	Value string `lang:"value" yaml:"value"` // The value to be set on the given Path.
+	Path  string `mcl:"path" yaml:"path"`   // The relative path to the value to be changed.
+	Value string `mcl:"value" yaml:"value"` // The value to be set on the given Path.
 }
 
 // Cmp compares this set with another one.

--- a/engine/resources/aws_ec2.go
+++ b/engine/resources/aws_ec2.go
@@ -152,37 +152,37 @@ type AwsEc2Res struct {
 	init *engine.Init
 
 	// State must be running, stopped, or terminated.
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 
 	// Region must match one of the AwsRegions. This list is static at the
 	// moment.
-	Region string `lang:"region" yaml:"region"`
+	Region string `mcl:"region" yaml:"region"`
 
 	// Type of ec2 instance, eg: t2.micro for example.
-	Type string `lang:"type" yaml:"type"`
+	Type string `mcl:"type" yaml:"type"`
 
 	// ImageID to use, and note that it must be available on the chosen
 	// region.
-	ImageID string `lang:"imageid" yaml:"imageid"`
+	ImageID string `mcl:"imageid" yaml:"imageid"`
 
 	// WatchEndpoint is the public url of the sns endpoint, eg:
 	// http://server:12345/ for example.
-	WatchEndpoint string `lang:"watchendpoint" yaml:"watchendpoint"`
+	WatchEndpoint string `mcl:"watchendpoint" yaml:"watchendpoint"`
 
 	// WatchListenAddr is the local address or port that the sns listens on,
 	// eg: 10.0.0.0:23456 or 23456.
-	WatchListenAddr string `lang:"watchlistenaddr" yaml:"watchlistenaddr"`
+	WatchListenAddr string `mcl:"watchlistenaddr" yaml:"watchlistenaddr"`
 
 	// ErrorOnMalformedPost controls whether or not malformed HTTP post
 	// requests, that cause JSON decoder errors, will also make the engine
 	// shut down. If ErrorOnMalformedPost set to true and an error occurs,
 	// Watch() will return the error and the engine will shut down.
-	ErrorOnMalformedPost bool `lang:"erroronmalformedpost" yaml:"erroronmalformedpost"`
+	ErrorOnMalformedPost bool `mcl:"erroronmalformedpost" yaml:"erroronmalformedpost"`
 
 	// UserData is used to run bash and cloud-init commands on first launch.
 	// See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html
 	// for documantation and examples.
-	UserData string `lang:"userdata" yaml:"userdata"`
+	UserData string `mcl:"userdata" yaml:"userdata"`
 
 	client *ec2.EC2 // client session for AWS API calls
 

--- a/engine/resources/config_etcd.go
+++ b/engine/resources/config_etcd.go
@@ -47,11 +47,11 @@ type ConfigEtcdRes struct {
 	// set this to zero, it will cause a cluster wide shutdown if
 	// AllowSizeShutdown is true. If it's not true, then it will cause a
 	// validation error.
-	IdealClusterSize uint16 `lang:"idealclustersize"`
+	IdealClusterSize uint16 `mcl:"idealclustersize"`
 	// AllowSizeShutdown is a required safety flag that you must set to true
 	// if you want to allow causing a cluster shutdown by setting
 	// IdealClusterSize to zero.
-	AllowSizeShutdown bool `lang:"allow_size_shutdown"`
+	AllowSizeShutdown bool `mcl:"allow_size_shutdown"`
 
 	// sizeFlag determines whether sizeCheckApply already ran or not.
 	sizeFlag bool

--- a/engine/resources/consul_kv.go
+++ b/engine/resources/consul_kv.go
@@ -46,19 +46,19 @@ type ConsulKVRes struct {
 	init *engine.Init
 
 	// Key is the name of the key. Defaults to the name of the resource.
-	Key string `lang:"key" yaml:"key"`
+	Key string `mcl:"key" yaml:"key"`
 
 	// Value is the value for the key.
-	Value string `lang:"value" yaml:"value"`
+	Value string `mcl:"value" yaml:"value"`
 
 	// Scheme is the URI scheme for the Consul server. Default: http.
-	Scheme string `lang:"scheme" yaml:"scheme"`
+	Scheme string `mcl:"scheme" yaml:"scheme"`
 
 	// Address is the address of the Consul server. Default: 127.0.0.1:8500.
-	Address string `lang:"address" yaml:"address"`
+	Address string `mcl:"address" yaml:"address"`
 
 	// Token is used to provide an ACL token to use for this resource.
-	Token string `lang:"token" yaml:"token"`
+	Token string `mcl:"token" yaml:"token"`
 
 	client *api.Client
 	config *api.Config // needed to close the idle connections

--- a/engine/resources/cron.go
+++ b/engine/resources/cron.go
@@ -87,52 +87,52 @@ type CronRes struct {
 	// Unit is the name of the systemd service unit. It is only necessary to
 	// set if you want to specify a service with a different name than the
 	// resource.
-	Unit string `lang:"unit" yaml:"unit"`
+	Unit string `mcl:"unit" yaml:"unit"`
 
 	// State must be 'exists' or 'absent'.
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 
 	// Session, if true, creates the timer as the current user, rather than
 	// root. The service it points to must also be a user unit. It defaults
 	// to false.
-	Session bool `lang:"session" yaml:"session"`
+	Session bool `mcl:"session" yaml:"session"`
 
 	// Trigger is the type of timer. Valid types are 'OnCalendar',
 	// 'OnActiveSec'. 'OnBootSec'. 'OnStartupSec'. 'OnUnitActiveSec', and
 	// 'OnUnitInactiveSec'. For more information see 'man systemd.timer'.
-	Trigger string `lang:"trigger" yaml:"trigger"`
+	Trigger string `mcl:"trigger" yaml:"trigger"`
 
 	// Time must be used with all triggers. For 'OnCalendar', it must be in
 	// the format defined in 'man systemd-time' under the heading 'Calendar
 	// Events'. For all other triggers, time should be a valid time span as
 	// defined in 'man systemd-time'
-	Time string `lang:"time" yaml:"time"`
+	Time string `mcl:"time" yaml:"time"`
 
 	// AccuracySec is the accuracy of the timer in systemd-time time span
 	// format. It defaults to one minute.
-	AccuracySec string `lang:"accuracysec" yaml:"accuracysec"`
+	AccuracySec string `mcl:"accuracysec" yaml:"accuracysec"`
 
 	// RandomizedDelaySec delays the timer by a randomly selected, evenly
 	// distributed amount of time between 0 and the specified time value.
 	// The value must be a valid systemd-time time span.
-	RandomizedDelaySec string `lang:"randomizeddelaysec" yaml:"randomizeddelaysec"`
+	RandomizedDelaySec string `mcl:"randomizeddelaysec" yaml:"randomizeddelaysec"`
 
 	// Persistent, if true, means the time when the service unit was last
 	// triggered is stored on disk. When the timer is activated, the service
 	// unit is triggered immediately if it would have been triggered at
 	// least once during the time when the timer was inactive. It defaults
 	// to false.
-	Persistent bool `lang:"persistent" yaml:"persistent"`
+	Persistent bool `mcl:"persistent" yaml:"persistent"`
 
 	// WakeSystem, if true, will cause the system to resume from suspend,
 	// should it be suspended and if the system supports this. It defaults
 	// to false.
-	WakeSystem bool `lang:"wakesystem" yaml:"wakesystem"`
+	WakeSystem bool `mcl:"wakesystem" yaml:"wakesystem"`
 
 	// RemainAfterElapse, if true, means an elapsed timer will stay loaded,
 	// and its state remains queriable. If false, an elapsed timer unit that
 	// cannot elapse anymore is unloaded. It defaults to true.
-	RemainAfterElapse bool `lang:"remainafterelapse" yaml:"remainafterelapse"`
+	RemainAfterElapse bool `mcl:"remainafterelapse" yaml:"remainafterelapse"`
 
 	file       *FileRes             // nested file resource
 	recWatcher *recwatch.RecWatcher // recwatcher for nested file

--- a/engine/resources/dhcp.go
+++ b/engine/resources/dhcp.go
@@ -73,13 +73,13 @@ type DHCPServerRes struct {
 	// Address is the listen address to use for the dhcp server. It is
 	// common to use `:67` (the standard) to listen on UDP port 67 on all
 	// addresses.
-	Address string `lang:"address" yaml:"address"`
+	Address string `mcl:"address" yaml:"address"`
 
 	// Interface is interface to bind to. For example `eth0` for the common
 	// case. You may leave this field blank to not run any specific binding.
 	// XXX: You need to actually specify an interface here at the moment. :(
 	// BUG: https://github.com/insomniacslk/dhcp/issues/372
-	Interface string `lang:"interface" yaml:"interface"`
+	Interface string `mcl:"interface" yaml:"interface"`
 
 	// ServerID is a unique IPv4 identifier for this server as specified in
 	// the DHCPv4 protocol. It is almost always the IP address of the DHCP
@@ -92,22 +92,22 @@ type DHCPServerRes struct {
 	// the specified interface, then this only happens at runtime when the
 	// first DHCP request needs this or during CheckApply, either of which
 	// could fail if for some reason it is not available.
-	ServerID *string `lang:"serverid" yaml:"serverid"`
+	ServerID *string `mcl:"serverid" yaml:"serverid"`
 
 	// LeaseTime is the default lease duration in a format that is parseable
 	// by the golang time.ParseDuration function, for example "60s" or "10m"
 	// or "1h42m13s". If it is unspecified, then a default will be used. If
 	// the empty string is specified, then no lease time will be set in the
 	// DHCP protocol, and your DHCP server might not work as you intend.
-	LeaseTime *string `lang:"leasetime" yaml:"leasetime"`
+	LeaseTime *string `mcl:"leasetime" yaml:"leasetime"`
 
 	// DNS represents a list of DNS servers to offer to the DHCP client.
 	// XXX: Is it mandatory? https://github.com/insomniacslk/dhcp/issues/359
-	DNS []string `lang:"dns" yaml:"dns"`
+	DNS []string `mcl:"dns" yaml:"dns"`
 
 	// Routers represents a list of routers to offer to the DHCP client. It
 	// is most common to only specify one unless you know what you're doing.
-	Routers []string `lang:"routers" yaml:"routers"`
+	Routers []string `mcl:"routers" yaml:"routers"`
 
 	// NBP is the network boot program URL. This is used for the tftp server
 	// name and the boot file name. For example, you might use:
@@ -119,7 +119,7 @@ type DHCPServerRes struct {
 	// For DHCPv4, the scheme must be "tftp". This values is used as the
 	// default for all dhcp:host resources. You can specify this here, and
 	// the NBPPath per-resource and they will successfully combine.
-	NBP string `lang:"nbp" yaml:"nbp"`
+	NBP string `mcl:"nbp" yaml:"nbp"`
 
 	// These private fields are ordered in the handler order, the above
 	// public fields are ordered in the human logical order.
@@ -964,17 +964,17 @@ type DHCPHostRes struct {
 	// be grouped into it automatically. If there is more than one main dhcp
 	// resource being used, then the grouping behaviour is *undefined* when
 	// this is not specified, and it is not recommended to leave this blank!
-	Server string `lang:"server" yaml:"server"`
+	Server string `mcl:"server" yaml:"server"`
 
 	// Mac is the mac address of the host in lower case and separated with
 	// colons.
-	Mac string `lang:"mac" yaml:"mac"`
+	Mac string `mcl:"mac" yaml:"mac"`
 
 	// IP is the IPv4 address with the CIDR suffix. The suffix is required
 	// because it specifies the netmask to be used in the DHCPv4 protocol.
 	// For example, you might specify 192.0.2.42/24 which represents a mask
 	// of 255.255.255.0 that will be sent.
-	IP string `lang:"ip" yaml:"ip"`
+	IP string `mcl:"ip" yaml:"ip"`
 
 	// NBP is the network boot program URL. This is used for the tftp server
 	// name and the boot file name. For example, you might use:
@@ -984,13 +984,13 @@ type DHCPHostRes struct {
 	// to specify a "root less" file (common for legacy tftp setups) then
 	// you can use this feature in conjunction with the NBPPath parameter.
 	// For DHCPv4, the scheme must be "tftp".
-	NBP string `lang:"nbp" yaml:"nbp"`
+	NBP string `mcl:"nbp" yaml:"nbp"`
 
 	// NBPPath overrides the path that is sent for the nbp protocols. By
 	// default it is taken from parsing a URL in NBP, but this can override
 	// that. This is useful if you require a path that doesn't start with a
 	// slash. This is sometimes desirable for legacy tftp setups.
-	NBPPath string `lang:"nbp_path" yaml:"nbp_path"`
+	NBPPath string `mcl:"nbp_path" yaml:"nbp_path"`
 
 	ipv4Addr net.IP
 	ipv4Mask net.IPMask

--- a/engine/resources/docker_container.go
+++ b/engine/resources/docker_container.go
@@ -65,27 +65,27 @@ type DockerContainerRes struct {
 	traits.Edgeable
 
 	// State of the container must be running, stopped, or removed.
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 
 	// Image is a docker image, or image:tag.
-	Image string `lang:"image" yaml:"image"`
+	Image string `mcl:"image" yaml:"image"`
 
 	// Cmd is a command, or list of commands to run on the container.
-	Cmd []string `lang:"cmd" yaml:"cmd"`
+	Cmd []string `mcl:"cmd" yaml:"cmd"`
 
 	// Env is a list of environment variables. E.g. ["VAR=val",].
-	Env []string `lang:"env" yaml:"env"`
+	Env []string `mcl:"env" yaml:"env"`
 
 	// Ports is a map of port bindings. E.g. {"tcp" => {80 => 8080},}.
-	Ports map[string]map[int64]int64 `lang:"ports" yaml:"ports"`
+	Ports map[string]map[int64]int64 `mcl:"ports" yaml:"ports"`
 
 	// APIVersion allows you to override the host's default client API
 	// version.
-	APIVersion string `lang:"apiversion" yaml:"apiversion"`
+	APIVersion string `mcl:"apiversion" yaml:"apiversion"`
 
 	// Force, if true, this will destroy and redeploy the container if the
 	// image is incorrect.
-	Force bool `lang:"force" yaml:"force"`
+	Force bool `mcl:"force" yaml:"force"`
 
 	client *client.Client // docker api client
 

--- a/engine/resources/docker_image.go
+++ b/engine/resources/docker_image.go
@@ -56,11 +56,11 @@ type DockerImageRes struct {
 	traits.Edgeable
 
 	// State of the image must be exists or absent.
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 
 	// APIVersion allows you to override the host's default client API
 	// version.
-	APIVersion string `lang:"apiversion" yaml:"apiversion"`
+	APIVersion string `mcl:"apiversion" yaml:"apiversion"`
 
 	image  string         // full image:tag format
 	client *client.Client // docker api client

--- a/engine/resources/exec.go
+++ b/engine/resources/exec.go
@@ -58,73 +58,73 @@ type ExecRes struct {
 	// the dir path doesn't exist. In general, it's best to use the `Args`
 	// field instead of including them here.
 	// XXX: if not using shell, don't allow args here, force them to args!
-	Cmd string `lang:"cmd" yaml:"cmd"`
+	Cmd string `mcl:"cmd" yaml:"cmd"`
 
 	// Args is a list of args to pass to Cmd. This can be used *instead* of
 	// passing the full command and args as a single string to Cmd. It can
 	// only be used when a Shell is *not* specified. The advantage of this
 	// is that you don't have to worry about escape characters.
-	Args []string `lang:"args" yaml:"args"`
+	Args []string `mcl:"args" yaml:"args"`
 
 	// Cwd is the dir to run the command in. If empty, then this will use
 	// the working directory of the calling process. (This process is mgmt,
 	// not the process being run here.)
-	Cwd string `lang:"cwd" yaml:"cwd"`
+	Cwd string `mcl:"cwd" yaml:"cwd"`
 
 	// Shell is the (optional) shell to use to run the cmd. If you specify
 	// this, then you can't use the Args parameter.
-	Shell string `lang:"shell" yaml:"shell"`
+	Shell string `mcl:"shell" yaml:"shell"`
 
 	// Timeout is the number of seconds to wait before sending a Kill to the
 	// running command. If the Kill is received before the process exits,
 	// then this be treated as an error.
-	Timeout uint64 `lang:"timeout" yaml:"timeout"`
+	Timeout uint64 `mcl:"timeout" yaml:"timeout"`
 
 	// Env allows the user to specify environment variables for script
 	// execution. These are taken using a map of format of VAR_NAME -> value.
-	Env map[string]string `lang:"env" yaml:"env"`
+	Env map[string]string `mcl:"env" yaml:"env"`
 
 	// WatchCmd is the command to run to detect event changes. Each line of
 	// output from this command is treated as an event.
-	WatchCmd string `lang:"watchcmd" yaml:"watchcmd"`
+	WatchCmd string `mcl:"watchcmd" yaml:"watchcmd"`
 
 	// WatchCwd is the Cwd for the WatchCmd. See the docs for Cwd.
-	WatchCwd string `lang:"watchcwd" yaml:"watchcwd"`
+	WatchCwd string `mcl:"watchcwd" yaml:"watchcwd"`
 
 	// WatchShell is the Shell for the WatchCmd. See the docs for Shell.
-	WatchShell string `lang:"watchshell" yaml:"watchshell"`
+	WatchShell string `mcl:"watchshell" yaml:"watchshell"`
 
 	// IfCmd is the command that runs to guard against running the Cmd. If
 	// this command succeeds, then Cmd *will* be run. If this command
 	// returns a non-zero result, then the Cmd will not be run. Any error
 	// scenario or timeout will cause the resource to error.
-	IfCmd string `lang:"ifcmd" yaml:"ifcmd"`
+	IfCmd string `mcl:"ifcmd" yaml:"ifcmd"`
 
 	// IfCwd is the Cwd for the IfCmd. See the docs for Cwd.
-	IfCwd string `lang:"ifcwd" yaml:"ifcwd"`
+	IfCwd string `mcl:"ifcwd" yaml:"ifcwd"`
 
 	// IfShell is the Shell for the IfCmd. See the docs for Shell.
-	IfShell string `lang:"ifshell" yaml:"ifshell"`
+	IfShell string `mcl:"ifshell" yaml:"ifshell"`
 
 	// DoneCmd is the command that runs after the regular Cmd runs
 	// successfully. This is a useful pattern to avoid the shelling out to
 	// bash simply to do `$cmd && echo done > /tmp/donefile`. If this
 	// command errors, it behaves as if the normal Cmd had errored.
-	DoneCmd string `lang:"donecmd" yaml:"donecmd"`
+	DoneCmd string `mcl:"donecmd" yaml:"donecmd"`
 
 	// DoneCwd is the Cwd for the DoneCmd. See the docs for Cwd.
-	DoneCwd string `lang:"donecwd" yaml:"donecwd"`
+	DoneCwd string `mcl:"donecwd" yaml:"donecwd"`
 
 	// DoneShell is the Shell for the DoneCmd. See the docs for Shell.
-	DoneShell string `lang:"doneshell" yaml:"doneshell"`
+	DoneShell string `mcl:"doneshell" yaml:"doneshell"`
 
 	// User is the (optional) user to use to execute the command. It is used
 	// for any command being run.
-	User string `lang:"user" yaml:"user"`
+	User string `mcl:"user" yaml:"user"`
 
 	// Group is the (optional) group to use to execute the command. It is
 	// used for any command being run.
-	Group string `lang:"group" yaml:"group"`
+	Group string `mcl:"group" yaml:"group"`
 
 	output *string // all cmd output, read only, do not set!
 	stdout *string // the cmd stdout, read only, do not set!
@@ -785,11 +785,11 @@ func (obj *ExecRes) UIDs() []engine.ResUID {
 // ExecSends is the struct of data which is sent after a successful Apply.
 type ExecSends struct {
 	// Output is the combined stdout and stderr of the command.
-	Output *string `lang:"output"`
+	Output *string `mcl:"output"`
 	// Stdout is the stdout of the command.
-	Stdout *string `lang:"stdout"`
+	Stdout *string `mcl:"stdout"`
 	// Stderr is the stderr of the command.
-	Stderr *string `lang:"stderr"`
+	Stderr *string `mcl:"stderr"`
 }
 
 // Sends represents the default struct of values we can send using Send/Recv.

--- a/engine/resources/file.go
+++ b/engine/resources/file.go
@@ -108,26 +108,26 @@ type FileRes struct {
 	// Path, which defaults to the name if not specified, represents the
 	// destination path for the file or directory being managed. It must be
 	// an absolute path, and as a result must start with a slash.
-	Path string `lang:"path" yaml:"path"`
+	Path string `mcl:"path" yaml:"path"`
 
 	// Dirname is used to override the path dirname. (The directory
 	// portion.)
-	Dirname string `lang:"dirname" yaml:"dirname"`
+	Dirname string `mcl:"dirname" yaml:"dirname"`
 
 	// Basename is used to override the path basename. (The file portion.)
-	Basename string `lang:"basename" yaml:"basename"`
+	Basename string `mcl:"basename" yaml:"basename"`
 
 	// State specifies the desired state of the file. It can be either
 	// `exists` or `absent`. If you do not specify this, we will not be able
 	// to create or remove a file if it might be logical for another
 	// param to require that. Instead it will error. This means that this
 	// field is not implied by specifying some content or a mode.
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 
 	// Content specifies the file contents to use. If this is nil, they are
 	// left undefined. It cannot be combined with the Source or Fragments
 	// parameters.
-	Content *string `lang:"content" yaml:"content"`
+	Content *string `mcl:"content" yaml:"content"`
 
 	// Source specifies the source contents for the file resource. It cannot
 	// be combined with the Content or Fragments parameters. It must be an
@@ -144,7 +144,7 @@ type FileRes struct {
 	// directory, then a directory will be created. If left undefined, and
 	// combined with the Purge option too, then any unmanaged file in this
 	// dir will be removed.
-	Source string `lang:"source" yaml:"source"`
+	Source string `mcl:"source" yaml:"source"`
 
 	// Fragments specifies that the file is built from a list of individual
 	// files. If one of the files is a directory, then the list of files in
@@ -158,19 +158,19 @@ type FileRes struct {
 	// Automatic edges will be added from these fragments. This currently
 	// isn't recursive in that if a fragment is a directory, this only
 	// searches one level deep at the moment.
-	Fragments []string `lang:"fragments" yaml:"fragments"`
+	Fragments []string `mcl:"fragments" yaml:"fragments"`
 
 	// Owner specifies the file owner. You can specify either the string
 	// name, or a string representation of the owner integer uid.
-	Owner string `lang:"owner" yaml:"owner"`
+	Owner string `mcl:"owner" yaml:"owner"`
 
 	// Group specifies the file group. You can specify either the string
 	// name, or a string representation of the group integer gid.
-	Group string `lang:"group" yaml:"group"`
+	Group string `mcl:"group" yaml:"group"`
 
 	// Mode is the mode of the file as a string representation of the octal
 	// form or symbolic form.
-	Mode string `lang:"mode" yaml:"mode"`
+	Mode string `mcl:"mode" yaml:"mode"`
 
 	// Recurse specifies if you want to work recursively on the resource. It
 	// is used when copying a source directory, or to determine if a watch
@@ -178,17 +178,17 @@ type FileRes struct {
 	// if you'd need the parent directories to be made as well. (Analogous
 	// to the `mkdir -p` option.)
 	// FIXME: There are some unimplemented cases where we should look at it.
-	Recurse bool `lang:"recurse" yaml:"recurse"`
+	Recurse bool `mcl:"recurse" yaml:"recurse"`
 
 	// Force must be set if we want to perform an unusual operation, such as
 	// changing a file into a directory or vice-versa.
-	Force bool `lang:"force" yaml:"force"`
+	Force bool `mcl:"force" yaml:"force"`
 
 	// Purge specifies that when true, any unmanaged file in this file
 	// directory will be removed. As a result, this file resource must be a
 	// directory. This isn't particularly meaningful if you don't also set
 	// Recurse to true. This doesn't work with Content or Fragments.
-	Purge bool `lang:"purge" yaml:"purge"`
+	Purge bool `mcl:"purge" yaml:"purge"`
 
 	sha256sum string
 }

--- a/engine/resources/group.go
+++ b/engine/resources/group.go
@@ -46,10 +46,10 @@ type GroupRes struct {
 	init *engine.Init
 
 	// State is `exists` or `absent`.
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 
 	// GID is the group's gid.
-	GID *uint32 `lang:"gid" yaml:"gid"`
+	GID *uint32 `mcl:"gid" yaml:"gid"`
 
 	recWatcher *recwatch.RecWatcher
 }

--- a/engine/resources/hetzner_vm.go
+++ b/engine/resources/hetzner_vm.go
@@ -148,7 +148,7 @@ type HetznerVMRes struct {
 	// a local file or the mgmt deploy, or provide it directly as a string.
 	// NOTE: It must be generated manually via https://console.hetzner.cloud/.
 	// NOTE: This token is usually a 64 character alphanumeric string.
-	APIToken string `lang:"apitoken"`
+	APIToken string `mcl:"apitoken"`
 
 	// State specifies the desired state of the server instance. The supported
 	// options are "" (undefined), "absent", "exists", "off" and "running".
@@ -160,7 +160,7 @@ type HetznerVMRes struct {
 	// NOTE: any other inputs will not pass Validate and result in an error.
 	// NOTE: setting the state of a live server to "absent" will delete all data
 	// and services that are located on that instance! Use with caution.
-	State string `lang:"state"`
+	State string `mcl:"state"`
 
 	// AllowRebuild provides flexible protection against unexpected server
 	// rebuilds. Any changes to the "servertype", "datacenter" or "image" params
@@ -173,7 +173,7 @@ type HetznerVMRes struct {
 	// NOTE: Soft updates related to power and rescue mode are always allowed,
 	// because they are only required for explicit changes to resource fields.
 	// TODO: add AllowReboot if any indirect poweroffs are ever implemented.
-	AllowRebuild string `lang:"allowrebuild"`
+	AllowRebuild string `mcl:"allowrebuild"`
 
 	// ServerType determines the machine type as defined by Hetzner. A complete
 	// and up-to-date list of options must be requested from the Hetzner API,
@@ -184,25 +184,25 @@ type HetznerVMRes struct {
 	// can also be dependent on the selected datacenter.
 	// https://github.com/JefMasereel/hcloud-go-getopts/
 	// TODO: set some kind of cost-based protection policy?
-	ServerType string `lang:"servertype"`
+	ServerType string `mcl:"servertype"`
 
 	// Datacenter determines where the resource is hosted.  A complete and
 	// up-to-date list of options must be requested from the Hetzner API, but
 	// hcloud-go-getopts (url) provides a static reference. The datacenter
 	// options include "nbg1-dc3", "fsn1-dc14", "hel1-dc2" etc.
 	// https://github.com/JefMasereel/hcloud-go-getopts/
-	Datacenter string `lang:"datacenter"`
+	Datacenter string `mcl:"datacenter"`
 
 	// Image determines the operating system to be installed. A complete and
 	// up-to-date list of options must be requested from the Hetzner API, but
 	// hcloud-go-getopts (url) provides a static reference. The image type
 	// options include "centos-7", "ubuntu-18.04", "debian-10" etc.
 	// https://github.com/JefMasereel/hcloud-go-getopts/
-	Image string `lang:"image"`
+	Image string `mcl:"image"`
 
 	// UserData can be used to run commands on the server instance at creation.
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html.
-	UserData string `lang:"userdata"`
+	UserData string `mcl:"userdata"`
 
 	// ServerRescueMode specifies the image type used when enabling rescue mode.
 	// The supported image types are "linux32", "linux64" and "freebsd64".
@@ -211,7 +211,7 @@ type HetznerVMRes struct {
 	// NOTE: rescue mode can not be enabled if the server is absent.
 	// NOTE: Rescue mode can be used to log into the server over SSH and access
 	// the disks when the normal OS has trouble booting on its own.
-	ServerRescueMode string `lang:"serverrescuemode"`
+	ServerRescueMode string `mcl:"serverrescuemode"`
 
 	// ServerRescueSSHKeys can be used to select a subset of keys that should be
 	// enabled for rescue mode operations over SSH. From all SSH keys known to
@@ -221,7 +221,7 @@ type HetznerVMRes struct {
 	// NOTE: live changes to this keylist while rescue mode is already enabled
 	// are not (yet) detected or applied by CheckApply.
 	// TODO: improve ssh key handling at checkApplyRescueMode and serverRebuild.
-	ServerRescueSSHKeys []string `lang:"serverrescuekeys"`
+	ServerRescueSSHKeys []string `mcl:"serverrescuekeys"`
 
 	// WaitInterval is the interval in seconds that is used when waiting for
 	// transient states to converge between intermediate operations. A zero
@@ -231,12 +231,12 @@ type HetznerVMRes struct {
 	// these factors into account: polling rate "Meta:poll", number of active
 	// resources under the same Hetzner project, and the expected rate of param
 	// updates. This will help to prevent rate limit errors.
-	WaitInterval uint32 `lang:"waitinterval"`
+	WaitInterval uint32 `mcl:"waitinterval"`
 
 	// WaitTimeout will cancel wait loops if they do not exit cleanly before
 	// the expected time in seconds, in order to detect defective loops and
 	// avoid unnecessary consumption of computational resources.
-	WaitTimeout uint32 `lang:"waittimeout"`
+	WaitTimeout uint32 `mcl:"waittimeout"`
 
 	// client is required for hcloud-go to interact with the Hetzner API.
 	client *hcloud.Client

--- a/engine/resources/hostname.go
+++ b/engine/resources/hostname.go
@@ -56,22 +56,22 @@ type HostnameRes struct {
 	// fields below. If only this Hostname field is specified, this will set
 	// all tree fields (PrettyHostname, StaticHostname, TransientHostname)
 	// to this value.
-	Hostname string `lang:"hostname" yaml:"hostname"`
+	Hostname string `mcl:"hostname" yaml:"hostname"`
 
 	// PrettyHostname is a free-form UTF8 host name for presentation to the
 	// user.
-	PrettyHostname string `lang:"pretty_hostname" yaml:"pretty_hostname"`
+	PrettyHostname string `mcl:"pretty_hostname" yaml:"pretty_hostname"`
 
 	// StaticHostname is the one configured in /etc/hostname or a similar
 	// file. It is chosen by the local user. It is not always in sync with
 	// the current host name as returned by the gethostname() system call.
-	StaticHostname string `lang:"static_hostname" yaml:"static_hostname"`
+	StaticHostname string `mcl:"static_hostname" yaml:"static_hostname"`
 
 	// TransientHostname is the one configured via the kernel's
 	// sethostbyname(). It can be different from the static hostname in case
 	// DHCP or mDNS have been configured to change the name based on network
 	// information.
-	TransientHostname string `lang:"transient_hostname" yaml:"transient_hostname"`
+	TransientHostname string `mcl:"transient_hostname" yaml:"transient_hostname"`
 
 	conn *dbus.Conn
 }

--- a/engine/resources/http.go
+++ b/engine/resources/http.go
@@ -106,26 +106,26 @@ type HTTPServerRes struct {
 	// Address is the listen address to use for the http server. It is
 	// common to use `:80` (the standard) to listen on TCP port 80 on all
 	// addresses.
-	Address string `lang:"address" yaml:"address"`
+	Address string `mcl:"address" yaml:"address"`
 
 	// Timeout is the maximum duration in seconds to use for unspecified
 	// timeouts. In other words, when this value is specified, it is used as
 	// the value for the other *Timeout values when they aren't used. Put
 	// another way, this makes it easy to set all the different timeouts
 	// with a single parameter.
-	Timeout *uint64 `lang:"timeout" yaml:"timeout"`
+	Timeout *uint64 `mcl:"timeout" yaml:"timeout"`
 
 	// ReadTimeout is the maximum duration in seconds for reading during the
 	// http request. If it is zero, then there is no timeout. If this is
 	// unspecified, then the value of Timeout is used instead if it is set.
 	// For more information, see the golang net/http Server documentation.
-	ReadTimeout *uint64 `lang:"read_timeout" yaml:"read_timeout"`
+	ReadTimeout *uint64 `mcl:"read_timeout" yaml:"read_timeout"`
 
 	// WriteTimeout is the maximum duration in seconds for writing during
 	// the http request. If it is zero, then there is no timeout. If this is
 	// unspecified, then the value of Timeout is used instead if it is set.
 	// For more information, see the golang net/http Server documentation.
-	WriteTimeout *uint64 `lang:"write_timeout" yaml:"write_timeout"`
+	WriteTimeout *uint64 `mcl:"write_timeout" yaml:"write_timeout"`
 
 	// ShutdownTimeout is the maximum duration in seconds to wait for the
 	// server to shutdown gracefully before calling Close. By default it is
@@ -136,13 +136,13 @@ type HTTPServerRes struct {
 	// indefinitely. The shutdown process can also be cancelled by the
 	// interrupt handler which this resource supports. If this is
 	// unspecified, then the value of Timeout is used instead if it is set.
-	ShutdownTimeout *uint64 `lang:"shutdown_timeout" yaml:"shutdown_timeout"`
+	ShutdownTimeout *uint64 `mcl:"shutdown_timeout" yaml:"shutdown_timeout"`
 
 	// Root is the root directory that we should serve files from. If it is
 	// not specified, then it is not used. Any http file resources will have
 	// precedence over anything in here, in case the same path exists twice.
 	// TODO: should we have a flag to determine the precedence rules here?
-	Root string `lang:"root" yaml:"root"`
+	Root string `mcl:"root" yaml:"root"`
 
 	// TODO: should we allow adding a list of one-of files directly here?
 
@@ -825,23 +825,23 @@ type HTTPFileRes struct {
 	// be grouped into it automatically. If there is more than one main http
 	// resource being used, then the grouping behaviour is *undefined* when
 	// this is not specified, and it is not recommended to leave this blank!
-	Server string `lang:"server" yaml:"server"`
+	Server string `mcl:"server" yaml:"server"`
 
 	// Filename is the name of the file this data should appear as on the
 	// http server.
-	Filename string `lang:"filename" yaml:"filename"`
+	Filename string `mcl:"filename" yaml:"filename"`
 
 	// Path is the absolute path to a file that should be used as the source
 	// for this file resource. It must not be combined with the data field.
 	// If this corresponds to a directory, then it will used as a root dir
 	// that will be served as long as the resource name or Filename are also
 	// a directory ending with a slash.
-	Path string `lang:"path" yaml:"path"`
+	Path string `mcl:"path" yaml:"path"`
 
 	// Data is the file content that should be used as the source for this
 	// file resource. It must not be combined with the path field.
 	// TODO: should this be []byte instead?
-	Data string `lang:"data" yaml:"data"`
+	Data string `mcl:"data" yaml:"data"`
 }
 
 // Default returns some sensible defaults for this resource.

--- a/engine/resources/http_flag.go
+++ b/engine/resources/http_flag.go
@@ -58,16 +58,16 @@ type HTTPFlagRes struct {
 	// be grouped into it automatically. If there is more than one main http
 	// resource being used, then the grouping behaviour is *undefined* when
 	// this is not specified, and it is not recommended to leave this blank!
-	Server string `lang:"server" yaml:"server"`
+	Server string `mcl:"server" yaml:"server"`
 
 	// Path is the path that this will present as on the http server.
-	Path string `lang:"path" yaml:"path"`
+	Path string `mcl:"path" yaml:"path"`
 
 	// Key is the querystring name that is used to capture a value as.
-	Key string `lang:"key" yaml:"key"`
+	Key string `mcl:"key" yaml:"key"`
 
 	// TODO: consider adding a method selection field
-	//Method string `lang:"method" yaml:"method"`
+	//Method string `mcl:"method" yaml:"method"`
 
 	mutex         *sync.Mutex // guard the value
 	value         *string     // cached value
@@ -302,7 +302,7 @@ func (obj *HTTPFlagRes) Cmp(r engine.Res) error {
 // HTTPFlagSends is the struct of data which is sent after a successful Apply.
 type HTTPFlagSends struct {
 	// Value is the received value being sent.
-	Value *string `lang:"value"`
+	Value *string `mcl:"value"`
 }
 
 // Sends represents the default struct of values we can send using Send/Recv.

--- a/engine/resources/kv.go
+++ b/engine/resources/kv.go
@@ -66,11 +66,11 @@ type KVRes struct {
 
 	// Key represents the key to set. If it is not specified, the Name value
 	// is used instead.
-	Key string `lang:"key" yaml:"key"`
+	Key string `mcl:"key" yaml:"key"`
 
 	// Value represents the string value to set. If this value is nil or,
 	// undefined, then this will delete that key.
-	Value *string `lang:"value" yaml:"value"`
+	Value *string `mcl:"value" yaml:"value"`
 
 	// Mapped specifies that we will store the value in a map with each
 	// hostname as part of the key. This is very useful for exchanging
@@ -85,11 +85,11 @@ type KVRes struct {
 	Mapped bool
 
 	// SkipLessThan causes the value to be updated as long as it is greater.
-	SkipLessThan bool `lang:"skiplessthan" yaml:"skiplessthan"`
+	SkipLessThan bool `mcl:"skiplessthan" yaml:"skiplessthan"`
 
 	// SkipCmpStyle is the type of compare function used when determining if
 	// the value is greater when using the SkipLessThan parameter.
-	SkipCmpStyle KVResSkipCmpStyle `lang:"skipcmpstyle" yaml:"skipcmpstyle"`
+	SkipCmpStyle KVResSkipCmpStyle `mcl:"skipcmpstyle" yaml:"skipcmpstyle"`
 
 	interruptChan chan struct{}
 

--- a/engine/resources/mount.go
+++ b/engine/resources/mount.go
@@ -110,22 +110,22 @@ type MountRes struct {
 
 	// State must be exists or absent. If absent, remaining fields are
 	// ignored.
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 
 	// Device is the location of the device or image.
-	Device string `lang:"device" yaml:"device"`
+	Device string `mcl:"device" yaml:"device"`
 
 	// Type of the filesystem.
-	Type string `lang:"type" yaml:"type"`
+	Type string `mcl:"type" yaml:"type"`
 
 	// Options are mount options.
-	Options map[string]string `lang:"options" yaml:"options"`
+	Options map[string]string `mcl:"options" yaml:"options"`
 
 	// Freq is the dump frequency.
-	Freq int `lang:"freq" yaml:"freq"`
+	Freq int `mcl:"freq" yaml:"freq"`
 
 	// PassNo is the verification order.
-	PassNo int `lang:"passno" yaml:"passno"`
+	PassNo int `mcl:"passno" yaml:"passno"`
 
 	mount *fstab.Mount // struct representing the mount
 }

--- a/engine/resources/msg.go
+++ b/engine/resources/msg.go
@@ -40,16 +40,16 @@ type MsgRes struct {
 
 	init *engine.Init
 
-	Body     string            `lang:"body" yaml:"body"`
-	Priority string            `lang:"priority" yaml:"priority"`
-	Fields   map[string]string `lang:"fields" yaml:"fields"`
+	Body     string            `mcl:"body" yaml:"body"`
+	Priority string            `mcl:"priority" yaml:"priority"`
+	Fields   map[string]string `mcl:"fields" yaml:"fields"`
 
 	// Journal should be true to enable systemd journaled (journald) output.
-	Journal bool `lang:"journal" yaml:"journal"`
+	Journal bool `mcl:"journal" yaml:"journal"`
 
 	// Syslog should be true to enable traditional syslog output. This is
 	// probably going to somewhere in `/var/log/` on your filesystem.
-	Syslog bool `lang:"syslog" yaml:"syslog"`
+	Syslog bool `mcl:"syslog" yaml:"syslog"`
 
 	logStateOK     bool
 	journalStateOK bool

--- a/engine/resources/net.go
+++ b/engine/resources/net.go
@@ -138,20 +138,20 @@ type NetRes struct {
 
 	// State is the desired state of the interface. It can be "up", "down",
 	// or the empty string to leave that unspecified.
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 
 	// Addrs is the list of addresses to set on the interface. They must
 	// each be in CIDR notation such as: 192.0.2.42/24 for example.
-	Addrs []string `lang:"addrs" yaml:"addrs"`
+	Addrs []string `mcl:"addrs" yaml:"addrs"`
 
 	// Gateway represents the default route to set for the interface.
-	Gateway string `lang:"gateway" yaml:"gateway"`
+	Gateway string `mcl:"gateway" yaml:"gateway"`
 
 	// IPForward is a boolean that sets whether we should forward incoming
 	// packets onward when this is set. It default to unspecified, which
 	// downstream (in the systemd-networkd configuration) defaults to false.
 	// XXX: this could also be "ipv4" or "ipv6", add those as a second option?
-	IPForward *bool `lang:"ip_forward" yaml:"ip_forward"`
+	IPForward *bool `mcl:"ip_forward" yaml:"ip_forward"`
 
 	iface        *iface // a struct containing the net.Interface and netlink.Link
 	unitFilePath string // the interface unit file path

--- a/engine/resources/noop.go
+++ b/engine/resources/noop.go
@@ -37,7 +37,7 @@ type NoopRes struct {
 
 	init *engine.Init
 
-	Comment string `lang:"comment" yaml:"comment"` // extra field for example purposes
+	Comment string `mcl:"comment" yaml:"comment"` // extra field for example purposes
 }
 
 // Default returns some sensible defaults for this resource.

--- a/engine/resources/nspawn.go
+++ b/engine/resources/nspawn.go
@@ -60,7 +60,7 @@ type NspawnRes struct {
 
 	// State specifies the desired state for this resource. This must be
 	// either `running` or `stopped`.
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 
 	// We're using the svc resource to start and stop the machine because
 	// that's what machinectl does. We're not using svc.Watch because then we

--- a/engine/resources/password.go
+++ b/engine/resources/password.go
@@ -55,17 +55,17 @@ type PasswordRes struct {
 
 	// Length is the number of characters to return.
 	// FIXME: is uint16 too big?
-	Length uint16 `lang:"length" yaml:"length"`
+	Length uint16 `mcl:"length" yaml:"length"`
 
 	// Saved caches the password in the clear locally.
-	Saved bool `lang:"saved" yaml:"saved"`
+	Saved bool `mcl:"saved" yaml:"saved"`
 
 	// CheckRecovery specifies that we should recover from, regenerate, and
 	// carry on casually without erroring the resource if the "check"
 	// facility fails. This can happen when loading a saved password from
 	// disk which is not of the expected length. In this case, we'd discard
 	// the old saved password and create a new one without erroring.
-	CheckRecovery bool `lang:"check_recovery" yaml:"check_recovery"`
+	CheckRecovery bool `mcl:"check_recovery" yaml:"check_recovery"`
 
 	path       string // the path to local storage
 	recWatcher *recwatch.RecWatcher
@@ -345,7 +345,7 @@ func (obj *PasswordRes) UIDs() []engine.ResUID {
 // PasswordSends is the struct of data which is sent after a successful Apply.
 type PasswordSends struct {
 	// Password is the generated password being sent.
-	Password *string `lang:"password"`
+	Password *string `mcl:"password"`
 	// Hashing is the algorithm used for this password. Empty is plain text.
 	Hashing string // TODO: implement me
 }

--- a/engine/resources/pippet.go
+++ b/engine/resources/pippet.go
@@ -52,17 +52,17 @@ type PippetRes struct {
 	// from a module. The Puppet installation local to the mgmt agent
 	// machine must be able recognize it. It has to be a native type though,
 	// as opposed to defined types from your Puppet manifest code.
-	Type string `lang:"type" yaml:"type" json:"type"`
+	Type string `mcl:"type" yaml:"type" json:"type"`
 
 	// Title is used by Puppet as the resource title. Puppet will often
 	// assign special meaning to the title, e.g. use it as the path for a
 	// file resource, or the name of a package.
-	Title string `lang:"title" yaml:"title" json:"title"`
+	Title string `mcl:"title" yaml:"title" json:"title"`
 
 	// Params is expected to be a hash in YAML format, pairing resource
 	// parameter names with their respective values, e.g. { ensure: present
 	// }
-	Params string `lang:"params" yaml:"params" json:"params"`
+	Params string `mcl:"params" yaml:"params" json:"params"`
 
 	runner *pippetReceiver
 }

--- a/engine/resources/pkg.go
+++ b/engine/resources/pkg.go
@@ -60,20 +60,20 @@ type PkgRes struct {
 	// what version we want to pin if any. Valid values include: installed,
 	// uninstalled, newest, and `version`, where you just put the raw
 	// version string desired.
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 
 	// AllowUntrusted specifies if we want to allow untrusted packages to be
 	// installed. Please see the PackageKit documentation for more
 	// information.
-	AllowUntrusted bool `lang:"allowuntrusted" yaml:"allowuntrusted"`
+	AllowUntrusted bool `mcl:"allowuntrusted" yaml:"allowuntrusted"`
 
 	// AllowNonFree specifies if we want to allow nonfree packages to be
 	// found? Please see the PackageKit documentation for more information.
-	AllowNonFree bool `lang:"allownonfree" yaml:"allownonfree"`
+	AllowNonFree bool `mcl:"allownonfree" yaml:"allownonfree"`
 
 	// AllowUnsupported specifies if we want to unsupported packages to be
 	// found? Please see the PackageKit documentation for more information.
-	AllowUnsupported bool `lang:"allowunsupported" yaml:"allowunsupported"`
+	AllowUnsupported bool `mcl:"allowunsupported" yaml:"allowunsupported"`
 
 	//bus              *packagekit.Conn    // pk bus connection
 	fileList []string // FIXME: update if pkg changes

--- a/engine/resources/print.go
+++ b/engine/resources/print.go
@@ -40,11 +40,11 @@ type PrintRes struct {
 
 	init *engine.Init
 
-	Msg string `lang:"msg" yaml:"msg"` // the message to display
+	Msg string `mcl:"msg" yaml:"msg"` // the message to display
 	// RefreshOnly is an option that causes the message to be printed only
 	// when notified by another resource. When set to true, this resource
 	// cannot be autogrouped.
-	RefreshOnly bool `lang:"refresh_only" yaml:"refresh_only"`
+	RefreshOnly bool `mcl:"refresh_only" yaml:"refresh_only"`
 }
 
 // Default returns some sensible defaults for this resource.

--- a/engine/resources/svc.go
+++ b/engine/resources/svc.go
@@ -51,15 +51,15 @@ type SvcRes struct {
 
 	// State is the desired state for this resource. Valid values include:
 	// running, stopped, and undefined (empty string).
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 
 	// Startup specifies what should happen on startup. Values can be:
 	// enabled, disabled, and undefined (empty string).
-	Startup string `lang:"startup" yaml:"startup"`
+	Startup string `mcl:"startup" yaml:"startup"`
 
 	// Session specifies if this is for a system service (false) or a user
 	// session specific service (true).
-	Session bool `lang:"session" yaml:"session"` // user session (true) or system?
+	Session bool `mcl:"session" yaml:"session"` // user session (true) or system?
 }
 
 // Default returns some sensible defaults for this resource.

--- a/engine/resources/test.go
+++ b/engine/resources/test.go
@@ -42,66 +42,66 @@ type TestRes struct {
 
 	init *engine.Init
 
-	Bool bool   `lang:"bool" yaml:"bool"`
-	Str  string `lang:"str" yaml:"str"` // can't name it String because of String()
+	Bool bool   `mcl:"bool" yaml:"bool"`
+	Str  string `mcl:"str" yaml:"str"` // can't name it String because of String()
 
-	Int   int   `lang:"int" yaml:"int"`
-	Int8  int8  `lang:"int8" yaml:"int8"`
-	Int16 int16 `lang:"int16" yaml:"int16"`
-	Int32 int32 `lang:"int32" yaml:"int32"`
-	Int64 int64 `lang:"int64" yaml:"int64"`
+	Int   int   `mcl:"int" yaml:"int"`
+	Int8  int8  `mcl:"int8" yaml:"int8"`
+	Int16 int16 `mcl:"int16" yaml:"int16"`
+	Int32 int32 `mcl:"int32" yaml:"int32"`
+	Int64 int64 `mcl:"int64" yaml:"int64"`
 
-	Uint   uint   `lang:"uint" yaml:"uint"`
-	Uint8  uint8  `lang:"uint8" yaml:"uint8"`
-	Uint16 uint16 `lang:"uint16" yaml:"uint16"`
-	Uint32 uint32 `lang:"uint32" yaml:"uint32"`
-	Uint64 uint64 `lang:"uint64" yaml:"uint64"`
+	Uint   uint   `mcl:"uint" yaml:"uint"`
+	Uint8  uint8  `mcl:"uint8" yaml:"uint8"`
+	Uint16 uint16 `mcl:"uint16" yaml:"uint16"`
+	Uint32 uint32 `mcl:"uint32" yaml:"uint32"`
+	Uint64 uint64 `mcl:"uint64" yaml:"uint64"`
 
-	//Uintptr uintptr `lang:"uintptr" yaml:"uintptr"`
-	Byte byte `lang:"byte" yaml:"byte"` // alias for uint8
-	Rune rune `lang:"rune" yaml:"rune"` // alias for int32, represents a Unicode code point
+	//Uintptr uintptr `mcl:"uintptr" yaml:"uintptr"`
+	Byte byte `mcl:"byte" yaml:"byte"` // alias for uint8
+	Rune rune `mcl:"rune" yaml:"rune"` // alias for int32, represents a Unicode code point
 
-	Float32    float32    `lang:"float32" yaml:"float32"`
-	Float64    float64    `lang:"float64" yaml:"float64"`
-	Complex64  complex64  `lang:"complex64" yaml:"complex64"`
-	Complex128 complex128 `lang:"complex128" yaml:"complex128"`
+	Float32    float32    `mcl:"float32" yaml:"float32"`
+	Float64    float64    `mcl:"float64" yaml:"float64"`
+	Complex64  complex64  `mcl:"complex64" yaml:"complex64"`
+	Complex128 complex128 `mcl:"complex128" yaml:"complex128"`
 
-	BoolPtr   *bool   `lang:"boolptr" yaml:"bool_ptr"`
-	StringPtr *string `lang:"stringptr" yaml:"string_ptr"` // TODO: tag name?
-	Int64Ptr  *int64  `lang:"int64ptr" yaml:"int64ptr"`
-	Int8Ptr   *int8   `lang:"int8ptr" yaml:"int8ptr"`
-	Uint8Ptr  *uint8  `lang:"uint8ptr" yaml:"uint8ptr"`
+	BoolPtr   *bool   `mcl:"boolptr" yaml:"bool_ptr"`
+	StringPtr *string `mcl:"stringptr" yaml:"string_ptr"` // TODO: tag name?
+	Int64Ptr  *int64  `mcl:"int64ptr" yaml:"int64ptr"`
+	Int8Ptr   *int8   `mcl:"int8ptr" yaml:"int8ptr"`
+	Uint8Ptr  *uint8  `mcl:"uint8ptr" yaml:"uint8ptr"`
 
 	// probably makes no sense, but is legal
-	Int8PtrPtrPtr ***int8 `lang:"int8ptrptrptr" yaml:"int8ptrptrptr"`
+	Int8PtrPtrPtr ***int8 `mcl:"int8ptrptrptr" yaml:"int8ptrptrptr"`
 
-	SliceString []string          `lang:"slicestring" yaml:"slicestring"`
-	MapIntFloat map[int64]float64 `lang:"mapintfloat" yaml:"mapintfloat"`
+	SliceString []string          `mcl:"slicestring" yaml:"slicestring"`
+	MapIntFloat map[int64]float64 `mcl:"mapintfloat" yaml:"mapintfloat"`
 	MixedStruct struct {
-		SomeBool         bool    `lang:"somebool" yaml:"somebool"`
-		SomeStr          string  `lang:"somestr" yaml:"somestr"`
-		SomeInt          int64   `lang:"someint" yaml:"someint"`
-		SomeFloat        float64 `lang:"somefloat" yaml:"somefloat"`
+		SomeBool         bool    `mcl:"somebool" yaml:"somebool"`
+		SomeStr          string  `mcl:"somestr" yaml:"somestr"`
+		SomeInt          int64   `mcl:"someint" yaml:"someint"`
+		SomeFloat        float64 `mcl:"somefloat" yaml:"somefloat"`
 		somePrivatefield string
-	} `lang:"mixedstruct" yaml:"mixedstruct"`
-	Interface interface{} `lang:"interface" yaml:"interface"`
+	} `mcl:"mixedstruct" yaml:"mixedstruct"`
+	Interface interface{} `mcl:"interface" yaml:"interface"`
 
-	AnotherStr string `lang:"anotherstr" yaml:"anotherstr"`
+	AnotherStr string `mcl:"anotherstr" yaml:"anotherstr"`
 
 	// Func1 passes the value 42 to the input and returns a string.
-	Func1 func(int) string `lang:"func1" yaml:"func1"`
+	Func1 func(int) string `mcl:"func1" yaml:"func1"`
 
-	ValidateBool  bool      `lang:"validatebool" yaml:"validate_bool"`   // set to true to cause a validate error
-	ValidateError string    `lang:"validateerror" yaml:"validate_error"` // set to cause a validate error
-	AlwaysGroup   bool      `lang:"alwaysgroup" yaml:"always_group"`     // set to true to cause auto grouping
-	CompareFail   bool      `lang:"comparefail" yaml:"compare_fail"`     // will compare fail?
-	SendValue     string    `lang:"sendvalue" yaml:"send_value"`         // what value should we send?
-	ExpectRecv    *[]string `lang:"expectrecv" yaml:"expect_recv"`       // what keys should we expect from send/recv?
-	OnlyShow      []string  `lang:"onlyshow" yaml:"only_show"`           // what values do we show?
+	ValidateBool  bool      `mcl:"validatebool" yaml:"validate_bool"`   // set to true to cause a validate error
+	ValidateError string    `mcl:"validateerror" yaml:"validate_error"` // set to cause a validate error
+	AlwaysGroup   bool      `mcl:"alwaysgroup" yaml:"always_group"`     // set to true to cause auto grouping
+	CompareFail   bool      `mcl:"comparefail" yaml:"compare_fail"`     // will compare fail?
+	SendValue     string    `mcl:"sendvalue" yaml:"send_value"`         // what value should we send?
+	ExpectRecv    *[]string `mcl:"expectrecv" yaml:"expect_recv"`       // what keys should we expect from send/recv?
+	OnlyShow      []string  `mcl:"onlyshow" yaml:"only_show"`           // what values do we show?
 
 	// TODO: add more fun properties!
 
-	Comment string `lang:"comment" yaml:"comment"`
+	Comment string `mcl:"comment" yaml:"comment"`
 }
 
 // Default returns some sensible defaults for this resource.
@@ -440,8 +440,8 @@ func (obj *TestRes) GroupCmp(r engine.GroupableRes) error {
 // TestSends is the struct of data which is sent after a successful Apply.
 type TestSends struct {
 	// Hello is some value being sent.
-	Hello  *string `lang:"hello" yaml:"hello"`
-	Answer int     `lang:"answer" yaml:"answer"` // some other value being sent
+	Hello  *string `mcl:"hello" yaml:"hello"`
+	Answer int     `mcl:"answer" yaml:"answer"` // some other value being sent
 }
 
 // Sends represents the default struct of values we can send using Send/Recv.

--- a/engine/resources/test_test.go
+++ b/engine/resources/test_test.go
@@ -29,10 +29,10 @@ import (
 func TestStructTagToFieldName0(t *testing.T) {
 	type TestStruct struct {
 		TestRes        // so that this struct implements `Res`
-		Alpha   bool   `lang:"alpha" yaml:"nope"`
+		Alpha   bool   `mcl:"alpha" yaml:"nope"`
 		Beta    string `yaml:"beta"`
 		Gamma   string
-		Delta   int `lang:"surprise"`
+		Delta   int `mcl:"surprise"`
 	}
 
 	mapping, err := engineUtil.StructTagToFieldName(&TestStruct{})
@@ -71,7 +71,7 @@ func TestLowerStructFieldNameToFieldName0(t *testing.T) {
 	}
 
 	expected := map[string]string{
-		"testres": "TestRes", // hide by specifying `lang:""` on it
+		"testres": "TestRes", // hide by specifying `mcl:""` on it
 		"alpha":   "Alpha",
 		//"skipme": "skipMe",
 		"beta":      "Beta",

--- a/engine/resources/tftp.go
+++ b/engine/resources/tftp.go
@@ -69,16 +69,16 @@ type TFTPServerRes struct {
 	// Address is the listen address to use for the tftp server. It is
 	// common to use `:69` (the standard) to listen on UDP port 69 on all
 	// addresses.
-	Address string `lang:"address" yaml:"address"`
+	Address string `mcl:"address" yaml:"address"`
 
 	// Timeout is the timeout in seconds to use for server connections.
-	Timeout uint64 `lang:"timeout" yaml:"timeout"`
+	Timeout uint64 `mcl:"timeout" yaml:"timeout"`
 
 	// Root is the root directory that we should serve files from. If it is
 	// not specified, then it is not used. Any tftp file resources will have
 	// precedence over anything in here, in case the same path exists twice.
 	// TODO: should we have a flag to determine the precedence rules here?
-	Root string `lang:"root" yaml:"root"`
+	Root string `mcl:"root" yaml:"root"`
 
 	// TODO: should we allow adding a list of one-of files directly here?
 }
@@ -466,20 +466,20 @@ type TFTPFileRes struct {
 	// be grouped into it automatically. If there is more than one main tftp
 	// resource being used, then the grouping behaviour is *undefined* when
 	// this is not specified, and it is not recommended to leave this blank!
-	Server string `lang:"server" yaml:"server"`
+	Server string `mcl:"server" yaml:"server"`
 
 	// Filename is the name of the file this data should appear as on the
 	// tftp server.
-	Filename string `lang:"filename" yaml:"filename"`
+	Filename string `mcl:"filename" yaml:"filename"`
 
 	// Path is the absolute path to a file that should be used as the source
 	// for this file resource. It must not be combined with the data field.
-	Path string `lang:"path" yaml:"path"`
+	Path string `mcl:"path" yaml:"path"`
 
 	// Data is the file content that should be used as the source for this
 	// file resource. It must not be combined with the path field.
 	// TODO: should this be []byte instead?
-	Data string `lang:"data" yaml:"data"`
+	Data string `mcl:"data" yaml:"data"`
 }
 
 // Default returns some sensible defaults for this resource.

--- a/engine/resources/timer.go
+++ b/engine/resources/timer.go
@@ -39,7 +39,7 @@ type TimerRes struct {
 	init *engine.Init
 
 	// Interval between runs in seconds.
-	Interval uint32 `lang:"interval" yaml:"interval"`
+	Interval uint32 `mcl:"interval" yaml:"interval"`
 
 	ticker *time.Ticker
 }

--- a/engine/resources/user.go
+++ b/engine/resources/user.go
@@ -48,28 +48,28 @@ type UserRes struct {
 	init *engine.Init
 
 	// State is either exists or absent.
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 
 	// UID specifies the usually unique user ID. It must be unique unless
 	// AllowDuplicateUID is true.
-	UID *uint32 `lang:"uid" yaml:"uid"`
+	UID *uint32 `mcl:"uid" yaml:"uid"`
 
 	// GID of the user's primary group.
-	GID *uint32 `lang:"gid" yaml:"gid"`
+	GID *uint32 `mcl:"gid" yaml:"gid"`
 
 	// Group is the name of the user's primary group.
-	Group *string `lang:"group" yaml:"group"`
+	Group *string `mcl:"group" yaml:"group"`
 
 	// Groups are a list of supplemental groups.
-	Groups []string `lang:"groups" yaml:"groups"`
+	Groups []string `mcl:"groups" yaml:"groups"`
 
 	// HomeDir is the path to the user's home directory.
-	HomeDir *string `lang:"homedir" yaml:"homedir"`
+	HomeDir *string `mcl:"homedir" yaml:"homedir"`
 
 	// AllowDuplicateUID is needed for a UID to be non-unique. This is rare
 	// but happens if you want more than one username to access the
 	// resources of the same UID. See the --non-unique flag in `useradd`.
-	AllowDuplicateUID bool `lang:"allowduplicateuid" yaml:"allowduplicateuid"`
+	AllowDuplicateUID bool `mcl:"allowduplicateuid" yaml:"allowduplicateuid"`
 
 	recWatcher *recwatch.RecWatcher
 }

--- a/engine/resources/value.go
+++ b/engine/resources/value.go
@@ -53,7 +53,7 @@ type ValueRes struct {
 	// received value overwrites this value for the lifetime of the
 	// resource. It is interface{} because it can hold any type. It has
 	// pointer because it is only set if an actual value exists.
-	Any *interface{} `lang:"any" yaml:"any"`
+	Any *interface{} `mcl:"any" yaml:"any"`
 
 	// Store specifies that we should store this value locally in our cache,
 	// so that if we have a cold startup, that it comes back instantly, even
@@ -212,7 +212,7 @@ type ValueSends struct {
 	// Any is the generated value being sent. It is interface{} because it
 	// can hold any type. It has pointer because it is only set if an actual
 	// value is actually being sent.
-	Any *interface{} `lang:"any"`
+	Any *interface{} `mcl:"any"`
 }
 
 // Sends represents the default struct of values we can send using Send/Recv.

--- a/engine/resources/virt.go
+++ b/engine/resources/virt.go
@@ -75,45 +75,45 @@ type VirtRes struct {
 	init *engine.Init
 
 	// URI is the libvirt connection URI, eg: `qemu:///session`.
-	URI string `lang:"uri" yaml:"uri"`
+	URI string `mcl:"uri" yaml:"uri"`
 	// State is the desired vm state. Possible values include: `running`,
 	// `paused` and `shutoff`.
-	State string `lang:"state" yaml:"state"`
+	State string `mcl:"state" yaml:"state"`
 	// Transient is whether the vm is defined (false) or undefined (true).
-	Transient bool `lang:"transient" yaml:"transient"`
+	Transient bool `mcl:"transient" yaml:"transient"`
 
 	// CPUs is the desired cpu count of the machine.
-	CPUs uint `lang:"cpus" yaml:"cpus"`
+	CPUs uint `mcl:"cpus" yaml:"cpus"`
 	// MaxCPUs is the maximum number of cpus allowed in the machine. You
 	// need to set this so that on boot the `hardware` knows how many cpu
 	// `slots` it might need to make room for.
-	MaxCPUs uint `lang:"maxcpus" yaml:"maxcpus"`
+	MaxCPUs uint `mcl:"maxcpus" yaml:"maxcpus"`
 	// HotCPUs specifies whether we can hot plug and unplug cpus.
-	HotCPUs bool `lang:"hotcpus" yaml:"hotcpus"`
+	HotCPUs bool `mcl:"hotcpus" yaml:"hotcpus"`
 	// Memory is the size in KBytes of memory to include in the machine.
-	Memory uint64 `lang:"memory" yaml:"memory"`
+	Memory uint64 `mcl:"memory" yaml:"memory"`
 
 	// OSInit is the init used by lxc.
-	OSInit string `lang:"osinit" yaml:"osinit"`
+	OSInit string `mcl:"osinit" yaml:"osinit"`
 	// Boot is the boot order. Values are `fd`, `hd`, `cdrom` and `network`.
-	Boot []string `lang:"boot" yaml:"boot"`
+	Boot []string `mcl:"boot" yaml:"boot"`
 	// Disk is the list of disk devices to include.
-	Disk []*DiskDevice `lang:"disk" yaml:"disk"`
+	Disk []*DiskDevice `mcl:"disk" yaml:"disk"`
 	// CdRom is the list of cdrom devices to include.
-	CDRom []*CDRomDevice `lang:"cdrom" yaml:"cdrom"`
+	CDRom []*CDRomDevice `mcl:"cdrom" yaml:"cdrom"`
 	// Network is the list of network devices to include.
-	Network []*NetworkDevice `lang:"network" yaml:"network"`
+	Network []*NetworkDevice `mcl:"network" yaml:"network"`
 	// Filesystem is the list of file system devices to include.
-	Filesystem []*FilesystemDevice `lang:"filesystem" yaml:"filesystem"`
+	Filesystem []*FilesystemDevice `mcl:"filesystem" yaml:"filesystem"`
 
 	// Auth points to the libvirt credentials to use if any are necessary.
-	Auth *VirtAuth `lang:"auth" yaml:"auth"`
+	Auth *VirtAuth `mcl:"auth" yaml:"auth"`
 
 	// RestartOnDiverge is the restart policy, and can be: `ignore`,
 	// `ifneeded` or `error`.
-	RestartOnDiverge string `lang:"restartondiverge" yaml:"restartondiverge"`
+	RestartOnDiverge string `mcl:"restartondiverge" yaml:"restartondiverge"`
 	// RestartOnRefresh specifies if we restart on refresh signal.
-	RestartOnRefresh bool `lang:"restartonrefresh" yaml:"restartonrefresh"`
+	RestartOnRefresh bool `mcl:"restartonrefresh" yaml:"restartonrefresh"`
 
 	wg                  *sync.WaitGroup
 	conn                *libvirt.Connect
@@ -128,8 +128,8 @@ type VirtRes struct {
 
 // VirtAuth is used to pass credentials to libvirt.
 type VirtAuth struct {
-	Username string `lang:"username" yaml:"username"`
-	Password string `lang:"password" yaml:"password"`
+	Username string `mcl:"username" yaml:"username"`
+	Password string `mcl:"password" yaml:"password"`
 }
 
 // Cmp compares two VirtAuth structs. It errors if they are not identical.
@@ -998,8 +998,8 @@ type virtDevice interface {
 
 // DiskDevice represents a disk that is attached to the virt machine.
 type DiskDevice struct {
-	Source string `lang:"source" yaml:"source"`
-	Type   string `lang:"type" yaml:"type"`
+	Source string `mcl:"source" yaml:"source"`
+	Type   string `mcl:"type" yaml:"type"`
 }
 
 // GetXML returns the XML representation of this device.
@@ -1036,8 +1036,8 @@ func (obj *DiskDevice) Cmp(dev *DiskDevice) error {
 
 // CDRomDevice represents a CDRom device that is attached to the virt machine.
 type CDRomDevice struct {
-	Source string `lang:"source" yaml:"source"`
-	Type   string `lang:"type" yaml:"type"`
+	Source string `mcl:"source" yaml:"source"`
+	Type   string `mcl:"type" yaml:"type"`
 }
 
 // GetXML returns the XML representation of this device.
@@ -1075,8 +1075,8 @@ func (obj *CDRomDevice) Cmp(dev *CDRomDevice) error {
 
 // NetworkDevice represents a network card that is attached to the virt machine.
 type NetworkDevice struct {
-	Name string `lang:"name" yaml:"name"`
-	MAC  string `lang:"mac" yaml:"mac"`
+	Name string `mcl:"name" yaml:"name"`
+	MAC  string `mcl:"mac" yaml:"mac"`
 }
 
 // GetXML returns the XML representation of this device.
@@ -1115,10 +1115,10 @@ func (obj *NetworkDevice) Cmp(dev *NetworkDevice) error {
 // FilesystemDevice represents a filesystem that is attached to the virt
 // machine.
 type FilesystemDevice struct {
-	Access   string `lang:"access" yaml:"access"`
-	Source   string `lang:"source" yaml:"source"`
-	Target   string `lang:"target" yaml:"target"`
-	ReadOnly bool   `lang:"read_only" yaml:"read_only"`
+	Access   string `mcl:"access" yaml:"access"`
+	Source   string `mcl:"source" yaml:"source"`
+	Target   string `mcl:"target" yaml:"target"`
+	ReadOnly bool   `mcl:"read_only" yaml:"read_only"`
 }
 
 // GetXML returns the XML representation of this device.

--- a/engine/util/util_test.go
+++ b/engine/util/util_test.go
@@ -113,9 +113,9 @@ func TestCurrentUserGroupById(t *testing.T) {
 
 func TestStructTagToFieldName0(t *testing.T) {
 	type foo struct {
-		A string `lang:"aaa"`
-		B bool   `lang:"bbb"`
-		C int64  `lang:"ccc"`
+		A string `mcl:"aaa"`
+		B bool   `mcl:"bbb"`
+		C int64  `mcl:"ccc"`
 	}
 	f := &foo{ // a ptr!
 		A: "hello",
@@ -141,9 +141,9 @@ func TestStructTagToFieldName0(t *testing.T) {
 
 func TestStructTagToFieldName1(t *testing.T) {
 	type foo struct {
-		A string `lang:"aaa"`
-		B bool   `lang:"bbb"`
-		C int64  `lang:"ccc"`
+		A string `mcl:"aaa"`
+		B bool   `mcl:"bbb"`
+		C int64  `mcl:"ccc"`
 	}
 	f := foo{ // not a ptr!
 		A: "hello",
@@ -170,8 +170,8 @@ func TestStructTagToFieldName2(t *testing.T) {
 }
 
 type testEngineRes struct {
-	PublicProp1  string                      `lang:"PublicProp1" yaml:"PublicProp1"`
-	PublicProp2  map[string][]map[string]int `lang:"PublicProp2" yaml:"PublicProp2"`
+	PublicProp1  string                      `mcl:"PublicProp1" yaml:"PublicProp1"`
+	PublicProp2  map[string][]map[string]int `mcl:"PublicProp2" yaml:"PublicProp2"`
 	privateProp1 bool
 	privateProp2 []int
 }

--- a/lang/types/type.go
+++ b/lang/types/type.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// StructTag is the key we use in struct field names for key mapping.
-	StructTag = "lang"
+	StructTag = "mcl"
 )
 
 // Basic types defined here as a convenience for use with Type.Cmp(X).
@@ -238,7 +238,7 @@ func ConfigurableTypeOf(t reflect.Type, opts ...TypeOfOption) (*Type, error) {
 			}
 			// TODO: should we skip over fields with field.Anonymous ?
 
-			// if struct field has a `lang:""` tag, use that instead of the struct field name
+			// if struct field has a `mcl:""` tag, use that instead of the struct field name
 			fieldName := field.Name
 			if options.structTag != "" {
 				if alias, ok := field.Tag.Lookup(options.structTag); ok {

--- a/lang/types/value.go
+++ b/lang/types/value.go
@@ -437,7 +437,7 @@ func Into(v Value, rv reflect.Value) error {
 		sort.Strings(keys)
 		for _, k := range keys { // loop in deterministic order
 			mk := k
-			// map mcl field name -> go field name based on `lang:""` tag
+			// map mcl field name -> go field name based on `mcl:""` tag
 			if key, exists := mapping[k]; exists {
 				mk = key
 			}

--- a/lang/types/value_test.go
+++ b/lang/types/value_test.go
@@ -668,10 +668,10 @@ func TestValueOf2(t *testing.T) {
 	pstr2 := &str2
 	ppstr2 := &pstr2
 	st := struct {
-		Num  int      `lang:"num"`
-		Name string   `lang:"name"`
-		Ptr  *string  `lang:"ptr"`
-		Ptr2 **string `lang:"ptr2"`
+		Num  int      `mcl:"num"`
+		Name string   `mcl:"name"`
+		Ptr  *string  `mcl:"ptr"`
+		Ptr2 **string `mcl:"ptr2"`
 	}{42, "mgmt", pstr, ppstr2}
 
 	value := &StructValue{
@@ -697,8 +697,8 @@ func TestValueOf2(t *testing.T) {
 
 func TestValueOf3(t *testing.T) {
 	st := struct {
-		Ptr  *string  `lang:"ptr"`
-		Ptr2 **string `lang:"ptr2"`
+		Ptr  *string  `mcl:"ptr"`
+		Ptr2 **string `mcl:"ptr2"`
 	}{nil, nil}
 
 	// cannot represent nil pointers, expect an err
@@ -720,10 +720,10 @@ func TestValueOf4(t *testing.T) {
 	pstr2 := &str2
 	ppstr2 := &pstr2
 	st := struct {
-		Num  int      `lang:"num"`
-		Name string   `lang:"name"`
-		Ptr  *string  `lang:"ptr"`
-		Ptr2 **string `lang:"ptr2"`
+		Num  int      `mcl:"num"`
+		Name string   `mcl:"name"`
+		Ptr  *string  `mcl:"ptr"`
+		Ptr2 **string `mcl:"ptr2"`
 	}{0, "", pstr, ppstr2}
 
 	value := &StructValue{
@@ -1082,8 +1082,8 @@ func TestValueIntoStructNameMapping(t *testing.T) {
 	}
 
 	var compare struct {
-		Word  string `lang:"word"`
-		Magic int    `lang:"magic"`
+		Word  string `mcl:"word"`
+		Magic int    `mcl:"magic"`
 	}
 	err := Into(st, reflect.ValueOf(&compare))
 	if err != nil {


### PR DESCRIPTION
mgmt's language is named `mcl`, and to avoid conflicts with the very generic term `lang` and to give mgmt more of an identity, it should use the `mcl` nomenclature to hopefully encourage other software to integrate more seamlessly.