### PR TITLE
Optimize dage engine to skip redundant table sends

### DIFF
--- a/lang/funcs/dage/dage.go
+++ b/lang/funcs/dage/dage.go
@@ -128,6 +128,9 @@ type Engine struct {
 	// streamChan is used to send the stream of tables to the outside world.
 	streamChan chan interfaces.Table
 
+	// lastTable stores the last table that was sent to streamChan.
+	lastTable interfaces.Table
+
 	// interrupt specifies that a txn "commit" just happened.
 	interrupt bool
 
@@ -281,6 +284,7 @@ Start:
 			// and those transactions run obj.effect() which resets
 			// this interrupt value back to true!
 			obj.interrupt = false            // reset
+			obj.lastTable = nil              // structural change, always send!
 			start = 0                        // restart the loop
 			for i, v := range obj.topoSort { // TODO: Do it once here, or repeatedly below?
 				mapping[v] = i
@@ -575,18 +579,24 @@ Start:
 		// The table must get cleaned up over time to be consistent. It
 		// currently happens in interrupt as a result of a node delete.
 
-		cp := table.Copy()
-		if obj.Debug {
-			obj.Logf("table:")
-			for k, v := range cp {
-				obj.Logf("table[%p %v]: %p %+v", k, k, v, v)
+		if obj.lastTable != nil && obj.lastTable.Cmp(table) == nil {
+			if obj.Debug {
+				obj.Logf("skipping table send, no change")
 			}
-		}
-		select {
-		case obj.streamChan <- cp:
-
-		case <-ctx.Done():
-			return ctx.Err()
+		} else {
+			cp := table.Copy()
+			if obj.Debug {
+				obj.Logf("table:")
+				for k, v := range cp {
+					obj.Logf("table[%p %v]: %p %+v", k, k, v, v)
+				}
+			}
+			select {
+			case obj.streamChan <- cp:
+				obj.lastTable = cp
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
 
 		// XXX: implement epoch rollover by relabelling all nodes

--- a/lang/interfaces/func.go
+++ b/lang/interfaces/func.go
@@ -40,6 +40,7 @@ import (
 	"github.com/purpleidea/mgmt/lang/types"
 	"github.com/purpleidea/mgmt/pgraph"
 	"github.com/purpleidea/mgmt/util"
+	"github.com/purpleidea/mgmt/util/errwrap"
 )
 
 // FuncSig is the simple signature that is used throughout our implementations.
@@ -56,6 +57,34 @@ func (obj Table) Copy() Table {
 		cp[k] = v
 	}
 	return cp
+}
+
+// Cmp returns an error if this table isn't the same as the arg passed in.
+func (obj Table) Cmp(val Table) error {
+	if len(obj) != len(val) {
+		return fmt.Errorf("tables have different lengths")
+	}
+
+	for k, v := range obj {
+		v2, exists := val[k]
+		if !exists {
+			return fmt.Errorf("key %s does not exist", k)
+		}
+
+		if v == nil && v2 == nil {
+			continue
+		}
+
+		if v == nil || v2 == nil {
+			return fmt.Errorf("key %s has nil mismatch", k)
+		}
+
+		if err := v.Cmp(v2); err != nil {
+			return errwrap.Wrapf(err, "key %s did not cmp", k)
+		}
+	}
+
+	return nil
 }
 
 // GraphSig is the simple signature that is used throughout our implementations.


### PR DESCRIPTION
Optimize dage engine to skip redundant table sends by comparing the current table with the last sent one. Structural changes correctly bypass this optimization.

---
*PR created automatically by Jules for task [4792386569729829659](https://jules.google.com/task/4792386569729829659) started by @purpleidea*