### PR TITLE
engine: resources: file: Support symbolic links

### DIFF
--- a/engine/resources/file.go
+++ b/engine/resources/file.go
@@ -1439,7 +1439,7 @@ func (obj *FileUID) IFF(uid engine.ResUID) bool {
 	if !ok {
 		return false
 	}
-	return obj.path == res.path
+	return obj.path == res.path || obj.path == res.path+"/" || obj.path+"/" == res.path
 }
 
 // FileResAutoEdges holds the state of the auto edge generator.
@@ -1527,23 +1527,14 @@ func (obj *FileRes) AutoEdges() (engine.AutoEdge, error) {
 		if !path.IsAbs(source) {
 			source = path.Join(path.Dir(obj.getPath()), source)
 		}
-		var reversed1 = true
-		var reversed2 = true
+		var reversed = true
 		frags = append(frags, &FileUID{
 			BaseUID: engine.BaseUID{
 				Name:     obj.Name(),
 				Kind:     obj.Kind(),
-				Reversed: &reversed1,
+				Reversed: &reversed,
 			},
 			path: source,
-		})
-		frags = append(frags, &FileUID{
-			BaseUID: engine.BaseUID{
-				Name:     obj.Name(),
-				Kind:     obj.Kind(),
-				Reversed: &reversed2,
-			},
-			path: source + "/",
 		})
 	}
 

--- a/engine/resources/file_test.go
+++ b/engine/resources/file_test.go
@@ -60,7 +60,17 @@ func TestFileAutoEdge1(t *testing.T) {
 	r3 := &FileRes{
 		Path: "/tmp/a/b/c", // some child file
 	}
-	g.AddVertex(r1, r2, r3)
+	r4 := &FileRes{
+		Path:    "/tmp/b", // some symbolic link
+		Symlink: true,
+		Source:  "/tmp/a",
+	}
+	r5 := &FileRes{
+		Path:    "/tmp/c", // some relative symbolic link
+		Symlink: true,
+		Source:  "a",
+	}
+	g.AddVertex(r1, r2, r3, r4, r5)
 
 	if i := g.NumEdges(); i != 0 {
 		t.Errorf("should have 0 edges instead of: %d", i)
@@ -76,8 +86,8 @@ func TestFileAutoEdge1(t *testing.T) {
 	}
 
 	// two edges should have been added
-	if i := g.NumEdges(); i != 2 {
-		t.Errorf("should have 2 edges instead of: %d", i)
+	if i := g.NumEdges(); i != 4 {
+		t.Errorf("should have 4 edges instead of: %d", i)
 	}
 }
 

--- a/examples/lang/file0.mcl
+++ b/examples/lang/file0.mcl
@@ -5,3 +5,15 @@ file "/tmp/file1" {
 file "/tmp/dir1/" {
 	state => $const.res.file.state.exists,
 }
+
+file "/tmp/symlink1" {
+	state => $const.res.file.state.exists,
+	source => "file1",
+	symlink => true,
+}
+
+file "/tmp/symlink2" {
+	state => $const.res.file.state.exists,
+	source => "dir1/",
+	symlink => true,
+}


### PR DESCRIPTION
Support managing symbolic links.

```
file "/tmp/symlink2" {
	state => $const.res.file.state.exists,
	source => "dir1/",
	symlink => true,
}
```

- Now file resources also generates auto-edges to `Source`.
- FileUID now sees `PATH/` and `PATH` as equivalent.