### PR TITLE
misc: Add vim syntax highlighting file

### DIFF
--- a/misc/vim/mcl.vim
+++ b/misc/vim/mcl.vim
@@ -1,0 +1,40 @@
+" Vim syntax file
+" Language: mgmt config language
+" Maintainer: Edward Toroshchyn
+" Latest Revision: 2025-02-05
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn case match
+
+syn keyword mclKeywords if else and or not in func class include import as
+syn keyword mclTypes bool str int float map struct variant 
+syn keyword mclBuiltins true false panic
+
+hi def link mclKeywords Keyword
+hi def link mclTypes Type
+hi def link mclBuiltins Constant
+
+syn keyword mclTodo contained TODO FIXME XXX BUG
+syn region mclComment start="#" end="$" contains=mclTodo
+
+hi def link mclTodo Todo
+hi def link mclComment Comment
+
+syn keyword mclResources augeas aws:ec2 bmc:power config:etcd consul:kv cron deploy:tar dhcp:host 
+syn keyword mclResources dhcp:range dhcp:server docker:container docker:image exec file
+syn keyword mclResources firewalld group gzip hetzner:vm hostname http:file http:flag http:proxy
+syn keyword mclResources http:server kv mount msg net noop nspawn password pippet pkg print svc 
+syn keyword mclResources sysctl tar test tftp:file tftp:server timer user value virt virt:builder
+
+hi def link mclResources Constant
+
+syn region mclString start=+"+ skip=+\\"+ end=+"+ contains=mclEscapeChar
+syn match mclEscapeChar display contained "\\."
+
+hi def link mclString String
+hi def link mclEscapeChar Special
+
+let b:current_syntax = "mcl"


### PR DESCRIPTION
This is an extremely basic initial version of syntax highlighting, written just so that I can edit the MCL files in vim and not cry.

The following features are supported:
 - MCL keywords
 - strings (including escape characters)
 - comments
 - built-in resources (as of 0.0.27)

## Tips:

* please read the style guide before submitting your patch:
[docs/style-guide.md](../docs/style-guide.md)

* commit message titles must be in the form:

```topic: Capitalized message with no trailing period```

or:

```topic, topic2: Capitalized message with no trailing period```

* golang code must be formatted according to the standard, please run:

```
make gofmt		# formats the entire project correctly
```

or format a single golang file correctly:

```
gofmt -w yourcode.go
```

* please rebase your patch against current git master:

```
git checkout master
git pull origin master
git checkout your-feature
git rebase master
git push your-remote your-feature
hub pull-request	# or submit with the github web ui
```

* after a patch review, please ping @purpleidea so we know to re-review:

```
# make changes based on reviews...
git add -p		# add new changes
git commit --amend	# combine with existing commit
git push your-remote your-feature -f
# now ping @purpleidea in the github PR since it doesn't notify us automatically
```

## Thanks for contributing to mgmt and welcome to the team!
