### PR TITLE
docker: fix deprecated instructions and improve build caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,5 @@
 docker
+build
+rpmbuild
+old
+tmp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,19 @@
 FROM golang:1.24
 
-MAINTAINER Michał Czeraszkiewicz <contact@czerasz.com>
+LABEL maintainer="Michał Czeraszkiewicz <contact@czerasz.com>"
 
-# Set the reset cache variable
-# Read more here: http://czerasz.com/2014/11/13/docker-tip-and-tricks/#use-refreshedat-variable-for-better-cache-control
-ENV REFRESHED_AT 2020-09-23
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Update the package list to be able to use required packages
-RUN apt-get update
-
-# Change the working directory
 WORKDIR /go/src/mgmt
 
-# Copy all the files to the working directory
+# Copy module files first for better layer caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the full source tree
 COPY . /go/src/mgmt
 
-# Install dependencies
+# Install system and golang dependencies
 RUN make deps
 
 # Build the binary


### PR DESCRIPTION
The Dockerfile had a few issues: `MAINTAINER` has been deprecated since Docker 1.13 in favor of `LABEL`, and the `ENV` used the legacy format without an equals sign. The `REFRESHED_AT` cache-busting variable from 2020 wasn't serving any purpose, so we removed it.

We replaced it with `DEBIAN_FRONTEND=noninteractive` which suppresses the debconf frontend warnings that were cluttering the build output. The standalone `apt-get update` was also redundant since `make deps` runs its own update.

We also added a `go mod download` step before copying the full source tree so that module downloads get cached in a separate layer — rebuilding after a code change no longer re-downloads all Go dependencies.

The `.dockerignore` now excludes `build/`, `rpmbuild/`, `old/`, and `tmp/` to reduce the build context.

Tested by building the image and verifying the resulting binary runs.