### PR TITLE
cli: add provisioner subcommand to help output

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -131,6 +131,9 @@ type Args struct {
 	// XXX: Can we do it nicely with the new arg parser? can it ignore all args?
 	EtcdCmd *EtcdArgs `arg:"subcommand:etcd" help:"run standalone etcd"`
 
+	// This never runs, it gets preempted in the real main() function.
+	ProvisionerCmd *ProvisionerArgs `arg:"subcommand:provisioner" help:"provision bare metal machines"`
+
 	// version is a private handle for our version string.
 	version string `arg:"-"` // ignored from parsing
 
@@ -187,3 +190,8 @@ func (obj *Args) Run(ctx context.Context, data *cliUtil.Data) (bool, error) {
 // particular one is empty because the `etcd` subcommand is preempted in the
 // real main() function.
 type EtcdArgs struct{}
+
+// ProvisionerArgs is the CLI parsing structure and type of the parsed result.
+// This particular one is empty because the `provisioner` subcommand is
+// preempted in the real main() function via the entry package.
+type ProvisionerArgs struct{}


### PR DESCRIPTION
The provisioner command was registered via the entry package but never showed up in `mgmt --help` because the go-arg parser only knows about subcommands defined as struct fields in `cli.Args`.

We add a dummy `ProvisionerCmd` field following the same pattern already used by `EtcdCmd` — both get preempted in `main()` before the parser acts on them, but their presence in the struct is enough for go-arg to include them in the help text.

Closes #841