### PR TITLE
engine: resources: Add a WatchFiles func to exec

### DIFF
--- a/engine/resources/exec.go
+++ b/engine/resources/exec.go
@@ -119,6 +119,9 @@ type ExecRes struct {
 	// WatchCwd is the Cwd for the WatchCmd. See the docs for Cwd.
 	WatchCwd string `lang:"watchcwd" yaml:"watchcwd"`
 
+	// WatchFiles is a list of files that will be kept track of.
+	WatchFiles []string `lang:"watchfiles" yaml:"watchfiles"`
+
 	// WatchShell is the Shell for the WatchCmd. See the docs for Shell.
 	WatchShell string `lang:"watchshell" yaml:"watchshell"`
 
@@ -197,6 +200,12 @@ func (obj *ExecRes) Validate() error {
 		return fmt.Errorf("the Args param can't be used when Cmd has args")
 	}
 
+	for _, file := range obj.WatchFiles {
+		if file != "" && !strings.HasPrefix(file, "/") {
+			return fmt.Errorf("the path (`%s`) in WatchFiles must be absolute", file)
+		}
+	}
+
 	if obj.Creates != "" && !strings.HasPrefix(obj.Creates, "/") {
 		return fmt.Errorf("the Creates param must be an absolute path")
 	}
@@ -238,10 +247,13 @@ func (obj *ExecRes) Cleanup() error {
 
 // Watch is the primary listener for this resource and it outputs events.
 func (obj *ExecRes) Watch(ctx context.Context) error {
-	defer obj.wg.Wait()
+	wg := &sync.WaitGroup{}
+	defer wg.Wait()
 
 	ioChan := make(chan *cmdOutput)
 	rwChan := make(chan recwatch.Event)
+	filesChan := make(chan recwatch.Event)
+
 	var watchCmd *exec.Cmd
 	if obj.WatchCmd != "" {
 		var cmdName string
@@ -279,6 +291,46 @@ func (obj *ExecRes) Watch(ctx context.Context) error {
 		if ioChan, err = obj.cmdOutputRunner(innerCtx, cmd); err != nil {
 			return errwrap.Wrapf(err, "error starting WatchCmd")
 		}
+	}
+
+	for _, file := range obj.WatchFiles {
+		recurse := strings.HasSuffix(file, "/") // check if it's a file or dir
+		recWatcher, err := recwatch.NewRecWatcher(file, recurse)
+		if err != nil {
+			return err
+		}
+		defer recWatcher.Close()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				var files recwatch.Event
+				var ok bool
+				var shutdown bool
+
+				select {
+				case files, ok = <-recWatcher.Events(): // receiving events
+				case <-ctx.Done(): // unblock
+					return
+				}
+
+				if !ok {
+					err := fmt.Errorf("channel shutdown")
+					files = recwatch.Event{Error: err}
+					shutdown = true
+				}
+
+				select {
+				case filesChan <- files: // send events
+					if shutdown { // optimization to free early
+						return
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
 	}
 
 	if obj.Creates != "" {
@@ -340,6 +392,15 @@ func (obj *ExecRes) Watch(ctx context.Context) error {
 				return fmt.Errorf("unexpected recwatch shutdown")
 			}
 			if err := event.Error; err != nil {
+				return errwrap.Wrapf(err, "unknown %s watcher error", obj)
+			}
+			send = true
+
+		case files, ok := <-filesChan:
+			if !ok { // channel shutdown
+				return fmt.Errorf("unexpected recwatch shutdown")
+			}
+			if err := files.Error; err != nil {
 				return errwrap.Wrapf(err, "unknown %s watcher error", obj)
 			}
 			send = true
@@ -707,6 +768,14 @@ func (obj *ExecRes) Cmp(r engine.Res) error {
 	}
 	if obj.WatchShell != res.WatchShell {
 		return fmt.Errorf("the WatchShell differs")
+	}
+	if len(obj.WatchFiles) != len(res.WatchFiles) {
+		return fmt.Errorf("the number of WatchFiles differs")
+	}
+	for i, a := range obj.WatchFiles {
+		if a != res.WatchFiles[i] {
+			return fmt.Errorf("the WatchFiles differ at index: %d", i)
+		}
 	}
 
 	if obj.IfCmd != res.IfCmd {

--- a/examples/lang/exec1.mcl
+++ b/examples/lang/exec1.mcl
@@ -1,0 +1,6 @@
+exec "exec1" {
+	cmd => "echo hello world > /tmp/whatever",
+	shell => "/bin/bash",
+	creates => "/tmp/whatever",
+	watchfiles => ["/tmp/whatever", "/tmp/adir/",],
+}


### PR DESCRIPTION
This adds a function that keeps track of changes to a given file inside the exec resource.

Keep this as a draft PR for now because it seems like we're generating more events than we should, looking for some feedback into this.
