### PR TITLE
Update docker build instructions

### DIFF
--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -21,8 +21,6 @@ to build your own.
 
 ### Downloading a pre-built release:
 
-This method is not recommended because those packages are now very old.
-
 The latest releases can be found [here](https://github.com/purpleidea/mgmt/releases/).
 An alternate mirror is available [here](https://dl.fedoraproject.org/pub/alt/purpleidea/mgmt/releases/).
 

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -101,13 +101,13 @@ This method avoids polluting your workstation with the dependencies for the
 build. Here is an example using Fedora, Podman and Buildah:
 
 ```shell
-git clone --recursive https://github.com/purpleidea/mgmt/ ~/mgmt/
-cd ~/mgmt/docker
-buildah build -f Dockerfile-fedora.build -t mgmt_build
-podman run -d -it --name mgmt_build localhost/mgmt_build
-podman cp mgmt_build:/src/github.com/purpleidea/mgmt/mgmt /tmp/mgmt
-sudo mv /tmp/mgmt /usr/local/bin  # be sure this is in your $PATH
-sudo chown root:root /usr/local/bin/mgmt
+git clone --recursive https://github.com/purpleidea/mgmt/
+cd mgmt
+docker build -t mgmt -f docker/Dockerfile .
+docker run --rm --entrypoint cat mgmt mgmt > mgmt
+chmod +x mgmt
+./mgmt --version
+# you could now copy the mgmt binary somewhere into your $PATH, e.g., /usr/local/bin/ to make it accessible from anywhere
 ```
 
 ## Running mgmt


### PR DESCRIPTION
Fixes #752.

I did not investigate what's the problem with the Fedora Dockerfile or the buildah instructions but these instructions worked for me.

Also, I took the liberty to remove the note about outdated binaries since this made me try to build things myself in the first place. (But the binaries are not outdated at all.)

## Tips:

* please read the style guide before submitting your patch: (I didn't read it because this is only a documentation fix.)