### PR TITLE
engine: fix errors on re-reconcilation of existing users

### DIFF
--- a/engine/resources/user.go
+++ b/engine/resources/user.go
@@ -291,13 +291,6 @@ func (obj *UserRes) CheckApply(ctx context.Context, apply bool) (bool, error) {
 	var cmdName string
 	var args []string
 	if obj.State == "exists" {
-		if exists {
-			cmdName = "usermod"
-			obj.init.Logf("modifying user: %s", obj.Name())
-		} else {
-			cmdName = "useradd"
-			obj.init.Logf("adding user: %s", obj.Name())
-		}
 		if obj.AllowDuplicateUID {
 			args = append(args, "--non-unique")
 		}
@@ -318,6 +311,16 @@ func (obj *UserRes) CheckApply(ctx context.Context, apply bool) (bool, error) {
 		}
 		if obj.Shell != nil {
 			args = append(args, "--shell", *obj.Shell)
+		}
+		if exists && len(args) == 0 {
+			return false, nil
+		}
+		if exists {
+			cmdName = "usermod"
+			obj.init.Logf("modifying user: %s", obj.Name())
+		} else {
+			cmdName = "useradd"
+			obj.init.Logf("adding user: %s", obj.Name())
 		}
 	}
 	if obj.State == "absent" {


### PR DESCRIPTION
Fixes #842 
Currently, running a block of mcl such as this will error on the 2nd reconcilation, even if no changes are made to the resource:

```
user "mgmtiscool" {
	state => "exists",
}

```

This is due to `usermod` returning non-zero on `usermod <username>` with no args.

This patch makes it exit early, correcting that behavior.
