### PR TITLE
Fix errwrap.Wrapf nil error bugs

### DIFF
--- a/engine/graph/reverse.go
+++ b/engine/graph/reverse.go
@@ -115,7 +115,7 @@ func (obj *Engine) Reversals() error {
 		res, ok := r.(engine.ReversibleRes)
 		if !ok {
 			// this requirement is here to keep things simpler...
-			return errwrap.Wrapf(err, "decoded res with UID: `%s` was not reversible", key)
+			return fmt.Errorf("decoded res with UID: `%s` was not reversible", key)
 		}
 
 		matchFn := func(vertex pgraph.Vertex) (bool, error) {

--- a/engine/resources/docker_container.go
+++ b/engine/resources/docker_container.go
@@ -414,7 +414,10 @@ func (obj *DockerContainerRes) containerStart(ctx context.Context, id string, op
 		if event.Status != "start" {
 			return fmt.Errorf("unexpected event: %+v", event)
 		}
-	case err := <-errCh:
+	case err, ok := <-errCh:
+		if !ok {
+			return fmt.Errorf("error waiting for container start: channel closed")
+		}
 		return errwrap.Wrapf(err, "error waiting for container start")
 	}
 	return nil
@@ -431,7 +434,10 @@ func (obj *DockerContainerRes) containerStop(ctx context.Context, id string, tim
 	// TODO: Should we add ctx here or does cancelling above guarantee exit?
 	select {
 	case <-ch:
-	case err := <-errCh:
+	case err, ok := <-errCh:
+		if !ok {
+			return fmt.Errorf("error waiting for container stop: channel closed")
+		}
 		return errwrap.Wrapf(err, "error waiting for container to stop")
 	}
 	return nil
@@ -446,7 +452,10 @@ func (obj *DockerContainerRes) containerRemove(ctx context.Context, id string, o
 	// TODO: Should we add ctx here or does cancelling above guarantee exit?
 	select {
 	case <-ch:
-	case err := <-errCh:
+	case err, ok := <-errCh:
+		if !ok {
+			return fmt.Errorf("error waiting for container to be removed: channel closed")
+		}
 		return errwrap.Wrapf(err, "error waiting for container to be removed")
 	}
 	return nil

--- a/engine/resources/firewalld.go
+++ b/engine/resources/firewalld.go
@@ -269,7 +269,7 @@ func (obj *FirewalldRes) Watch(ctx context.Context) error {
 				return nil
 			}
 			if event.Error != nil {
-				return errwrap.Wrapf(err, "monitor err")
+				return fmt.Errorf("monitor err: %v", event.Error)
 			}
 			if obj.init.Debug {
 				//obj.init.Logf("event: %#v", event)

--- a/engine/resources/virt_builder.go
+++ b/engine/resources/virt_builder.go
@@ -679,17 +679,17 @@ func (obj *VirtBuilderRes) CheckApply(ctx context.Context, apply bool) (bool, er
 	exitErr, ok := cmderr.(*exec.ExitError) // embeds an os.ProcessState
 	if !ok {
 		// command failed in some bad way
-		return false, errwrap.Wrapf(err, "cmd failed in some bad way")
+		return false, errwrap.Wrapf(cmderr, "cmd failed in some bad way")
 	}
 	pStateSys := exitErr.Sys() // (*os.ProcessState) Sys
 	wStatus, ok := pStateSys.(syscall.WaitStatus)
 	if !ok {
-		return false, errwrap.Wrapf(err, "could not get exit status of cmd")
+		return false, errwrap.Wrapf(cmderr, "could not get exit status of cmd")
 	}
 	exitStatus := wStatus.ExitStatus()
 	if exitStatus == 0 {
 		// i'm not sure if this could happen
-		return false, errwrap.Wrapf(err, "unexpected cmd exit status of zero")
+		return false, errwrap.Wrapf(cmderr, "unexpected cmd exit status of zero")
 	}
 
 	obj.init.Logf("cmd: %s", strings.Join(cmd.Args, " "))
@@ -698,7 +698,7 @@ func (obj *VirtBuilderRes) CheckApply(ctx context.Context, apply bool) (bool, er
 	} else {
 		obj.init.Logf("cmd error:\n%s", out) // newline because it's long
 	}
-	return false, errwrap.Wrapf(err, "cmd error") // exit status will be in the error
+	return false, errwrap.Wrapf(cmderr, "cmd error") // exit status will be in the error
 }
 
 // Cmp compares two resources and returns an error if they are not equivalent.

--- a/lang/ast/structs.go
+++ b/lang/ast/structs.go
@@ -10115,7 +10115,7 @@ func (obj *ExprFunc) Graph(env *interfaces.Env) (*pgraph.Graph, interfaces.Func,
 			funcExprCopy, ok := exprCopy.(*ExprFunc)
 			if !ok {
 				// programming error
-				return nil, errwrap.Wrapf(err, "ExprFunc.Copy() does not produce an ExprFunc")
+				return nil, fmt.Errorf("ExprFunc.Copy() does not produce an ExprFunc")
 			}
 			valueTransformingFunc := funcExprCopy.function
 			txn.AddVertex(valueTransformingFunc)


### PR DESCRIPTION
I have identified and fixed several bugs where `errwrap.Wrapf` was used incorrectly with a `nil` error, causing functions to return success instead of an intended error message.

- In `engine/resources/firewalld.go`, I replaced a call that used the wrong (nil) variable with a `fmt.Errorf` using `event.Error`.
- In `engine/resources/docker_container.go`, I added checks for closed error channels in three locations to prevent silent success when an expected event was not received.

I also investigated `lang/ast/structs.go:2905` and confirmed that Go's scoping rules prevent a bug there.
I acknowledged that the user will handle the bug in `engine/resources/svc.go:401`.

---
*PR created automatically by Jules for task [1801004162543345132](https://jules.google.com/task/1801004162543345132) started by @purpleidea*