### PR TITLE
engine: deep-copy ReversibleMeta in ResCopy

### DIFF
--- a/engine/copy.go
+++ b/engine/copy.go
@@ -126,7 +126,7 @@ func ResCopy(r CopyableRes) (CopyableRes, error) {
 			// programming error
 			panic("reversible interfaces are illogical")
 		}
-		dst.SetReversibleMeta(x.ReversibleMeta()) // no need to copy atm
+		dst.SetReversibleMeta(x.ReversibleMeta().Copy())
 	}
 
 	return res, nil

--- a/engine/copy_test.go
+++ b/engine/copy_test.go
@@ -1,0 +1,141 @@
+// Mgmt
+// Copyright (C) James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Additional permission under GNU GPL version 3 section 7
+//
+// If you modify this program, or any covered work, by linking or combining it
+// with embedded mcl code and modules (and that the embedded mcl code and
+// modules which link with this program, contain a copy of their source code in
+// the authoritative form) containing parts covered by the terms of any other
+// license, the licensors of this program grant you additional permission to
+// convey the resulting work. Furthermore, the licensors of this program grant
+// the original author, James Shubin, additional permission to update this
+// additional permission if he deems it necessary to achieve the goals of this
+// additional permission.
+
+package engine_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/purpleidea/mgmt/engine"
+	"github.com/purpleidea/mgmt/engine/traits"
+)
+
+type reversibleCopyTestRes struct {
+	traits.Base
+	traits.Reversible
+
+	Value string
+}
+
+func (obj *reversibleCopyTestRes) Default() engine.Res {
+	return &reversibleCopyTestRes{}
+}
+
+func (obj *reversibleCopyTestRes) Validate() error { return nil }
+
+func (obj *reversibleCopyTestRes) Init(*engine.Init) error { return nil }
+
+func (obj *reversibleCopyTestRes) Cleanup() error { return nil }
+
+func (obj *reversibleCopyTestRes) Watch(context.Context) error { return nil }
+
+func (obj *reversibleCopyTestRes) CheckApply(context.Context, bool) (bool, error) {
+	return true, nil
+}
+
+func (obj *reversibleCopyTestRes) Cmp(engine.Res) error { return nil }
+
+func (obj *reversibleCopyTestRes) Copy() engine.CopyableRes {
+	return &reversibleCopyTestRes{
+		Value: obj.Value,
+	}
+}
+
+func (obj *reversibleCopyTestRes) Reversed() (engine.ReversibleRes, error) {
+	cp, err := engine.ResCopy(obj)
+	if err != nil {
+		return nil, err
+	}
+	rev, ok := cp.(engine.ReversibleRes)
+	if !ok {
+		return nil, nil
+	}
+	rev.ReversibleMeta().Disabled = true
+	return rev, nil
+}
+
+func newReversibleCopyTestRes(name string) *reversibleCopyTestRes {
+	res := &reversibleCopyTestRes{
+		Value: "hello",
+	}
+	res.SetKind("copytest")
+	res.SetName(name)
+	return res
+}
+
+func TestResCopyCopiesReversibleMetaByValue(t *testing.T) {
+	original := newReversibleCopyTestRes("meta-by-value")
+	original.ReversibleMeta().Disabled = false
+	original.ReversibleMeta().Overwrite = true
+
+	copiedRes, err := engine.ResCopy(original)
+	if err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+
+	copied, ok := copiedRes.(*reversibleCopyTestRes)
+	if !ok {
+		t.Fatalf("unexpected copy type: %T", copiedRes)
+	}
+
+	if copied.ReversibleMeta() == original.ReversibleMeta() {
+		t.Fatalf("reversible meta pointer was aliased")
+	}
+
+	copied.ReversibleMeta().Disabled = true
+	copied.ReversibleMeta().Reversal = true
+
+	if original.ReversibleMeta().Disabled {
+		t.Fatalf("mutating copied reversible meta changed original Disabled flag")
+	}
+	if original.ReversibleMeta().Reversal {
+		t.Fatalf("mutating copied reversible meta changed original Reversal flag")
+	}
+}
+
+func TestReversedDoesNotMutateOriginalReversibleMeta(t *testing.T) {
+	original := newReversibleCopyTestRes("reversed-isolated")
+	original.ReversibleMeta().Disabled = false
+
+	reversed, err := original.Reversed()
+	if err != nil {
+		t.Fatalf("reverse failed: %v", err)
+	}
+	if reversed == nil {
+		t.Fatalf("reverse returned nil")
+	}
+
+	if !reversed.ReversibleMeta().Disabled {
+		t.Fatalf("reversed resource should disable its own reversal")
+	}
+	if original.ReversibleMeta().Disabled {
+		t.Fatalf("building the reversed resource mutated the original Disabled flag")
+	}
+}

--- a/engine/graph/reverse_test.go
+++ b/engine/graph/reverse_test.go
@@ -1,0 +1,156 @@
+// Mgmt
+// Copyright (C) James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Additional permission under GNU GPL version 3 section 7
+//
+// If you modify this program, or any covered work, by linking or combining it
+// with embedded mcl code and modules (and that the embedded mcl code and
+// modules which link with this program, contain a copy of their source code in
+// the authoritative form) containing parts covered by the terms of any other
+// license, the licensors of this program grant you additional permission to
+// convey the resulting work. Furthermore, the licensors of this program grant
+// the original author, James Shubin, additional permission to update this
+// additional permission if he deems it necessary to achieve the goals of this
+// additional permission.
+
+//go:build !root
+
+package graph
+
+import (
+	"context"
+	"encoding/gob"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/purpleidea/mgmt/engine"
+	"github.com/purpleidea/mgmt/engine/traits"
+)
+
+func init() {
+	gob.Register(&reversibleGraphTestRes{})
+}
+
+type reversibleGraphTestRes struct {
+	traits.Base
+	traits.Reversible
+
+	Value string
+}
+
+func (obj *reversibleGraphTestRes) Default() engine.Res {
+	return &reversibleGraphTestRes{}
+}
+
+func (obj *reversibleGraphTestRes) Validate() error { return nil }
+
+func (obj *reversibleGraphTestRes) Init(*engine.Init) error { return nil }
+
+func (obj *reversibleGraphTestRes) Cleanup() error { return nil }
+
+func (obj *reversibleGraphTestRes) Watch(context.Context) error { return nil }
+
+func (obj *reversibleGraphTestRes) CheckApply(context.Context, bool) (bool, error) {
+	return true, nil
+}
+
+func (obj *reversibleGraphTestRes) Cmp(engine.Res) error { return nil }
+
+func (obj *reversibleGraphTestRes) Copy() engine.CopyableRes {
+	return &reversibleGraphTestRes{
+		Value: obj.Value,
+	}
+}
+
+func (obj *reversibleGraphTestRes) Reversed() (engine.ReversibleRes, error) {
+	cp, err := engine.ResCopy(obj)
+	if err != nil {
+		return nil, err
+	}
+	rev, ok := cp.(engine.ReversibleRes)
+	if !ok {
+		return nil, nil
+	}
+	rev.ReversibleMeta().Disabled = true
+	return rev, nil
+}
+
+func newReversibleGraphTestRes(name string) *reversibleGraphTestRes {
+	res := &reversibleGraphTestRes{
+		Value: "hello",
+	}
+	res.SetKind("copytest")
+	res.SetName(name)
+	return res
+}
+
+func newReversibleGraphTestState(t *testing.T, res engine.Res) *State {
+	t.Helper()
+
+	st := &State{
+		Vertex:   res,
+		Hostname: "test-host",
+		Prefix:   t.TempDir(),
+		Logf:     func(string, ...interface{}) {},
+	}
+	if err := st.Init(); err != nil {
+		t.Fatalf("state init failed: %v", err)
+	}
+	return st
+}
+
+func TestReversalInitDoesNotMutateOriginalReversibleMeta(t *testing.T) {
+	res := newReversibleGraphTestRes("reversal-init")
+	res.ReversibleMeta().Disabled = false
+
+	st := newReversibleGraphTestState(t, res)
+	if err := st.ReversalInit(); err != nil {
+		t.Fatalf("reversal init failed: %v", err)
+	}
+
+	if res.ReversibleMeta().Disabled {
+		t.Fatalf("reversal init mutated original Disabled flag")
+	}
+	if res.ReversibleMeta().Reversal {
+		t.Fatalf("reversal init mutated original Reversal flag")
+	}
+}
+
+func TestReversalCleanupDoesNotDeletePendingReverseFromOriginalResource(t *testing.T) {
+	res := newReversibleGraphTestRes("reversal-cleanup")
+	res.ReversibleMeta().Disabled = false
+
+	st := newReversibleGraphTestState(t, res)
+	if err := st.ReversalInit(); err != nil {
+		t.Fatalf("reversal init failed: %v", err)
+	}
+
+	reverseFile := filepath.Join(st.Prefix, ReverseFile)
+	if _, err := os.Stat(reverseFile); err != nil {
+		t.Fatalf("reverse file missing after init: %v", err)
+	}
+
+	st.isStateOK.Store(true)
+	if err := st.ReversalCleanup(); err != nil {
+		t.Fatalf("reversal cleanup failed: %v", err)
+	}
+
+	if _, err := os.Stat(reverseFile); err != nil {
+		t.Fatalf("original resource removed pending reverse file: %v", err)
+	}
+}

--- a/engine/reverse.go
+++ b/engine/reverse.go
@@ -82,6 +82,18 @@ type ReversibleMeta struct {
 	// TODO: add options here, including whether to reverse edges, etc...
 }
 
+// Copy copies this struct and returns a new one.
+func (obj *ReversibleMeta) Copy() *ReversibleMeta {
+	if obj == nil {
+		return nil
+	}
+	return &ReversibleMeta{
+		Disabled:  obj.Disabled,
+		Reversal:  obj.Reversal,
+		Overwrite: obj.Overwrite,
+	}
+}
+
 // Cmp compares two ReversibleMeta structs and determines if they're equivalent.
 func (obj *ReversibleMeta) Cmp(rm *ReversibleMeta) error {
 	if obj.Disabled != rm.Disabled {

--- a/test/shell/reversible-meta-copy-mre-cleanup.mcl
+++ b/test/shell/reversible-meta-copy-mre-cleanup.mcl
@@ -1,0 +1,3 @@
+file "/tmp/reversible-meta-copy-mre/" {
+	state => $const.res.file.state.exists,
+}

--- a/test/shell/reversible-meta-copy-mre.mcl
+++ b/test/shell/reversible-meta-copy-mre.mcl
@@ -1,0 +1,33 @@
+file "/tmp/reversible-meta-copy-mre/" {
+	state => $const.res.file.state.exists,
+}
+
+# Step 1 of the runtime proof for the reversible meta aliasing bug.
+#
+# Run this file first, let it converge, and then run
+# `test/shell/reversible-meta-copy-mre-cleanup.mcl` with the same `--prefix`.
+#
+# Example:
+#   ./mgmt run --prefix /tmp/reversible-meta-copy-mre-prefix \
+#     --converged-timeout=2 --no-pgp lang \
+#     test/shell/reversible-meta-copy-mre.mcl
+#
+#   ./mgmt run --prefix /tmp/reversible-meta-copy-mre-prefix \
+#     --converged-timeout=2 --no-pgp lang \
+#     test/shell/reversible-meta-copy-mre-cleanup.mcl
+#
+# Expected on a correct engine:
+# 1. This run creates `/tmp/reversible-meta-copy-mre/target`.
+# 2. The cleanup run logs `adding 1 reversals...` and removes the target.
+#
+# Buggy engine behavior:
+# 1. This run converges and then deletes its own pending reverse state during
+#    shutdown cleanup.
+# 2. The cleanup run has no stored reversal to add, so the target is left
+#    behind.
+file "/tmp/reversible-meta-copy-mre/target" {
+	state => $const.res.file.state.exists,
+	content => "proof\n",
+
+	Meta:reverse => true,
+}


### PR DESCRIPTION
Fixes a reversible-resource copy bug caused by aliasing `*ReversibleMeta`.

`engine.ResCopy()` was reusing the same reversible metadata pointer for the original resource and its copied/reversed form. 
Reversal setup mutates that metadata (`Disabled`, `Reversal`), so those mutations could leak back into the original live resource.

## MRE
<details>
  <summary>First run</summary>
  
  ```mcl
file "/tmp/reversible-meta-copy-mre/" {
        state => $const.res.file.state.exists,
}

# Step 1 of the runtime proof for the reversible meta aliasing bug.
#
# Run this file first, let it converge, and then run
# `test/shell/reversible-meta-copy-mre-cleanup.mcl` with the same `--prefix`.
#
# Example:
#   ./mgmt run --prefix /tmp/reversible-meta-copy-mre-prefix \
#     --converged-timeout=2 --no-pgp lang \
#     test/shell/reversible-meta-copy-mre.mcl
#
#   ./mgmt run --prefix /tmp/reversible-meta-copy-mre-prefix \
#     --converged-timeout=2 --no-pgp lang \
#     test/shell/reversible-meta-copy-mre-cleanup.mcl
#
# Expected on a correct engine:
# 1. This run creates `/tmp/reversible-meta-copy-mre/target`.
# 2. The cleanup run logs `adding 1 reversals...` and removes the target.
#
# Buggy engine behavior:
# 1. This run converges and then deletes its own pending reverse state during
#    shutdown cleanup.
# 2. The cleanup run has no stored reversal to add, so the target is left
#    behind.
file "/tmp/reversible-meta-copy-mre/target" {
        state => $const.res.file.state.exists,
        content => "proof\n",

        Meta:reverse => true,
}
  ```
</details>


<details>
  <summary>Second run</summary>
  
  ```mcl
file "/tmp/reversible-meta-copy-mre/" {
        state => $const.res.file.state.exists,
}
  ```
</details>


## Impact

This could cause the original resource to be treated as if it were itself a reversal resource during cleanup, which in turn could delete the pending reverse state that should have been preserved for a later run.

In practice, that means a normal converged reversible resource can disappear from the graph, and the next run has
nothing left to reverse.

## Fix

Add `(*ReversibleMeta).Copy()` and use it in `engine.ResCopy()` so reversible metadata is copied by value instead of
shared by pointer.

## Verification

Added focused Go tests covering:

- copy isolation for `ReversibleMeta`
- `Reversed()` not mutating the original resource
- `ReversalInit()` not mutating the original resource
- `ReversalCleanup()` not deleting the original resource's pending reverse file

The MCL repro is a second commit, so feel free to cherry-pick.