### PR TITLE
Fix engine Commit race condition

### DIFF
--- a/engine/graph/actions.go
+++ b/engine/graph/actions.go
@@ -567,6 +567,17 @@ func (obj *Engine) Worker(vertex pgraph.Vertex) error {
 	var reterr error
 	var failed bool // has Process permanently failed?
 	var closed bool // has the resumeSignal channel closed?
+
+	// if we're started while the engine is paused, wait for resume
+	if state.paused {
+		select {
+		case _, ok := <-state.resumeSignal:
+			if !ok {
+				closed = true
+			}
+		}
+	}
+
 Loop:
 	for { // process loop
 		// This is the main select where things happen and where we exit

--- a/engine/graph/engine.go
+++ b/engine/graph/engine.go
@@ -267,6 +267,7 @@ func (obj *Engine) Commit() error {
 		obj.state[vertex] = &State{
 			Graph:  obj.graph, // Update if we swap the graph!
 			Vertex: vertex,
+			paused: obj.paused,
 
 			Program:  obj.Program,
 			Version:  obj.Version,
@@ -502,6 +503,11 @@ func (obj *Engine) Resume() error {
 	return nil
 }
 
+// IsPaused returns true if the engine is currently paused.
+func (obj *Engine) IsPaused() bool {
+	return obj.paused
+}
+
 // SetFastPause puts the graph into fast pause mode. This is usually done via
 // the argument to the Pause command, but this method can be used if a pause was
 // already started, and you'd like subsequent parts to pause quickly. Once in
@@ -520,15 +526,19 @@ func (obj *Engine) Pause(fastPause bool) error {
 	//obj.mutex.Lock()
 	//defer obj.mutex.Unlock()
 
-	if obj.paused {
-		return fmt.Errorf("already paused")
-	}
-
 	obj.fastPause.Store(fastPause)
 	topoSort, _ := obj.graph.TopologicalSort()
 	for _, vertex := range topoSort { // squeeze out the events...
 		// The Event is sent to an unbuffered channel, so this event is
 		// synchronous, and as a result it blocks until it is received.
+		if err := obj.state[vertex].Pause(); err != nil && err != engine.ErrClosed {
+			return err
+		}
+	}
+
+	// now catch anything else that might be in obj.state but not in topoSort
+	// this can happen if a previous commit failed, or for other reasons
+	for vertex := range obj.state {
 		if err := obj.state[vertex].Pause(); err != nil && err != engine.ErrClosed {
 			return err
 		}

--- a/engine/graph/state.go
+++ b/engine/graph/state.go
@@ -350,7 +350,7 @@ func (obj *State) Poke() {
 // so only call these one at a time and alternate between the two.
 func (obj *State) Pause() error {
 	if obj.paused {
-		panic("already paused")
+		return nil
 	}
 
 	// wait for ack (or exit signal)

--- a/lib/main.go
+++ b/lib/main.go
@@ -806,7 +806,7 @@ func (obj *Main) Run(ctx context.Context) error {
 						gapiChan = nil
 					}
 
-					if started {
+					if started || !obj.ge.IsPaused() {
 						obj.ge.Pause(false)
 					}
 					// must be paused before this is run
@@ -1080,7 +1080,7 @@ func (obj *Main) Run(ctx context.Context) error {
 
 			// we need the vertices to be paused to work on them, so
 			// run graph vertex LOCK...
-			if started { // TODO: we can flatten this check out I think
+			if started || !obj.ge.IsPaused() {
 				converger.Pause()       // FIXME: add sync wait?
 				obj.ge.Pause(fastPause) // sync
 				started = false


### PR DESCRIPTION
Fixed a race condition where the engine's graph synchronization (Commit) could occur while resource workers were still accessing the graph (via FilteredGraph). The fix involves making the engine's pause/resume mechanism more robust, ensuring new resources start paused if the engine is paused, and verifying that all resources are paused before graph updates proceed.

---
*PR created automatically by Jules for task [10420186596888863235](https://jules.google.com/task/10420186596888863235) started by @purpleidea*