### PR TITLE
Port Running() and Event() to func(context.Context) error

### DIFF
--- a/docs/function-guide.md
+++ b/docs/function-guide.md
@@ -200,7 +200,7 @@ Stream(context.Context) error
 
 `Stream` is where any evented work is done. This method is started by the
 function engine. It will run this function once. It should call the
-`obj.init.Event()` method when it believes the function engine should run
+`obj.init.Event(ctx)` method when it believes the function engine should run
 `Call()` again.
 
 Implementing this is not required if you don't have events.

--- a/docs/resource-guide.md
+++ b/docs/resource-guide.md
@@ -359,7 +359,7 @@ func (obj *FooRes) Watch(ctx context.Context) error {
 	defer obj.whatever.CloseFoo() // shutdown our Foo
 
 	// notify engine that we're running
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -378,7 +378,7 @@ func (obj *FooRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 ```

--- a/engine/resources.go
+++ b/engine/resources.go
@@ -144,10 +144,10 @@ type Init struct {
 	// Called from within Watch:
 
 	// Running must be called after your watches are all started and ready.
-	Running func()
+	Running func(context.Context) error
 
 	// Event sends an event notifying the engine of a possible state change.
-	Event func()
+	Event func(context.Context) error
 
 	// Called from within CheckApply:
 

--- a/engine/resources/augeas.go
+++ b/engine/resources/augeas.go
@@ -143,7 +143,7 @@ func (obj *AugeasRes) Watch(ctx context.Context) error {
 	}
 	defer recWatcher.Close()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		if obj.init.Debug {
@@ -166,7 +166,7 @@ func (obj *AugeasRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/aws_ec2.go
+++ b/engine/resources/aws_ec2.go
@@ -449,7 +449,7 @@ func (obj *AwsEc2Res) Watch(ctx context.Context) error {
 func (obj *AwsEc2Res) longpollWatch(ctx context.Context) error {
 	// We tell the engine that we're running right away. This is not correct,
 	// but the api doesn't have a way to signal when the waiters are ready.
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	// cancellable context used for exiting cleanly
 	innerCtx, cancel := context.WithCancel(context.TODO())
@@ -531,7 +531,7 @@ func (obj *AwsEc2Res) longpollWatch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 
@@ -611,7 +611,7 @@ func (obj *AwsEc2Res) snsWatch(ctx context.Context) error {
 			// is confirmed, we are ready to receive events, so we
 			// can notify the engine that we're running.
 			if msg.event == awsEc2EventWatchReady {
-				obj.init.Running() // when started, notify engine that we're running
+				if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 				continue
 			}
 			obj.init.Logf("State: %v", msg.event)
@@ -620,7 +620,7 @@ func (obj *AwsEc2Res) snsWatch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/bmc_firmware.go
+++ b/engine/resources/bmc_firmware.go
@@ -269,13 +269,13 @@ func (obj *BmcFirmwareRes) Cleanup() error {
 
 // Watch is the primary listener for this resource and it outputs events.
 func (obj *BmcFirmwareRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }

--- a/engine/resources/bmc_power.go
+++ b/engine/resources/bmc_power.go
@@ -351,13 +351,13 @@ func (obj *BmcPowerRes) client() *bmclib.Client {
 
 // Watch is the primary listener for this resource and it outputs events.
 func (obj *BmcPowerRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }

--- a/engine/resources/consul_kv.go
+++ b/engine/resources/consul_kv.go
@@ -168,7 +168,7 @@ func (obj *ConsulKVRes) Watch(ctx context.Context) error {
 				}
 
 				if !obj.once {
-					obj.init.Running()
+					if err := obj.init.Running(ctx); err != nil { return err }
 					obj.once = true
 					continue
 				}
@@ -198,7 +198,7 @@ func (obj *ConsulKVRes) Watch(ctx context.Context) error {
 			if obj.init.Debug {
 				obj.init.Logf("event!")
 			}
-			obj.init.Event()
+			if err := obj.init.Event(ctx); err != nil { return err }
 
 		case <-ctx.Done(): // signal for shutdown request
 			return nil

--- a/engine/resources/cron.go
+++ b/engine/resources/cron.go
@@ -298,7 +298,7 @@ func (obj *CronRes) Watch(ctx context.Context) error {
 	}
 	defer recWatcher.Close()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -324,7 +324,7 @@ func (obj *CronRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/deploy_tar.go
+++ b/engine/resources/deploy_tar.go
@@ -156,7 +156,7 @@ func (obj *DeployTar) Watch(ctx context.Context) error {
 	}
 	defer recWatcher.Close()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -178,7 +178,7 @@ func (obj *DeployTar) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/dhcp.go
+++ b/engine/resources/dhcp.go
@@ -484,7 +484,7 @@ func (obj *DHCPServerRes) Watch(ctx context.Context) error {
 		return errwrap.Wrapf(err, "could not start listener") // it's inside
 	}
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 	//defer obj.mutex.RLock()
 	//obj.mutex.RUnlock() // it's safe to let CheckApply proceed
 
@@ -530,7 +530,7 @@ func (obj *DHCPServerRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 
@@ -1134,13 +1134,13 @@ func (obj *DHCPHostRes) Cleanup() error {
 // particular one does absolutely nothing but block until we've received a done
 // signal.
 func (obj *DHCPHostRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }
@@ -1727,13 +1727,13 @@ func (obj *DHCPRangeRes) Cleanup() error {
 // particular one does absolutely nothing but block until we've received a done
 // signal.
 func (obj *DHCPRangeRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }

--- a/engine/resources/docker_container.go
+++ b/engine/resources/docker_container.go
@@ -198,7 +198,7 @@ func (obj *DockerContainerRes) Watch(ctx context.Context) error {
 		if dockerClient.IsErrConnectionFailed(err) && !obj.sflag {
 			// notify engine that we're running so that CheckApply
 			// can start...
-			obj.init.Running()
+			if err := obj.init.Running(ctx); err != nil { return err }
 			select {
 			case <-obj.start:
 				obj.sflag = true
@@ -219,7 +219,7 @@ func (obj *DockerContainerRes) Watch(ctx context.Context) error {
 
 	// notify engine that we're running
 	if !obj.sflag {
-		obj.init.Running()
+		if err := obj.init.Running(ctx); err != nil { return err }
 	}
 
 	for {
@@ -242,7 +242,7 @@ func (obj *DockerContainerRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/docker_image.go
+++ b/engine/resources/docker_image.go
@@ -145,7 +145,7 @@ func (obj *DockerImageRes) Watch(ctx context.Context) error {
 		if dockerClient.IsErrConnectionFailed(err) && !obj.sflag {
 			// notify engine that we're running so that CheckApply
 			// can start...
-			obj.init.Running()
+			if err := obj.init.Running(ctx); err != nil { return err }
 			select {
 			case <-obj.start:
 				obj.sflag = true
@@ -166,7 +166,7 @@ func (obj *DockerImageRes) Watch(ctx context.Context) error {
 
 	// notify engine that we're running
 	if !obj.sflag {
-		obj.init.Running()
+		if err := obj.init.Running(ctx); err != nil { return err }
 	}
 
 	for {
@@ -189,7 +189,7 @@ func (obj *DockerImageRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/exec.go
+++ b/engine/resources/exec.go
@@ -425,7 +425,7 @@ func (obj *ExecRes) Watch(ctx context.Context) error {
 		}()
 	}
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -481,7 +481,7 @@ func (obj *ExecRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/exec_test.go
+++ b/engine/resources/exec_test.go
@@ -54,6 +54,12 @@ func fakeExecInit(t *testing.T) (*engine.Init, *ExecSends) {
 	}
 	execSends := &ExecSends{}
 	return &engine.Init{
+		Running: func(ctx context.Context) error {
+			return nil
+		},
+		Event: func(ctx context.Context) error {
+			return nil
+		},
 		Send: func(st interface{}) error {
 			x, ok := st.(*ExecSends)
 			if !ok {

--- a/engine/resources/file.go
+++ b/engine/resources/file.go
@@ -516,7 +516,7 @@ func (obj *FileRes) Watch(ctx context.Context) error {
 		}()
 	}
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		if obj.init.Debug {
@@ -553,7 +553,7 @@ func (obj *FileRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/firewalld.go
+++ b/engine/resources/firewalld.go
@@ -260,7 +260,7 @@ func (obj *FirewalldRes) Watch(ctx context.Context) error {
 		return err
 	}
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -281,7 +281,7 @@ func (obj *FirewalldRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/fwattr.go
+++ b/engine/resources/fwattr.go
@@ -512,7 +512,7 @@ func (obj *FWAttrRes) Watch(ctx context.Context) error {
 			obj.init.Logf("warning: skip mode: this key is ineffective")
 		}
 
-		obj.init.Running() // when started, notify engine that we're running
+		if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 		select {
 		case <-ctx.Done(): // closed by the engine to signal shutdown
@@ -528,7 +528,7 @@ func (obj *FWAttrRes) Watch(ctx context.Context) error {
 	}
 	defer recWatcher.Close()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -547,7 +547,7 @@ func (obj *FWAttrRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/group.go
+++ b/engine/resources/group.go
@@ -103,7 +103,7 @@ func (obj *GroupRes) Watch(ctx context.Context) error {
 	}
 	defer recWatcher.Close()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		if obj.init.Debug {
@@ -126,7 +126,7 @@ func (obj *GroupRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/gsettings.go
+++ b/engine/resources/gsettings.go
@@ -339,7 +339,7 @@ func (obj *GsettingsRes) Watch(ctx context.Context) error {
 	}
 	defer recWatcher.Close()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		if obj.init.Debug {
@@ -362,7 +362,7 @@ func (obj *GsettingsRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 		if _, err := obj.uid(); err == nil {
 			break // we can watch normally now...

--- a/engine/resources/gzip.go
+++ b/engine/resources/gzip.go
@@ -241,7 +241,7 @@ func (obj *GzipRes) Watch(ctx context.Context) error {
 		events = recWatcher.Events()
 	}
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -274,7 +274,7 @@ func (obj *GzipRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/hostname.go
+++ b/engine/resources/hostname.go
@@ -181,7 +181,7 @@ func (obj *HostnameRes) Watch(ctx context.Context) error {
 	signals := make(chan *dbus.Signal, 10) // closed by dbus package
 	bus.Signal(signals)
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -206,7 +206,7 @@ func (obj *HostnameRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/http_server_file.go
+++ b/engine/resources/http_server_file.go
@@ -274,13 +274,13 @@ func (obj *HTTPServerFileRes) Cleanup() error {
 // particular one does absolutely nothing but block until we've received a done
 // signal.
 func (obj *HTTPServerFileRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }

--- a/engine/resources/http_server_flag.go
+++ b/engine/resources/http_server_flag.go
@@ -276,7 +276,7 @@ func (obj *HTTPServerFlagRes) Cleanup() error {
 // and notifies the engine so that CheckApply can then run and return the
 // correct value on send/recv.
 func (obj *HTTPServerFlagRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	startupChan := make(chan struct{})
 	close(startupChan) // send one initial signal
@@ -303,7 +303,7 @@ func (obj *HTTPServerFlagRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/http_server_proxy.go
+++ b/engine/resources/http_server_proxy.go
@@ -474,13 +474,13 @@ func (obj *HTTPServerProxyRes) Cleanup() error {
 // particular one does absolutely nothing but block until we've received a done
 // signal.
 func (obj *HTTPServerProxyRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }

--- a/engine/resources/http_server_ui_input.go
+++ b/engine/resources/http_server_ui_input.go
@@ -352,7 +352,7 @@ func (obj *HTTPServerUIInputRes) Watch(ctx context.Context) error {
 		return obj.worldWatch(ctx)
 	}
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	// XXX: do we need to watch on obj.event for normal .Value stuff?
 
@@ -360,7 +360,7 @@ func (obj *HTTPServerUIInputRes) Watch(ctx context.Context) error {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }
@@ -374,7 +374,7 @@ func (obj *HTTPServerUIInputRes) localWatch(ctx context.Context) error {
 		return errwrap.Wrapf(err, "error during watch")
 	}
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -395,7 +395,7 @@ func (obj *HTTPServerUIInputRes) localWatch(ctx context.Context) error {
 		if obj.init.Debug {
 			obj.init.Logf("event!")
 		}
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 
 }
@@ -409,7 +409,7 @@ func (obj *HTTPServerUIInputRes) worldWatch(ctx context.Context) error {
 		return errwrap.Wrapf(err, "error during watch")
 	}
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -433,7 +433,7 @@ func (obj *HTTPServerUIInputRes) worldWatch(ctx context.Context) error {
 		if obj.init.Debug {
 			obj.init.Logf("event!")
 		}
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 
 }

--- a/engine/resources/kv.go
+++ b/engine/resources/kv.go
@@ -207,7 +207,7 @@ func (obj *KVRes) Watch(ctx context.Context) error {
 		return errwrap.Wrapf(err, "error during watch")
 	}
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -226,7 +226,7 @@ func (obj *KVRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/line.go
+++ b/engine/resources/line.go
@@ -157,7 +157,7 @@ func (obj *LineRes) Watch(ctx context.Context) error {
 	}
 	defer recWatcher.Close()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		if obj.init.Debug {
@@ -180,7 +180,7 @@ func (obj *LineRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/mount.go
+++ b/engine/resources/mount.go
@@ -251,7 +251,7 @@ func (obj *MountRes) Watch(ctx context.Context) error {
 	// close the recwatcher when we're done
 	defer recWatcher.Close()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	var done bool
 	for {
@@ -287,7 +287,7 @@ func (obj *MountRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/msg.go
+++ b/engine/resources/msg.go
@@ -119,7 +119,7 @@ func (obj *MsgRes) Cleanup() error {
 
 // Watch is the primary listener for this resource and it outputs events.
 func (obj *MsgRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown

--- a/engine/resources/net.go
+++ b/engine/resources/net.go
@@ -318,7 +318,7 @@ func (obj *NetRes) Watch(ctx context.Context) error {
 		}
 	}()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	var done bool
 	for {
@@ -357,7 +357,7 @@ func (obj *NetRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/noop.go
+++ b/engine/resources/noop.go
@@ -77,13 +77,13 @@ func (obj *NoopRes) Cleanup() error {
 
 // Watch is the primary listener for this resource and it outputs events.
 func (obj *NoopRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }

--- a/engine/resources/nspawn.go
+++ b/engine/resources/nspawn.go
@@ -181,7 +181,7 @@ func (obj *NspawnRes) Watch(ctx context.Context) error {
 	bus.Signal(busChan)
 	defer bus.RemoveSignal(busChan) // not needed here, but nice for symmetry
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -203,7 +203,7 @@ func (obj *NspawnRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/panic.go
+++ b/engine/resources/panic.go
@@ -78,13 +78,13 @@ func (obj *PanicRes) Cleanup() error {
 
 // Watch is the primary listener for this resource and it outputs events.
 func (obj *PanicRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }

--- a/engine/resources/password.go
+++ b/engine/resources/password.go
@@ -218,7 +218,7 @@ func (obj *PasswordRes) Watch(ctx context.Context) error {
 	}
 	defer recWatcher.Close()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -235,7 +235,7 @@ func (obj *PasswordRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/pippet.go
+++ b/engine/resources/pippet.go
@@ -108,13 +108,13 @@ func (obj *PippetRes) Cleanup() error {
 
 // Watch is the primary listener for this resource and it outputs events.
 func (obj *PippetRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }

--- a/engine/resources/pkg.go
+++ b/engine/resources/pkg.go
@@ -156,7 +156,7 @@ func (obj *PkgRes) Watch(ctx context.Context) error {
 		return errwrap.Wrapf(err, "error adding signal match")
 	}
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		if obj.init.Debug {
@@ -180,7 +180,7 @@ func (obj *PkgRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 
@@ -725,6 +725,12 @@ func InstallOnePackage(ctx context.Context, name string) error {
 	pkg.State = PkgStateInstalled
 
 	init := &engine.Init{
+		Running: func(ctx context.Context) error {
+			return nil
+		},
+		Event: func(ctx context.Context) error {
+			return nil
+		},
 		Debug: false,
 		Logf: func(format string, v ...interface{}) {
 			// noop

--- a/engine/resources/print.go
+++ b/engine/resources/print.go
@@ -85,13 +85,13 @@ func (obj *PrintRes) Cleanup() error {
 
 // Watch is the primary listener for this resource and it outputs events.
 func (obj *PrintRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }

--- a/engine/resources/resources_test.go
+++ b/engine/resources/resources_test.go
@@ -507,18 +507,22 @@ func TestResources1(t *testing.T) {
 				t.Logf(fmt.Sprintf("test #%d: ", index)+format, v...)
 			}
 			init := &engine.Init{
-				Running: func() {
+				Running: func(ctx context.Context) error {
 					close(readyChan)
 					select { // this always sends one!
 					case eventChan <- struct{}{}:
-
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
 					}
 				},
 				// Watch runs this to send a changed event.
-				Event: func() {
+				Event: func(ctx context.Context) error {
 					select {
 					case eventChan <- struct{}{}:
-
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
 					}
 				},
 
@@ -751,6 +755,14 @@ func TestResources2(t *testing.T) {
 		init := &engine.Init{
 			//Debug: debug,
 			Logf: logf,
+
+			// unused
+			Running: func(ctx context.Context) error {
+				return nil
+			},
+			Event: func(ctx context.Context) error {
+				return nil
+			},
 
 			// unused
 			Send: func(st interface{}) error {

--- a/engine/resources/schedule.go
+++ b/engine/resources/schedule.go
@@ -209,7 +209,7 @@ func (obj *ScheduleRes) Watch(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-obj.once:
@@ -283,7 +283,7 @@ func (obj *ScheduleRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/svc.go
+++ b/engine/resources/svc.go
@@ -212,7 +212,7 @@ func (obj *SvcRes) Watch(ctx context.Context) error {
 		}
 	}()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	svc := obj.svc() // systemd name
 
@@ -349,7 +349,7 @@ func (obj *SvcRes) Watch(ctx context.Context) error {
 			return ctx.Err()
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/sysctl.go
+++ b/engine/resources/sysctl.go
@@ -215,7 +215,7 @@ func (obj *SysctlRes) Watch(ctx context.Context) error {
 		events2 = recWatcher.Events()
 	}
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -245,7 +245,7 @@ func (obj *SysctlRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/tar.go
+++ b/engine/resources/tar.go
@@ -216,7 +216,7 @@ func (obj *TarRes) Watch(ctx context.Context) error {
 	}
 	events := recwatch.MergeChannels(chanList...)
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -252,7 +252,7 @@ func (obj *TarRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/test.go
+++ b/engine/resources/test.go
@@ -147,13 +147,13 @@ func (obj *TestRes) Cleanup() error {
 
 // Watch is the primary listener for this resource and it outputs events.
 func (obj *TestRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }

--- a/engine/resources/tftp.go
+++ b/engine/resources/tftp.go
@@ -169,7 +169,7 @@ func (obj *TFTPServerRes) Watch(ctx context.Context) error {
 		return fmt.Errorf("the hook is nil") // programming error
 	}
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	// Use nil in place of handler to disable read or write operations.
 	server := tftp.NewServer(obj.readHandler(), obj.writeHandler())
@@ -215,7 +215,7 @@ func (obj *TFTPServerRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 
@@ -556,13 +556,13 @@ func (obj *TFTPFileRes) Cleanup() error {
 // particular one does absolutely nothing but block until we've received a done
 // signal.
 func (obj *TFTPFileRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	select {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }

--- a/engine/resources/timer.go
+++ b/engine/resources/timer.go
@@ -89,7 +89,7 @@ func (obj *TimerRes) Watch(ctx context.Context) error {
 	obj.ticker = obj.newTicker()
 	defer obj.ticker.Stop()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -100,7 +100,7 @@ func (obj *TimerRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/user.go
+++ b/engine/resources/user.go
@@ -152,7 +152,7 @@ func (obj *UserRes) Watch(ctx context.Context) error {
 	}
 	defer recWatcher.Close()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		if obj.init.Debug {
@@ -175,7 +175,7 @@ func (obj *UserRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 

--- a/engine/resources/value.go
+++ b/engine/resources/value.go
@@ -113,7 +113,7 @@ func (obj *ValueRes) Cleanup() error {
 
 // Watch is the primary listener for this resource and it outputs events.
 func (obj *ValueRes) Watch(ctx context.Context) error {
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	// XXX: Should we be using obj.init.Local.ValueWatch ?
 
@@ -121,7 +121,7 @@ func (obj *ValueRes) Watch(ctx context.Context) error {
 	case <-ctx.Done(): // closed by the engine to signal shutdown
 	}
 
-	//obj.init.Event() // notify engine of an event (this can block)
+	//if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 
 	return nil
 }

--- a/engine/resources/virt.go
+++ b/engine/resources/virt.go
@@ -365,7 +365,7 @@ func (obj *VirtRes) Watch(ctx context.Context) error {
 		}
 	}()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	send := false // send event?
 	for {
@@ -485,7 +485,7 @@ func (obj *VirtRes) Watch(ctx context.Context) error {
 		// do all our event sending all together to avoid duplicate msgs
 		if send {
 			send = false
-			obj.init.Event() // notify engine of an event (this can block)
+			if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 		}
 	}
 }

--- a/engine/resources/virt_builder.go
+++ b/engine/resources/virt_builder.go
@@ -437,7 +437,7 @@ func (obj *VirtBuilderRes) Watch(ctx context.Context) error {
 	}
 	defer recWatcher.Close()
 
-	obj.init.Running() // when started, notify engine that we're running
+	if err := obj.init.Running(ctx); err != nil { return err } // when started, notify engine that we're running
 
 	for {
 		select {
@@ -456,7 +456,7 @@ func (obj *VirtBuilderRes) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		obj.init.Event() // notify engine of an event (this can block)
+		if err := obj.init.Event(ctx); err != nil { return err } // notify engine of an event (this can block)
 	}
 }
 


### PR DESCRIPTION
Ported Running() and Event() functions in the engine to have the signature func(context.Context) error. Updated all call sites in resources, internal engine logic, tests, and documentation to use the new signature and handle errors accordingly.

---
*PR created automatically by Jules for task [17279313665796411642](https://jules.google.com/task/17279313665796411642) started by @purpleidea*