### PR TITLE
engine: resources: file: Remove Validate owner/group Checks

### DIFF
--- a/engine/resources/file.go
+++ b/engine/resources/file.go
@@ -352,13 +352,6 @@ func (obj *FileRes) Validate() error {
 			return fmt.Errorf("can't set Owner or Group on this platform")
 		}
 	}
-	if _, err := engineUtil.GetUID(obj.Owner); obj.Owner != "" && err != nil {
-		return err
-	}
-
-	if _, err := engineUtil.GetGID(obj.Group); obj.Group != "" && err != nil {
-		return err
-	}
 
 	// TODO: should we silently ignore this error or include it?
 	//if obj.State == FileStateAbsent && obj.Mode != "" {


### PR DESCRIPTION
The owner/group of a file should not be validated on the host until runtime. This removes the checks in Validate() that were happening before the execution of the resource graph (and therefore bound to fail if the system was being bootstrapped).

Fixes #762 