### PR TITLE
Fix incorrect usage of errwrap.Wrapf with nil errors

### DIFF
--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -182,7 +182,7 @@ func (obj *DeployArgs) Run(ctx context.Context, data *cliUtil.Data) (bool, error
 			pHash = "" // don't check this :(
 		}
 		if hash == "" {
-			return false, errwrap.Wrapf(err, "could not get git deploy hash")
+			return false, fmt.Errorf("could not get git deploy hash")
 		}
 	}
 

--- a/engine/resources/aws_ec2.go
+++ b/engine/resources/aws_ec2.go
@@ -750,7 +750,7 @@ func (obj *AwsEc2Res) CheckApply(ctx context.Context, apply bool) (bool, error) 
 	case ec2.InstanceStateNameTerminated:
 		err = obj.client.WaitUntilInstanceTerminatedWithContext(innerCtx, waitInput)
 	default:
-		return false, errwrap.Wrapf(err, "unrecognized instance state")
+		return false, fmt.Errorf("unrecognized instance state")
 	}
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {

--- a/lang/core/golang/template.go
+++ b/lang/core/golang/template.go
@@ -309,7 +309,7 @@ Loop:
 
 		case types.KindMap:
 			if v.Type().Key.Cmp(types.TypeStr) != nil {
-				return "", errwrap.Wrapf(err, "template: map keys must be str")
+				return "", fmt.Errorf("template: map keys must be str")
 			}
 			m := make(map[string]interface{})
 			for k, v := range v.Map() { // map[Value]Value

--- a/lang/core/net/url_parser.go
+++ b/lang/core/net/url_parser.go
@@ -78,7 +78,7 @@ func URLParser(ctx context.Context, input []types.Value) (types.Value, error) {
 		return nil, errwrap.Wrapf(err, "error parsing the URL")
 	}
 	if u.Scheme == "" {
-		return nil, errwrap.Wrapf(err, "empty schemes are invalid")
+		return nil, fmt.Errorf("empty schemes are invalid")
 	}
 
 	v := types.NewStruct(types.NewType(urlParserReturnType))

--- a/lang/inputs/inputs.go
+++ b/lang/inputs/inputs.go
@@ -313,7 +313,7 @@ func inputDirectory(s string, fs engine.Fs) (*ParsedInput, error) {
 		return nil, errwrap.Wrapf(err, "dir: `%s` does not exist", s)
 	}
 	if !fi.IsDir() {
-		return nil, errwrap.Wrapf(err, "dir: `%s` is not a dir", s)
+		return nil, fmt.Errorf("dir: `%s` is not a dir", s)
 	}
 
 	// try looking for a metadata file in the root

--- a/pgp/pgp.go
+++ b/pgp/pgp.go
@@ -36,6 +36,7 @@ import (
 	"bytes"
 	"crypto"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -230,13 +231,13 @@ func ParseIdentity(identity string) (name, comment, email string, err error) {
 	// get name
 	n := strings.Split(identity, " <")
 	if len(n) != 2 {
-		return "", "", "", errwrap.Wrapf(err, "user string malformed")
+		return "", "", "", fmt.Errorf("user string malformed")
 	}
 
 	// get email and comment
 	ec := strings.Split(n[1], "> ")
 	if len(ec) != 2 {
-		return "", "", "", errwrap.Wrapf(err, "user string malformed")
+		return "", "", "", fmt.Errorf("user string malformed")
 	}
 
 	return n[0], ec[1], ec[0], nil


### PR DESCRIPTION
Found several instances where `errwrap.Wrapf(err, ...)` was called even though `err` was guaranteed to be `nil` (either by previous checks or being an uninitialized named return). Since `errwrap.Wrapf` returns `nil` when its input error is `nil`, these calls were mistakenly returning success instead of an error. Converted these to `fmt.Errorf`.

---
*PR created automatically by Jules for task [3302323015338650016](https://jules.google.com/task/3302323015338650016) started by @purpleidea*