### PR TITLE
Streamline finding files in scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .envrc
 old/
 tmp/
+vendor/
 *WIP
 *_stringer.go
 mgmt

--- a/lang/fuzz/Makefile
+++ b/lang/fuzz/Makefile
@@ -34,6 +34,6 @@ all: fuzz
 
 fuzz:
 	mkdir -p corpus/
-	find ../.. -name \*.mcl -exec cp {} corpus/ \;
+	find ../.. -type f -name '*.mcl' -exec cp -t corpus/ {} +
 	go-fuzz-build
 	go-fuzz -bin=./fuzz-fuzz.zip -workdir=.

--- a/test/test-examples.sh
+++ b/test/test-examples.sh
@@ -14,7 +14,7 @@ failures=''
 # Test examples/lang/ directory to see if the .mcl files compile correctly.
 
 find_mcl_examples() {
-	git ls-files | grep '\.mcl$' | grep '^examples/lang/' | grep -v 'modules/'
+	git ls-files -co --exclude-standard '*.mcl' | grep '^examples/lang/' | grep -v 'modules/'
 }
 
 for file in $(find_mcl_examples); do
@@ -31,7 +31,7 @@ ln -s "$linkto"	# symlink outside of dir
 cd `basename "$linkto"`
 
 # loop through individual *.go files in working dir
-for file in `find . -maxdepth 9 -type f -name '*.go'`; do
+for file in `git ls-files -co --exclude-standard '*.go'`; do
 	#echo "running test on: $file"
 	run-test go build -o "$buildout" "$file" || fail_test "could not build: $file"
 done

--- a/test/test-vet.sh
+++ b/test/test-vet.sh
@@ -42,7 +42,7 @@ function parser-conflicts() {
 }
 
 # loop through individual *.y files
-for file in `find . -maxdepth 9 -type f -name '*.y' -not -path './old/*' -not -path './tmp/*' -not -path './vendor/*'`; do
+for file in `git ls-files -co --exclude-standard '*.y'`; do
 	run-test parser-indentation "$file"
 	run-test parser-conflicts "$file"
 done


### PR DESCRIPTION
Replace most usages of `find` by `git ls-files`

Some reasons for using git over find:
- Respects .gitignore
  - no need to redefine/copy-paste each ignored directory with every `find` call (configured only once)
- Scans only relevant files (only lists files Git knows about)
- git index is already optimized for this, while `find` needs to traverse directories

Here are the options in use explained in the man page of `git ls-files`:
```
       -c, --cached
           Show all files cached in Git’s index, i.e. all tracked files. (This is the default if
           no -c/-s/-d/-o/-u/-k/-m/--resolve-undo options are specified.)
       -o, --others
           Show other (i.e. untracked) files in the output
       --exclude-standard
           Add the standard Git exclusions: .git/info/exclude, .gitignore in each directory, and
           the user’s global exclusion file.
```
---
I have also added the vendor directory to the .gitignore file, since it appeared in several find commands, but i could not figure out if this directory is actually (still) in use or not.

---

I was not sure about it but I have generally ignored the `-maxdepth` arguments which was previously 9.
The awk command under `yamlfmt:` (https://github.com/karpfediem/mgmt/blob/0d41ad9f786d045eefc32e843268503c80c7ec2a/Makefile#L272) serves to limit the `-maxdepth` to the same one as in the find command (find . -maxdepth 3) 
```sh
			| awk -F'/' 'NF<=4' \
```
If this depth isn't important either that line can be removed as well.

---

I also have a question regarding this line https://github.com/karpfediem/mgmt/blob/0d41ad9f786d045eefc32e843268503c80c7ec2a/Makefile#L38

Does this comment still apply? E.g. is the cause the slow find command or the longer tests due to more files?

---
Please let me know I should explain anything else in more detail.