### PR TITLE
Fix `golang.template()` with nested structs

### DIFF
--- a/lang/interpret_test/TestAstFunc2/template-0.txtar
+++ b/lang/interpret_test/TestAstFunc2/template-0.txtar
@@ -1,16 +1,17 @@
 -- main.mcl --
 import "datetime"
 import "golang"
+import "sys"
 
 $secplus42 = 42 + $ayear
 
 # note the order of the assignment (year can come later in the code)
 $ayear = 60 * 60 * 24 * 365	# is a year in seconds (31536000)
 
-$tmplvalues = struct{time => $secplus42, hello => "world",}
+$tmplvalues = struct{time => $secplus42, hello => "world", load => sys.load(),}
 
 print "template-0" {
-	msg => golang.template("Hello: {{ .hello }}, 42 sec + 1 year is: {{ .time }} seconds, aka: {{ datetime_print .time }}", $tmplvalues),
+	msg => golang.template("Hello: {{ .hello }}, 42 sec + 1 year is: {{ .time }} seconds, aka: {{ datetime_print .time }} with load {{ .load.x1 }}", $tmplvalues),
 }
 -- OUTPUT --
 Vertex: print[template-0]


### PR DESCRIPTION
Recursively convert nested structs to maps when feeding values into golang.template(). Fixes:

    gapi: lang: funcs: panic in process: struct has unexported field: x1

Fixes: https://github.com/purpleidea/mgmt/issues/838