### PR TITLE
Draft: fix: allow runtime to be ANY

### DIFF
--- a/engine/resources/packagekit/packagekit.go
+++ b/engine/resources/packagekit/packagekit.go
@@ -972,5 +972,5 @@ func IsMyArch(arch string) (bool, error) {
 	if goarch == archUtil.Any { // special value that corresponds to noarch
 		return true, nil
 	}
-	return goarch == runtime.GOARCH, nil
+	return goarch == runtime.GOARCH || goarch == "ANY", nil
 }

--- a/engine/resources/packagekit/packagekit.go
+++ b/engine/resources/packagekit/packagekit.go
@@ -969,7 +969,7 @@ func IsMyArch(arch string) (bool, error) {
 		// if you get this error, please update the PkArchMap const
 		return false, fmt.Errorf("arch '%s', not found", arch)
 	}
-	if goarch == archUtil.Any { // special value that corresponds to noarch
+	return goarch == runtime.GOARCH || goarch == "ANY" || goarch == archUtil.Any, nil
 		return true, nil
 	}
 	return goarch == runtime.GOARCH || goarch == "ANY", nil

--- a/engine/resources/packagekit/packagekit.go
+++ b/engine/resources/packagekit/packagekit.go
@@ -970,7 +970,4 @@ func IsMyArch(arch string) (bool, error) {
 		return false, fmt.Errorf("arch '%s', not found", arch)
 	}
 	return goarch == runtime.GOARCH || goarch == "ANY" || goarch == archUtil.Any, nil
-		return true, nil
-	}
-	return goarch == runtime.GOARCH || goarch == "ANY", nil
 }


### PR DESCRIPTION
Found a bug within IsMyArch in packagekit.go
it gets passed 'any' which is mapped by archUtil to 'ANY'
This is then directly compared with the runtime.GOARCH

Digged deep enough with logging statements to show this is where it returns false (usually without error)
10:58:55 main.go:88: engine: pkg\[unattended-upgrades\]: packagekit: PackagesToPackageIDs() \[IsMyArch\] b: false, err: goarch 'ANY', GOARCH 'amd64'

The code after this skips evaluating this package further, so it has them still marked as not found.