### PR TITLE
Use /usr/bin/env for a more generic shebang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@
 # additional permission if he deems it necessary to achieve the goals of this
 # additional permission.
 
-SHELL = /usr/bin/env bash
+SHELL = bash
 .PHONY: all art cleanart version program lang path deps run race generate build build-debug crossbuild clean test gofmt yamlfmt format docs
 .PHONY: rpmbuild mkdirs rpm srpm spec tar upload upload-sources upload-srpms upload-rpms upload-releases copr tag
 .PHONY: mkosi mkosi_fedora-latest mkosi_fedora-older mkosi_stream-latest mkosi_debian-stable mkosi_ubuntu-latest mkosi_archlinux

--- a/docker/scripts/build
+++ b/docker/scripts/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 script_directory="$( cd "$( dirname "$0" )" && pwd )"
 project_directory=$script_directory/../..

--- a/docker/scripts/build-development
+++ b/docker/scripts/build-development
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Stop on any error
 set -e

--- a/docker/scripts/exec-development
+++ b/docker/scripts/exec-development
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # runs command provided as argument inside a development (Linux) Docker container
 

--- a/docker/scripts/run-development
+++ b/docker/scripts/run-development
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Stop on any error
 set -e

--- a/examples/dhcp_client/Makefile
+++ b/examples/dhcp_client/Makefile
@@ -27,7 +27,7 @@
 # additional permission if he deems it necessary to achieve the goals of this
 # additional permission.
 
-SHELL = /usr/bin/env bash
+SHELL = bash
 
 .PHONY: clean
 .SILENT: clean

--- a/lang/Makefile
+++ b/lang/Makefile
@@ -27,7 +27,7 @@
 # additional permission if he deems it necessary to achieve the goals of this
 # additional permission.
 
-SHELL = /usr/bin/env bash
+SHELL = bash
 .PHONY: all build clean fuzz
 
 all: build

--- a/lang/core/embedded/provisioner/main.mcl
+++ b/lang/core/embedded/provisioner/main.mcl
@@ -794,7 +794,7 @@ class base:host($name, $config) {
 		# passed into the provisioner. It's just now in a deploy subdir.
 		# If it's a dir, then this becomes the empty strings.
 		# XXX: The deploy could instead happen over the network to etcd.
-		"echo '#!/bin/bash' > ${firstboot_scripts_dir}mgmt-deploy.sh && echo '${handoff_binary_path} deploy lang --seeds=http://127.0.0.1:2379 --no-git --module-path=${deploy_dir_modules} ${deploy_dir}${handoff_code_chunk}' >> ${firstboot_scripts_dir}mgmt-deploy.sh && chmod u+x ${firstboot_scripts_dir}mgmt-deploy.sh"
+		"echo '#!/usr/bin/env bash' > ${firstboot_scripts_dir}mgmt-deploy.sh && echo '${handoff_binary_path} deploy lang --seeds=http://127.0.0.1:2379 --no-git --module-path=${deploy_dir_modules} ${deploy_dir}${handoff_code_chunk}' >> ${firstboot_scripts_dir}mgmt-deploy.sh && chmod u+x ${firstboot_scripts_dir}mgmt-deploy.sh"
 	}
 
 	# TODO: Do we want to signal an http:flag if we're a "default" host?

--- a/lang/fuzz/Makefile
+++ b/lang/fuzz/Makefile
@@ -27,7 +27,7 @@
 # additional permission if he deems it necessary to achieve the goals of this
 # additional permission.
 
-SHELL = /usr/bin/env bash
+SHELL = bash
 .PHONY: all fuzz
 
 all: fuzz

--- a/misc/bashrc.sh
+++ b/misc/bashrc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 _cli_bash_autocomplete_mgmt() {
 	local cur prev opts base

--- a/misc/delta-cpu.sh
+++ b/misc/delta-cpu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shitty cpu count control, useful for live demos
 
 minimum=1	# don't decrease below this number of cpus

--- a/misc/fpm-pack.sh
+++ b/misc/fpm-pack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script packages rpm, deb, and pacman packages of mgmt with fpm. The
 # first argument is the distro type, and the second argument is the version. All
 # subsequent arguments are the dependencies.

--- a/misc/header.sh
+++ b/misc/header.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$1" = "" ] || [ "$1" = "--help" ]; then
 	echo "usage: append standard header to file"

--- a/misc/looper.sh
+++ b/misc/looper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # simple test loop runner, eg: ./looper.sh make test-shell-exec-fail
 
 while true

--- a/misc/make-baddev.sh
+++ b/misc/make-baddev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Make a new "baddev" branch, start on whatever branch you want to base it on.
 git checkout -B baddev # scary -B reset the branch
 make

--- a/misc/make-deb-changelog.sh
+++ b/misc/make-deb-changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script generates a deb changelog from the project's git history.
 
 # version we're releasing

--- a/misc/make-deps.sh
+++ b/misc/make-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # setup a simple golang environment
 XPWD=`pwd`
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"	# dir!

--- a/misc/make-path.sh
+++ b/misc/make-path.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # setup a few environment path values
 
 if ! env | grep -q '^GOPATH='; then

--- a/misc/make-rpm-changelog.sh
+++ b/misc/make-rpm-changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script generates an rpm changelog from the project's git history.
 
 # version we're releasing

--- a/misc/mgmt_debug.sh
+++ b/misc/mgmt_debug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is a helper script to run mgmt and capture and filter stack traces. Any
 # time mgmt crashes with a trace, it will first be filtered, and then displayed

--- a/misc/mkosi/Makefile
+++ b/misc/mkosi/Makefile
@@ -27,7 +27,7 @@
 # additional permission if he deems it necessary to achieve the goals of this
 # additional permission.
 
-SHELL = /usr/bin/env bash
+SHELL = bash
 .PHONY: all clean
 
 default: all

--- a/misc/mkosi/make.sh
+++ b/misc/mkosi/make.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 echo running "$0"
 set -o errexit

--- a/misc/mkosi/mkosi.build
+++ b/misc/mkosi/mkosi.build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # If mkosi.builddir/ exists mkosi will set $BUILDDIR to it, let's then use it as
 # out-of-tree build dir. Otherwise, let's make up our own builddir.

--- a/misc/tag.sh
+++ b/misc/tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eEu
 set -o pipefail
 

--- a/misc/travis-encrypt.sh
+++ b/misc/travis-encrypt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # modified slightly, originally from:
 # https://raw.githubusercontent.com/dlenski/travis-encrypt-sh/master/travis-encrypt
 

--- a/misc/txtar-port.sh
+++ b/misc/txtar-port.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # port tests to txtar
 for f in */main.mcl; do
 	echo $f == $(dirname $f)

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # simple way to kick off runs of the project, since 'go run' sucks!
 make build || exit 1

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 # runs all (or selected) test suite(s) in test/ and aggregates results
 # Usage:
 #	./test.sh

--- a/test/Makefile
+++ b/test/Makefile
@@ -27,7 +27,7 @@
 # additional permission if he deems it necessary to achieve the goals of this
 # additional permission.
 
-SHELL = /usr/bin/env bash
+SHELL = bash
 .PHONY: all build clean
 
 all: build

--- a/test/shell/augeas-1.sh
+++ b/test/shell/augeas-1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 exit 0	# XXX: disable for now
 

--- a/test/shell/embedded-provisioner.sh
+++ b/test/shell/embedded-provisioner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/env0.sh
+++ b/test/shell/env0.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/etcd-clustersize.sh
+++ b/test/shell/etcd-clustersize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/etcd-conflicting-server.sh
+++ b/test/shell/etcd-conflicting-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/etcd-three-hosts-reversed.sh
+++ b/test/shell/etcd-three-hosts-reversed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/etcd-three-hosts.sh
+++ b/test/shell/etcd-three-hosts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/etcd-two-hosts-reversed.sh
+++ b/test/shell/etcd-two-hosts-reversed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/etcd-two-hosts.sh
+++ b/test/shell/etcd-two-hosts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/exchange.sh
+++ b/test/shell/exchange.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/exec-fail.sh
+++ b/test/shell/exec-fail.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/exec-usergroup.sh
+++ b/test/shell/exec-usergroup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/file-mode.sh
+++ b/test/shell/file-mode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 exit 0	# XXX: disable for now
 

--- a/test/shell/file-move-upper-dir.sh
+++ b/test/shell/file-move-upper-dir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 # FIXME: test for #124 --- Disabled for now
 

--- a/test/shell/file-move.sh
+++ b/test/shell/file-move.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 exit 0	# XXX: disable for now
 

--- a/test/shell/file-owner.sh
+++ b/test/shell/file-owner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 # vim: noet:ts=8:sts=8:sw=8
 
 exit 0	# XXX: disable for now

--- a/test/shell/file-source.sh
+++ b/test/shell/file-source.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 # vim: noet:ts=8:sts=8:sw=8
 
 . "$(dirname "$0")/../util.sh"

--- a/test/shell/graph-exit1.sh
+++ b/test/shell/graph-exit1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/graph-exit2.sh
+++ b/test/shell/graph-exit2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/graph-fanin-1.sh
+++ b/test/shell/graph-fanin-1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/ipv6-localhost.sh
+++ b/test/shell/ipv6-localhost.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/libmgmt-change1.sh
+++ b/test/shell/libmgmt-change1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/libmgmt-change2.sh
+++ b/test/shell/libmgmt-change2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/load0.sh
+++ b/test/shell/load0.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/net.sh
+++ b/test/shell/net.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/no-network.sh
+++ b/test/shell/no-network.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/prometheus-1.sh
+++ b/test/shell/prometheus-1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/prometheus-2.sh
+++ b/test/shell/prometheus-2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/prometheus-3.sh
+++ b/test/shell/prometheus-3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/prometheus-4.sh
+++ b/test/shell/prometheus-4.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env -S bash -xe
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/sema-1.sh
+++ b/test/shell/sema-1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/sema-2.sh
+++ b/test/shell/sema-2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/t1.sh
+++ b/test/shell/t1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 # NOTES:
 #	* this is a simple shell based `mgmt` test case
 #	* it is recommended that you run mgmt wrapped in the timeout command

--- a/test/shell/t2.sh
+++ b/test/shell/t2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/t3.sh
+++ b/test/shell/t3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/t5.sh
+++ b/test/shell/t5.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/t5b.sh
+++ b/test/shell/t5b.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/t6.sh
+++ b/test/shell/t6.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/t7.sh
+++ b/test/shell/t7.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/shell/yaml-change1.sh
+++ b/test/shell/yaml-change1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 . "$(dirname "$0")/../util.sh"
 

--- a/test/test-bashfmt.sh
+++ b/test/test-bashfmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check for any bash files that aren't properly formatted
 # TODO: this is hardly exhaustive
 

--- a/test/test-commit-message.sh
+++ b/test/test-commit-message.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 # tests if commit message conforms to convention
 
 # library of utility functions

--- a/test/test-crossbuild.sh
+++ b/test/test-crossbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -o pipefail
 

--- a/test/test-docs-generate.sh
+++ b/test/test-docs-generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check that our documentation still generates, even if we don't use it here
 
 # shellcheck disable=SC1091

--- a/test/test-examples.sh
+++ b/test/test-examples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check that our examples still build, even if we don't run them here
 
 # shellcheck disable=SC1091

--- a/test/test-gofmt.sh
+++ b/test/test-gofmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # original version of this script from kubernetes project, under ALv2 license
 
 echo running "$0"

--- a/test/test-golangci-lint.sh
+++ b/test/test-golangci-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check a bunch of linters with the golangci_lint
 # TODO: run this from the test-golint.sh file instead to check for deltas
 

--- a/test/test-golint.sh
+++ b/test/test-golint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check that go lint passes or doesn't get worse by some threshold
 
 echo running "$0"

--- a/test/test-gometalinter.sh
+++ b/test/test-gometalinter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check a bunch of linters with the gometalinter
 # TODO: run this from the test-golint.sh file instead to check for deltas
 

--- a/test/test-gotest.sh
+++ b/test/test-gotest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo running "$0" "$@"
 

--- a/test/test-govet.sh
+++ b/test/test-govet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check that go vet passes
 
 echo running "$0"

--- a/test/test-headerfmt.sh
+++ b/test/test-headerfmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check that headers are properly formatted
 
 echo running "$0"

--- a/test/test-integration.sh
+++ b/test/test-integration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # this file exists to that bash completion for test names works
 

--- a/test/test-markdownlint.sh
+++ b/test/test-markdownlint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check for any markdown files that aren't in an ideal format
 
 echo running "$0 $*"

--- a/test/test-mclfmt.sh
+++ b/test/test-mclfmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check for any mcl files that aren't properly formatted
 # TODO: this is hardly exhaustive
 

--- a/test/test-misc.sh
+++ b/test/test-misc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # simple tests that don't deserve their own testfile
 
 # library of utility functions

--- a/test/test-modules.sh
+++ b/test/test-modules.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check that our modules still build, even if we don't run them here
 
 # shellcheck disable=SC1091

--- a/test/test-omv.sh
+++ b/test/test-omv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -i
+#!/usr/bin/env -S bash -i
 # simple test harness for testing mgmt via omv
 echo running "$0"
 CWD=`pwd`

--- a/test/test-reproducible.sh
+++ b/test/test-reproducible.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # simple test for reproducibility, probably needs major improvements
 echo running "$0"
 set -o errexit

--- a/test/test-shell.sh
+++ b/test/test-shell.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # simple test harness for testing mgmt
 # NOTE: this will rm -rf /tmp/mgmt/
 

--- a/test/test-vet.sh
+++ b/test/test-vet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # vet a few random things
 
 echo running "$0"

--- a/test/test-yamlfmt.sh
+++ b/test/test-yamlfmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # check for any yaml files that aren't properly formatted
 
 exit 0	# i give up, we're skipping this entirely, help wanted to fix this

--- a/test/util.sh
+++ b/test/util.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # common settings and functions for test scripts
 


### PR DESCRIPTION
Replaces all static file paths such as `#!/bin/bash` in shebangs by prefixing the binary with `#!/usr/bin/env`

This should be preferable due to more widespread compatibility, especially with [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) non-compliant systems such as NixOS.

In my experience it's universal enough that it is generally the recommended way. It's more universal than /bin/bash. It works even on busybox and termux.

However this requires that those binaries are in the user's PATH.