### PR TITLE
Port int64/uint64 to int/uint for 32-bit compatibility

### DIFF
--- a/engine/graph/actions.go
+++ b/engine/graph/actions.go
@@ -475,7 +475,7 @@ func (obj *Engine) Worker(vertex pgraph.Vertex) error {
 
 		var err error
 		var retry = res.MetaParams().Retry // lookup the retry value
-		var delay uint64
+		var delay uint
 		for { // retry loop
 			// a retry-delay was requested, wait, but don't block events!
 			if delay > 0 {
@@ -706,7 +706,7 @@ Loop:
 		// retry...
 		var err error
 		//var retry = res.MetaParams().Retry // lookup the retry value
-		var delay uint64
+		var delay uint
 	RetryLoop:
 		for { // retry loop
 			if delay > 0 {

--- a/engine/metaparams.go
+++ b/engine/metaparams.go
@@ -90,7 +90,7 @@ type MetaParams struct {
 
 	// Delay is the number of milliseconds to wait between retries. This
 	// value is used for both Watch and CheckApply.
-	Delay uint64 `yaml:"delay"`
+	Delay uint `yaml:"delay"`
 
 	// Poll is the number of seconds between poll intervals. Use 0 to Watch.
 	Poll uint32 `yaml:"poll"`

--- a/engine/resources/docker_container.go
+++ b/engine/resources/docker_container.go
@@ -85,7 +85,7 @@ type DockerContainerRes struct {
 	// Ports is a map of port bindings. E.g. {"tcp" => {8080 => 80},}. The
 	// key is the host port, and the val is the inner service port to
 	// forward to.
-	Ports map[string]map[int64]int64 `lang:"ports" yaml:"ports"`
+	Ports map[string]map[int]int `lang:"ports" yaml:"ports"`
 
 	// APIVersion allows you to override the host's default client API
 	// version.

--- a/engine/resources/exec.go
+++ b/engine/resources/exec.go
@@ -105,7 +105,7 @@ type ExecRes struct {
 	// Timeout is the number of seconds to wait before sending a Kill to the
 	// running command. If the Kill is received before the process exits,
 	// then this be treated as an error.
-	Timeout uint64 `lang:"timeout" yaml:"timeout"`
+	Timeout uint `lang:"timeout" yaml:"timeout"`
 
 	// Env allows the user to specify environment variables for script
 	// execution. These are taken using a map of format of VAR_KEY -> value.

--- a/engine/resources/gsettings.go
+++ b/engine/resources/gsettings.go
@@ -156,11 +156,11 @@ func (obj *GsettingsRes) value() (string, error) {
 	}
 
 	if obj.Type == "int" {
-		v, ok := obj.Value.(int64)
+		v, ok := obj.Value.(int)
 		if !ok {
 			return "", fmt.Errorf("invalid int, got: %T", obj.Value)
 		}
-		return strconv.FormatInt(v, 10), nil
+		return strconv.Itoa(v), nil
 	}
 
 	if obj.Type == "custom" {

--- a/engine/resources/http_server.go
+++ b/engine/resources/http_server.go
@@ -118,19 +118,19 @@ type HTTPServerRes struct {
 	// the value for the other *Timeout values when they aren't used. Put
 	// another way, this makes it easy to set all the different timeouts
 	// with a single parameter.
-	Timeout *uint64 `lang:"timeout" yaml:"timeout"`
+	Timeout *uint `lang:"timeout" yaml:"timeout"`
 
 	// ReadTimeout is the maximum duration in seconds for reading during the
 	// http request. If it is zero, then there is no timeout. If this is
 	// unspecified, then the value of Timeout is used instead if it is set.
 	// For more information, see the golang net/http Server documentation.
-	ReadTimeout *uint64 `lang:"read_timeout" yaml:"read_timeout"`
+	ReadTimeout *uint `lang:"read_timeout" yaml:"read_timeout"`
 
 	// WriteTimeout is the maximum duration in seconds for writing during
 	// the http request. If it is zero, then there is no timeout. If this is
 	// unspecified, then the value of Timeout is used instead if it is set.
 	// For more information, see the golang net/http Server documentation.
-	WriteTimeout *uint64 `lang:"write_timeout" yaml:"write_timeout"`
+	WriteTimeout *uint `lang:"write_timeout" yaml:"write_timeout"`
 
 	// ShutdownTimeout is the maximum duration in seconds to wait for the
 	// server to shutdown gracefully before calling Close. By default it is
@@ -141,7 +141,7 @@ type HTTPServerRes struct {
 	// indefinitely. The shutdown process can also be cancelled by the
 	// interrupt handler which this resource supports. If this is
 	// unspecified, then the value of Timeout is used instead if it is set.
-	ShutdownTimeout *uint64 `lang:"shutdown_timeout" yaml:"shutdown_timeout"`
+	ShutdownTimeout *uint `lang:"shutdown_timeout" yaml:"shutdown_timeout"`
 
 	// Root is the root directory that we should serve files from. If it is
 	// not specified, then it is not used. Any http file resources will have
@@ -175,7 +175,7 @@ func (obj *HTTPServerRes) getAddress() string {
 
 // getReadTimeout determines the value for ReadTimeout, because if unspecified,
 // this will default to the value of Timeout.
-func (obj *HTTPServerRes) getReadTimeout() *uint64 {
+func (obj *HTTPServerRes) getReadTimeout() *uint {
 	if obj.ReadTimeout != nil {
 		return obj.ReadTimeout
 	}
@@ -184,7 +184,7 @@ func (obj *HTTPServerRes) getReadTimeout() *uint64 {
 
 // getWriteTimeout determines the value for WriteTimeout, because if
 // unspecified, this will default to the value of Timeout.
-func (obj *HTTPServerRes) getWriteTimeout() *uint64 {
+func (obj *HTTPServerRes) getWriteTimeout() *uint {
 	if obj.WriteTimeout != nil {
 		return obj.WriteTimeout
 	}
@@ -193,7 +193,7 @@ func (obj *HTTPServerRes) getWriteTimeout() *uint64 {
 
 // getShutdownTimeout determines the value for ShutdownTimeout, because if
 // unspecified, this will default to the value of Timeout.
-func (obj *HTTPServerRes) getShutdownTimeout() *uint64 {
+func (obj *HTTPServerRes) getShutdownTimeout() *uint {
 	if obj.ShutdownTimeout != nil {
 		return obj.ShutdownTimeout
 	}
@@ -407,11 +407,11 @@ func (obj *HTTPServerRes) Watch(ctx context.Context) error {
 	// essentially having our own "router" API with AcceptHTTP.
 	obj.serveMux.HandleFunc("/", obj.handler())
 
-	readTimeout := uint64(0)
+	readTimeout := uint(0)
 	if i := obj.getReadTimeout(); i != nil {
 		readTimeout = *i
 	}
-	writeTimeout := uint64(0)
+	writeTimeout := uint(0)
 	if i := obj.getWriteTimeout(); i != nil {
 		writeTimeout = *i
 	}
@@ -664,7 +664,7 @@ func (obj *HTTPServerRes) Interrupt() error {
 // Copy copies the resource. Don't call it directly, use engine.ResCopy instead.
 // TODO: should this copy internal state?
 func (obj *HTTPServerRes) Copy() engine.CopyableRes {
-	var timeout, readTimeout, writeTimeout, shutdownTimeout *uint64
+	var timeout, readTimeout, writeTimeout, shutdownTimeout *uint
 	if obj.Timeout != nil {
 		x := *obj.Timeout
 		timeout = &x

--- a/engine/resources/resources_test.go
+++ b/engine/resources/resources_test.go
@@ -204,7 +204,7 @@ func FileOwnerExpect(p, o string) Step { // path & owner
 			if err != nil {
 				return err
 			}
-			if i != uint64(stat.Uid) {
+			if uint32(i) != stat.Uid {
 				return fmt.Errorf("file uid did not match in %s", p)
 			}
 			return nil

--- a/engine/resources/tar.go
+++ b/engine/resources/tar.go
@@ -61,22 +61,22 @@ func init() {
 		"format": {
 			"unknown": func() interfaces.Var {
 				return &types.IntValue{
-					V: int64(tar.FormatUnknown),
+					V: int(tar.FormatUnknown),
 				}
 			},
 			"ustar": func() interfaces.Var {
 				return &types.IntValue{
-					V: int64(tar.FormatUSTAR),
+					V: int(tar.FormatUSTAR),
 				}
 			},
 			"pax": func() interfaces.Var {
 				return &types.IntValue{
-					V: int64(tar.FormatPAX),
+					V: int(tar.FormatPAX),
 				}
 			},
 			"gnu": func() interfaces.Var {
 				return &types.IntValue{
-					V: int64(tar.FormatGNU),
+					V: int(tar.FormatGNU),
 				}
 			},
 		},

--- a/engine/resources/tftp.go
+++ b/engine/resources/tftp.go
@@ -84,7 +84,7 @@ type TFTPServerRes struct {
 	Address string `lang:"address" yaml:"address"`
 
 	// Timeout is the timeout in seconds to use for server connections.
-	Timeout uint64 `lang:"timeout" yaml:"timeout"`
+	Timeout uint `lang:"timeout" yaml:"timeout"`
 
 	// Root is the root directory that we should serve files from. If it is
 	// not specified, then it is not used. Any tftp file resources will have

--- a/examples/dhcp_client/dhcp_client.go
+++ b/examples/dhcp_client/dhcp_client.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"strconv"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
@@ -39,7 +40,7 @@ func main() {
 		return
 	}
 
-	port := string(nclient4.ServerPort) // the default is 67
+	port := strconv.Itoa(int(nclient4.ServerPort)) // the default is 67
 	if len(os.Args) >= 3 {
 		port = os.Args[1]
 	}

--- a/lang/ast/structs.go
+++ b/lang/ast/structs.go
@@ -3988,7 +3988,7 @@ func (obj *StmtFor) Graph(env *interfaces.Env) (*pgraph.Graph, error) {
 					Textarea: obj.Textarea, // XXX: advance by `for ` chars?
 
 					Value: &types.IntValue{
-						V: int64(index),
+						V: index,
 					},
 					NameHint: obj.Index, // XXX: is this right?
 				}
@@ -7718,7 +7718,7 @@ type ExprInt struct {
 	data  *interfaces.Data
 	scope *interfaces.Scope // store for referencing this later
 
-	V int64
+	V int
 }
 
 // String returns a short representation of this expression.

--- a/lang/core/convert/str_to_int.go
+++ b/lang/core/convert/str_to_int.go
@@ -57,9 +57,7 @@ func StrToInt(ctx context.Context, input []types.Value) (types.Value, error) {
 		return nil, fmt.Errorf("not enough args")
 	}
 
-	base := 10
-	bits := 64 // TODO: get from runtime?
-	x, err := strconv.ParseInt(input[0].Str(), base, bits)
+	x, err := strconv.Atoi(input[0].Str())
 	if err != nil {
 		return nil, err
 	}

--- a/lang/core/convert/to_float_test.go
+++ b/lang/core/convert/to_float_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/purpleidea/mgmt/lang/types"
 )
 
-func testToFloat(t *testing.T, input int64, expected float64) {
+func testToFloat(t *testing.T, input int, expected float64) {
 	got, err := ToFloat(context.Background(), []types.Value{&types.IntValue{V: input}})
 	if err != nil {
 		t.Error(err)

--- a/lang/core/convert/to_int.go
+++ b/lang/core/convert/to_int.go
@@ -52,6 +52,6 @@ func init() {
 // ToInt converts a float to an integer.
 func ToInt(ctx context.Context, input []types.Value) (types.Value, error) {
 	return &types.IntValue{
-		V: int64(input[0].Float()),
+		V: int(input[0].Float()),
 	}, nil
 }

--- a/lang/core/convert/to_int_test.go
+++ b/lang/core/convert/to_int_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/purpleidea/mgmt/lang/types"
 )
 
-func testToInt(t *testing.T, input float64, expected int64) {
+func testToInt(t *testing.T, input float64, expected int) {
 
 	got, err := ToInt(context.Background(), []types.Value{&types.FloatValue{V: input}})
 	if err != nil {

--- a/lang/core/datetime/format.go
+++ b/lang/core/datetime/format.go
@@ -62,7 +62,7 @@ func Format(ctx context.Context, input []types.Value) (types.Value, error) {
 	}
 	format := input[1].Str()
 
-	v := time.Unix(epochDelta, 0).Format(format)
+	v := time.Unix(int64(epochDelta), 0).Format(format)
 	return &types.StrValue{
 		V: v,
 	}, nil

--- a/lang/core/datetime/hour.go
+++ b/lang/core/datetime/hour.go
@@ -60,8 +60,8 @@ func Hour(ctx context.Context, input []types.Value) (types.Value, error) {
 		return nil, fmt.Errorf("epoch delta must be positive")
 	}
 
-	hour := time.Unix(epochDelta, 0).Hour()
+	hour := time.Unix(int64(epochDelta), 0).Hour()
 	return &types.IntValue{
-		V: int64(hour),
+		V: hour,
 	}, nil
 }

--- a/lang/core/datetime/now.go
+++ b/lang/core/datetime/now.go
@@ -118,6 +118,6 @@ func (obj *Now) Stream(ctx context.Context) error {
 // Call this fact and return the value if it is possible to do so at this time.
 func (obj *Now) Call(ctx context.Context, args []types.Value) (types.Value, error) {
 	return &types.IntValue{ // seconds since 1970...
-		V: time.Now().Unix(), // .UTC() not necessary
+		V: int(time.Now().Unix()), // .UTC() not necessary
 	}, nil
 }

--- a/lang/core/datetime/print.go
+++ b/lang/core/datetime/print.go
@@ -59,6 +59,6 @@ func Print(ctx context.Context, input []types.Value) (types.Value, error) {
 		return nil, fmt.Errorf("epoch delta must be positive")
 	}
 	return &types.StrValue{
-		V: time.Unix(epochDelta, 0).String(),
+		V: time.Unix(int64(epochDelta), 0).String(),
 	}, nil
 }

--- a/lang/core/datetime/weekday.go
+++ b/lang/core/datetime/weekday.go
@@ -61,7 +61,7 @@ func Weekday(ctx context.Context, input []types.Value) (types.Value, error) {
 		return nil, fmt.Errorf("epoch delta must be positive")
 	}
 
-	weekday := time.Unix(epochDelta, 0).Weekday()
+	weekday := time.Unix(int64(epochDelta), 0).Weekday()
 	return &types.StrValue{
 		V: strings.ToLower(weekday.String()),
 	}, nil

--- a/lang/core/example/str2int.go
+++ b/lang/core/example/str2int.go
@@ -53,8 +53,8 @@ func init() {
 // Str2Int takes an str, and returns it as an int. If it can't convert it, it
 // returns 0.
 func Str2Int(ctx context.Context, input []types.Value) (types.Value, error) {
-	var i int64
-	if val, err := strconv.ParseInt(input[0].Str(), 10, 64); err == nil {
+	var i int
+	if val, err := strconv.Atoi(input[0].Str()); err == nil {
 		i = val
 	}
 	return &types.IntValue{

--- a/lang/core/history.go
+++ b/lang/core/history.go
@@ -82,8 +82,8 @@ type HistoryFunc struct {
 
 	init *interfaces.Init
 
-	input chan int64
-	delay *int64
+	input chan int
+	delay *int
 
 	value     types.Value // last value
 	buffer    []*valueWithTimestamp
@@ -187,7 +187,7 @@ func (obj *HistoryFunc) Info() *interfaces.Info {
 // Init runs some startup code for this function.
 func (obj *HistoryFunc) Init(init *interfaces.Init) error {
 	obj.init = init
-	obj.input = make(chan int64)
+	obj.input = make(chan int)
 	obj.mutex = &sync.Mutex{}
 	return nil
 }

--- a/lang/core/iter/range.go
+++ b/lang/core/iter/range.go
@@ -191,7 +191,7 @@ func (obj *RangeFunc) Call(ctx context.Context, args []types.Value) (types.Value
 
 // loop is the private helper function that calculates the range according to
 // the inputs provided.
-func (obj *RangeFunc) loop(ctx context.Context, start, stop, step int64) (types.Value, error) {
+func (obj *RangeFunc) loop(ctx context.Context, start, stop, step int) (types.Value, error) {
 	if step == 0 {
 		return nil, fmt.Errorf("step value cannot be 0")
 	}

--- a/lang/core/len.go
+++ b/lang/core/len.go
@@ -98,6 +98,6 @@ func Len(ctx context.Context, input []types.Value) (types.Value, error) {
 	}
 
 	return &types.IntValue{
-		V: int64(length),
+		V: length,
 	}, nil
 }

--- a/lang/core/local/pool.go
+++ b/lang/core/local/pool.go
@@ -145,6 +145,6 @@ func (obj *PoolFunc) Call(ctx context.Context, args []types.Value) (types.Value,
 		return nil, err
 	}
 	return &types.IntValue{
-		V: int64(result),
+		V: result,
 	}, nil
 }

--- a/lang/core/math/mod.go
+++ b/lang/core/math/mod.go
@@ -90,6 +90,6 @@ func Mod(ctx context.Context, input []types.Value) (types.Value, error) {
 		}, nil
 	}
 	return &types.IntValue{
-		V: int64(z), // XXX: does this truncate?
+		V: int(z), // XXX: does this truncate?
 	}, nil
 }

--- a/lang/core/sys/cpucount.go
+++ b/lang/core/sys/cpucount.go
@@ -181,13 +181,13 @@ func (obj *CPUCount) Call(ctx context.Context, args []types.Value) (types.Value,
 	}
 
 	return &types.IntValue{
-		V: int64(count),
+		V: count,
 	}, nil
 
 }
 
 // getCPUCount looks in sysfs to get the number of CPUs that are online.
-func getCPUCount() (int64, error) {
+func getCPUCount() (int, error) {
 	dat, err := os.ReadFile("/sys/devices/system/cpu/online")
 	if err != nil {
 		return 0, err
@@ -198,18 +198,18 @@ func getCPUCount() (int64, error) {
 // Parses a line of the form X,Y,Z,... where X,Y,Z can be either a single CPU or
 // a contiguous range of CPUs. e.g. "2,4-31,32-63". If there is an error parsing
 // the line the function will return 0.
-func parseCPUList(list string) (int64, error) {
-	var count int64
+func parseCPUList(list string) (int, error) {
+	var count int
 	for _, rg := range strings.Split(list, ",") {
 		cpuRange := strings.SplitN(rg, "-", 2)
 		if len(cpuRange) == 1 {
 			count++
 		} else if len(cpuRange) == 2 {
-			lo, err := strconv.ParseInt(cpuRange[0], 10, 64)
+			lo, err := strconv.Atoi(cpuRange[0])
 			if err != nil {
 				return 0, err
 			}
-			hi, err := strconv.ParseInt(strings.TrimRight(cpuRange[1], "\n"), 10, 64)
+			hi, err := strconv.Atoi(strings.TrimRight(cpuRange[1], "\n"))
 			if err != nil {
 				return 0, err
 			}

--- a/lang/core/sys/cpucount_test.go
+++ b/lang/core/sys/cpucount_test.go
@@ -39,7 +39,7 @@ func TestParseCPUList(t *testing.T) {
 	var cpulistTests = []struct {
 		desc   string
 		list   string
-		result int64
+		result int
 	}{
 		{
 			desc:   "single CPU",

--- a/lang/core/sys/uptime.go
+++ b/lang/core/sys/uptime.go
@@ -118,6 +118,6 @@ func (obj *Uptime) Call(ctx context.Context, args []types.Value) (types.Value, e
 	}
 
 	return &types.IntValue{
-		V: uptime,
+		V: int(uptime),
 	}, nil
 }

--- a/lang/core/test/fastcount.go
+++ b/lang/core/test/fastcount.go
@@ -116,6 +116,6 @@ func (obj *FastCount) Call(ctx context.Context, args []types.Value) (types.Value
 	count := obj.count
 	obj.mutex.Unlock()
 	return &types.IntValue{
-		V: int64(count),
+		V: count,
 	}, nil
 }

--- a/lang/funcs/dage/dage.go
+++ b/lang/funcs/dage/dage.go
@@ -145,7 +145,7 @@ type Engine struct {
 	// graphvizCount keeps a running tally of how many graphs we've
 	// generated. This is useful for displaying a sequence (timeline) of
 	// graphs in a linear order.
-	graphvizCount int64
+	graphvizCount int
 
 	// graphvizDirectory stores the generated path for outputting graphviz
 	// files if one is not specified at runtime.
@@ -206,7 +206,7 @@ func (obj *Engine) Run(ctx context.Context) error {
 // process could be combined with Run, but it is left separate in case we try to
 // build a recursive process operation that runs on a subgraph. It would need an
 // incoming graph argument as well, I would expect.
-func (obj *Engine) process(ctx context.Context, epoch int64) error {
+func (obj *Engine) process(ctx context.Context, epoch int) error {
 
 	mapping := make(map[pgraph.Vertex]int)
 	start := 0
@@ -1048,7 +1048,7 @@ type state struct {
 	// epoch represents the "iteration count" through the graph. All values
 	// in a returned table should be part of the same epoch. This guarantees
 	// that they're all consistent with respect to each other.
-	epoch int64 // if this rolls over, we've been running for too many years
+	epoch int // if this rolls over, we've been running for too many years
 
 	// result is the latest output from calling this function.
 	result types.Value

--- a/lang/funcs/funcgen/config.go
+++ b/lang/funcs/funcgen/config.go
@@ -31,7 +31,6 @@ package main
 
 import (
 	"fmt"
-	"math/bits"
 
 	"github.com/purpleidea/mgmt/lang/types"
 )
@@ -112,13 +111,9 @@ func (obj *arg) ToGolang(val string) (string, error) {
 		return fmt.Sprintf("%s.Str()", val), nil
 
 	case "int":
-		// TODO: consider switching types.Value int64 to int everywhere
-		if bits.UintSize == 32 { // special case for 32 bit golang
-			return fmt.Sprintf("int(%s.Int())", val), nil
-		}
-		fallthrough
-	case "int64":
 		return fmt.Sprintf("%s.Int()", val), nil
+	case "int64":
+		return fmt.Sprintf("int64(%s.Int())", val), nil
 
 	case "float64":
 		return fmt.Sprintf("%s.Float()", val), nil

--- a/lang/funcs/ref/ref.go
+++ b/lang/funcs/ref/ref.go
@@ -46,10 +46,10 @@ type Count struct {
 	mutex *sync.Mutex
 
 	// vertices is a reference count of the number of vertices used.
-	vertices map[interfaces.Func]int64
+	vertices map[interfaces.Func]int
 
 	// edges is a reference count of the number of edges used.
-	edges map[*CountEdge]int64 // TODO: hash *CountEdge as a key instead
+	edges map[*CountEdge]int // TODO: hash *CountEdge as a key instead
 }
 
 // CountEdge is a virtual "hash" entry for the Count edges map key.
@@ -76,8 +76,8 @@ func (obj *Count) String() string {
 // Init must be called to initialized the struct before first use.
 func (obj *Count) Init() *Count {
 	obj.mutex = &sync.Mutex{}
-	obj.vertices = make(map[interfaces.Func]int64)
-	obj.edges = make(map[*CountEdge]int64)
+	obj.vertices = make(map[interfaces.Func]int)
+	obj.edges = make(map[*CountEdge]int)
 	return obj // return self so it can be called in a chain
 }
 

--- a/lang/types/json/json.go
+++ b/lang/types/json/json.go
@@ -103,10 +103,10 @@ func convertJSON(val interface{}, typ *types.Type, flexible bool) (types.Value, 
 		}
 		v, err := num.Int64()
 		if err != nil {
-			return nil, fmt.Errorf("num doesn't contain int64")
+			return nil, fmt.Errorf("num doesn't contain int")
 		}
 
-		return &types.IntValue{V: v}, nil
+		return &types.IntValue{V: int(v)}, nil
 
 	case types.KindFloat:
 		num, ok := val.(json.Number)

--- a/lang/types/type.go
+++ b/lang/types/type.go
@@ -1037,7 +1037,7 @@ func (obj *Type) Reflect() reflect.Type {
 	case KindStr:
 		return reflect.TypeOf(string(""))
 	case KindInt:
-		return reflect.TypeOf(int64(0))
+		return reflect.TypeOf(int(0))
 	case KindFloat:
 		return reflect.TypeOf(float64(0))
 

--- a/lang/types/type_test.go
+++ b/lang/types/type_test.go
@@ -724,7 +724,7 @@ func TestType2(t *testing.T) {
 		"string": {
 			Kind: KindStr,
 		},
-		"int64": {
+		"int": {
 			Kind: KindInt,
 		},
 		"float64": {
@@ -744,7 +744,7 @@ func TestType2(t *testing.T) {
 				Kind: KindStr,
 			},
 		},
-		"[]int64": {
+		"[]int": {
 			Kind: KindList,
 			Val: &Type{
 				Kind: KindInt,
@@ -761,7 +761,7 @@ func TestType2(t *testing.T) {
 				},
 			},
 		},
-		"[][]int64": {
+		"[][]int": {
 			Kind: KindList,
 			Val: &Type{
 				Kind: KindList,
@@ -793,7 +793,7 @@ func TestType2(t *testing.T) {
 				Kind: KindStr,
 			},
 		},
-		"map[string]int64": {
+		"map[string]int": {
 			Kind: KindMap,
 			Key: &Type{
 				Kind: KindStr,
@@ -804,7 +804,7 @@ func TestType2(t *testing.T) {
 		},
 
 		// nested maps
-		"map[string]map[int64]bool": {
+		"map[string]map[int]bool": {
 			Kind: KindMap,
 			Key: &Type{
 				Kind: KindStr,
@@ -820,7 +820,7 @@ func TestType2(t *testing.T) {
 			},
 		},
 		// FIXME: should we prevent this in our implementation as well?
-		//"map[map[int64]bool]string": &Type{ // no map keys in golang!
+		//"map[map[int]bool]string": &Type{ // no map keys in golang!
 		//	Kind: KindMap,
 		//	Key: &Type{
 		//		Kind: KindMap,
@@ -835,7 +835,7 @@ func TestType2(t *testing.T) {
 		//		Kind: KindStr,
 		//	},
 		//},
-		//"map[map[string]int64]map[int64]bool": &Type{
+		//"map[map[string]int]map[int]bool": &Type{
 		//	Kind: KindMap,
 		//	Key: &Type{
 		//		Kind: KindMap,
@@ -856,7 +856,7 @@ func TestType2(t *testing.T) {
 		//		},
 		//	},
 		//},
-		"map[string]map[int64]map[int64]bool": {
+		"map[string]map[int]map[int]bool": {
 			Kind: KindMap,
 			Key: &Type{
 				Kind: KindStr,
@@ -894,7 +894,7 @@ func TestType2(t *testing.T) {
 				},
 			},
 		},
-		"struct { A bool; Bb int64 }": {
+		"struct { A bool; Bb int }": {
 			Kind: KindStruct,
 			Ord: []string{
 				"A",
@@ -909,7 +909,7 @@ func TestType2(t *testing.T) {
 				},
 			},
 		},
-		"struct { A bool; Bb int64; Ccc string }": {
+		"struct { A bool; Bb int; Ccc string }": {
 			Kind: KindStruct,
 			Ord: []string{
 				"A",
@@ -953,7 +953,7 @@ func TestType2(t *testing.T) {
 				},
 			},
 		},
-		"struct { A bool; Bb struct { Z bool; Yy int64 }; Ccc string }": {
+		"struct { A bool; Bb struct { Z bool; Yy int }; Ccc string }": {
 			Kind: KindStruct,
 			Ord: []string{
 				"A",
@@ -984,7 +984,7 @@ func TestType2(t *testing.T) {
 				},
 			},
 		},
-		"struct { A bool; Bb struct { Z bool; Yy struct { Struct int64; Nested bool } }; Ccc string }": {
+		"struct { A bool; Bb struct { Z bool; Yy struct { Struct int; Nested bool } }; Ccc string }": {
 			Kind: KindStruct,
 			Ord: []string{
 				"A",
@@ -1057,7 +1057,7 @@ func TestType2(t *testing.T) {
 			},
 		},
 
-		"struct { A map[string]map[struct { Deeply int64; Nested bool }]map[int64]bool; Bb struct { Z bool; Yy int64 }; Ccc string }": {
+		"struct { A map[string]map[struct { Deeply int; Nested bool }]map[int]bool; Bb struct { Z bool; Yy int }; Ccc string }": {
 			Kind: KindStruct,
 			Ord: []string{
 				"A",
@@ -1149,7 +1149,7 @@ func TestType2(t *testing.T) {
 				Kind: KindBool,
 			},
 		},
-		"func(string, int64) bool": {
+		"func(string, int) bool": {
 			Kind: KindFunc,
 			// key names are arbitrary...
 			Map: map[string]*Type{
@@ -1168,7 +1168,7 @@ func TestType2(t *testing.T) {
 				Kind: KindBool,
 			},
 		},
-		"func(string, []int64, float64) bool": {
+		"func(string, []int, float64) bool": {
 			Kind: KindFunc,
 			// key names are arbitrary...
 			Map: map[string]*Type{
@@ -1774,7 +1774,7 @@ func TestTypeOf0(t *testing.T) {
 func TestTypeOfSkipPrivateFields(t *testing.T) {
 	type testStruct struct {
 		Name    string
-		Count   int64
+		Count   int
 		private string //nolint:unused
 	}
 

--- a/lang/types/value.go
+++ b/lang/types/value.go
@@ -74,7 +74,7 @@ type Value interface {
 	Value() interface{}
 	Bool() bool
 	Str() string
-	Int() int64
+	Int() int
 	Float() float64
 	List() []Value
 	Map() map[Value]Value // keys must all have same type, same for values
@@ -141,10 +141,10 @@ func ValueOf(v reflect.Value) (Value, error) {
 		return &StrValue{V: value.String()}, nil
 
 	case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8:
-		return &IntValue{V: value.Int()}, nil
+		return &IntValue{V: int(value.Int())}, nil
 
 	case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
-		return &IntValue{V: int64(value.Uint())}, nil
+		return &IntValue{V: int(value.Uint())}, nil
 
 	case reflect.Float64, reflect.Float32:
 		return &FloatValue{V: value.Float()}, nil
@@ -374,11 +374,11 @@ func Into(v Value, rv reflect.Value) error {
 		// overflow check
 		switch kind { // match on destination field kind
 		case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8:
-			ff := reflect.Zero(typ)  // test on a non-ptr equivalent
-			if ff.OverflowInt(v.V) { // this is valid!
+			ff := reflect.Zero(typ)        // test on a non-ptr equivalent
+			if ff.OverflowInt(int64(v.V)) { // this is valid!
 				return fmt.Errorf("%+v is an `%s`, and rv `%d` will overflow it", rv.Interface(), rv.Kind(), v.V)
 			}
-			rv.SetInt(v.V)
+			rv.SetInt(int64(v.V))
 			return nil
 
 		case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
@@ -549,7 +549,7 @@ func (obj *Base) Str() string {
 
 // Int represents the value of this type as an integer if it is one. If this is
 // not an integer, then this panics.
-func (obj *Base) Int() int64 {
+func (obj *Base) Int() int {
 	panic("not an int")
 }
 
@@ -782,7 +782,7 @@ func (obj *StrValue) Str() string {
 // IntValue represents an integer value.
 type IntValue struct {
 	Base
-	V int64
+	V int
 }
 
 // NewInt creates a new int value.
@@ -790,7 +790,7 @@ func NewInt() *IntValue { return &IntValue{} }
 
 // String returns a visual representation of this value.
 func (obj *IntValue) String() string {
-	return strconv.FormatInt(obj.V, 10)
+	return strconv.Itoa(obj.V)
 }
 
 // Type returns the type data structure that represents this type.
@@ -829,13 +829,13 @@ func (obj *IntValue) Value() interface{} {
 
 // Hash hashes this value to provide a unique key for referencing this in a map.
 func (obj *IntValue) Hash(seed Seed) Hash {
-	//return Comparable[int64](seed, obj.V)
+	//return Comparable[int](seed, obj.V)
 	return Comparable(seed, obj.V)
 }
 
 // Int represents the value of this type as an integer if it is one. If this is
 // not an integer, then this panics.
-func (obj *IntValue) Int() int64 {
+func (obj *IntValue) Int() int {
 	return obj.V
 }
 
@@ -1676,8 +1676,8 @@ func (obj *VariantValue) Str() string {
 
 // Int represents the value of this type as an integer if it is one. If this is
 // not an integer, then this panics.
-func (obj *VariantValue) Int() int64 {
-	//return obj.V.(int64)
+func (obj *VariantValue) Int() int {
+	//return obj.V.(int)
 	return obj.V.Int()
 }
 

--- a/lang/types/value_test.go
+++ b/lang/types/value_test.go
@@ -583,7 +583,7 @@ func TestStruct2(t *testing.T) {
 	if val := fmt.Sprintf("%+v", v); val != `{Answer:42 Truth:true Hello: Nested:[]}` {
 		t.Errorf("struct displayed wrong value: %s", val)
 	}
-	if typ := fmt.Sprintf("%T", v); typ != `struct { Answer int64; Truth bool; Hello string; Nested []int64 }` {
+	if typ := fmt.Sprintf("%T", v); typ != `struct { Answer int; Truth bool; Hello string; Nested []int }` {
 		t.Errorf("struct displayed type value: %s", typ)
 	}
 
@@ -618,7 +618,7 @@ func TestValueOf0(t *testing.T) {
 				&IntValue{V: 3},
 				&IntValue{V: 5},
 			},
-		}: []int64{1, 3, 5},
+		}: []int{1, 3, 5},
 		&MapValue{
 			T: NewType("map{str: int}"),
 			V: map[Value]Value{
@@ -783,8 +783,8 @@ func TestValueInto0(t *testing.T) {
 	var b bool
 	var s string
 
-	var i int64
-	var u uint64
+	var i int
+	var u uint
 	var i8 int8
 	var u8 uint8
 
@@ -836,27 +836,27 @@ func TestValueInto0(t *testing.T) {
 		},
 		{
 			container: &i,
-			value:     mustValue(int64(-12345)),
-			compare:   int64(-12345),
+			value:     mustValue(int(-12345)),
+			compare:   int(-12345),
 		},
 		{
 			container: &u,
-			value:     mustValue(uint64(math.MaxUint64)),
-			compare:   uint64(math.MaxUint64),
+			value:     mustValue(uint(math.MaxUint)),
+			compare:   uint(math.MaxUint),
 		},
-		{ // ensure -1 from an int64 fits into an int8
+		{ // ensure -1 from an int fits into an int8
 			container: &i8,
-			value:     mustValue(int64(-1)),
+			value:     mustValue(int(-1)),
 			compare:   int8(-1),
 		},
-		{ // ensure valid uint8 from an int64 fits into an uint8
+		{ // ensure valid uint8 from an int fits into an uint8
 			container: &u8,
-			value:     mustValue(int64(200)),
+			value:     mustValue(int(200)),
 			compare:   uint8(200),
 		},
 		{ // this test case proves overflows work
 			container: &u8,
-			value:     mustValue(int64(256)),
+			value:     mustValue(int(256)),
 			shouldErr: true,
 		},
 		{ // it would be good to put float32 -> float64 here but precision says no


### PR DESCRIPTION
Ported `int64` and `uint64` to `int` and `uint` respectively throughout the codebase to support 32-bit machines. This includes core types, AST, built-in functions, and resource parameters. Library-dependent 64-bit types were preserved with explicit casts where necessary.

---
*PR created automatically by Jules for task [7771913843721359248](https://jules.google.com/task/7771913843721359248) started by @purpleidea*