### PR TITLE
util: Bound watch path index

### DIFF
--- a/util/recwatch/recwatch.go
+++ b/util/recwatch/recwatch.go
@@ -32,7 +32,6 @@ package recwatch
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -180,6 +179,9 @@ func (obj *RecWatcher) Watch() error {
 	var send = false                          // send event?
 
 	for {
+		if index < 1 || index > len(patharray) {
+			return fmt.Errorf("recwatch: invalid path index %d for %q", index, obj.safename)
+		}
 		current = strings.Join(patharray[0:index], "/")
 		if current == "" { // the empty string top is the root dir ("/")
 			current = "/"
@@ -194,8 +196,9 @@ func (obj *RecWatcher) Watch() error {
 			}
 			// ENOENT for linux, etc and IsNotExist for macOS
 			if err == syscall.ENOENT || os.IsNotExist(err) {
-				index-- // usually not found, move up one dir
-				index = int(math.Max(1, float64(index)))
+				if index > 1 {
+					index-- // usually not found, move up one dir
+				}
 				continue
 			}
 
@@ -265,9 +268,11 @@ func (obj *RecWatcher) Watch() error {
 
 				// file removed, move the watch upwards
 				if deltaDepth >= 0 && (event.Op&fsnotify.Remove == fsnotify.Remove) {
-					//obj.options.logf("removal!")
-					obj.watcher.Remove(current)
-					index--
+					if index > 1 {
+						//obj.options.logf("removal!")
+						obj.watcher.Remove(current)
+						index--
+					}
 				}
 
 				// when the file is moved, remove the watcher and add a new one,
@@ -279,9 +284,11 @@ func (obj *RecWatcher) Watch() error {
 
 				// we must be a parent watcher, so descend in
 				if deltaDepth < 0 {
-					// XXX: we can block here due to: https://github.com/fsnotify/fsnotify/issues/123
-					obj.watcher.Remove(current)
-					index++
+					if index < len(patharray) {
+						// XXX: we can block here due to: https://github.com/fsnotify/fsnotify/issues/123
+						obj.watcher.Remove(current)
+						index++
+					}
 				}
 
 				// if safename starts with event.Name, we're above, and no event should be sent
@@ -289,9 +296,11 @@ func (obj *RecWatcher) Watch() error {
 				//obj.options.logf("above!")
 
 				if deltaDepth >= 0 && (event.Op&fsnotify.Remove == fsnotify.Remove) {
-					//obj.options.logf("removal!")
-					obj.watcher.Remove(current)
-					index--
+					if index > 1 {
+						//obj.options.logf("removal!")
+						obj.watcher.Remove(current)
+						index--
+					}
 				}
 
 				if deltaDepth < 0 {
@@ -299,8 +308,11 @@ func (obj *RecWatcher) Watch() error {
 					if util.PathPrefixDelta(obj.safename, event.Name) == 1 { // we're the parent dir
 						send = true
 					}
-					obj.watcher.Remove(current)
-					index++
+					if index < len(patharray) {
+						// XXX: we can block here due to: https://github.com/fsnotify/fsnotify/issues/123
+						obj.watcher.Remove(current)
+						index++
+					}
 				}
 
 				// if event.Name startswith safename, send event, we're already deeper

--- a/util/recwatch/recwatch_test.go
+++ b/util/recwatch/recwatch_test.go
@@ -1,0 +1,122 @@
+// Mgmt
+// Copyright (C) James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Additional permission under GNU GPL version 3 section 7
+//
+// If you modify this program, or any covered work, by linking or combining it
+// with embedded mcl code and modules (and that the embedded mcl code and
+// modules which link with this program, contain a copy of their source code in
+// the authoritative form) containing parts covered by the terms of any other
+// license, the licensors of this program grant you additional permission to
+// convey the resulting work. Furthermore, the licensors of this program grant
+// the original author, James Shubin, additional permission to update this
+// additional permission if he deems it necessary to achieve the goals of this
+// additional permission.
+
+package recwatch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestWatchDoesNotDescendPastLeaf(t *testing.T) {
+	dir := t.TempDir()
+	parent := filepath.Join(dir, "parent")
+	target := filepath.Join(parent, "file.txt")
+
+	if err := os.Mkdir(parent, 0700); err != nil {
+		t.Fatalf("could not create parent directory: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("contents\n"), 0600); err != nil {
+		t.Fatalf("could not create target file: %v", err)
+	}
+
+	logs := make(chan string, 16)
+	rw, err := NewRecWatcher(target, false, Debug(true), Logf(func(format string, v ...interface{}) {
+		logs <- fmt.Sprintf(format, v...)
+	}))
+	if err != nil {
+		t.Fatalf("could not create watcher: %v", err)
+	}
+	defer rw.Close()
+
+	events := rw.Events()
+	waitForWatchPath(t, logs, target)
+
+	// A parent event can arrive after the watcher is already at the leaf. This
+	// used to move the watch index past the end of the target path.
+	injectEvent(t, rw, fsnotify.Event{Name: parent, Op: fsnotify.Chmod})
+	expectEvent(t, events)
+	waitForWatchPath(t, logs, target)
+
+	injectEvent(t, rw, fsnotify.Event{Name: target, Op: fsnotify.Chmod})
+	expectEvent(t, events)
+}
+
+func injectEvent(t *testing.T, rw *RecWatcher, event fsnotify.Event) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		rw.watcher.Events <- event
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out injecting fsnotify event: %v", event)
+	}
+}
+
+func waitForWatchPath(t *testing.T, logs <-chan string, path string) {
+	t.Helper()
+
+	expected := fmt.Sprintf("watching: %s", path)
+	timer := time.After(2 * time.Second)
+
+	for {
+		select {
+		case log := <-logs:
+			if strings.Contains(log, expected) {
+				return
+			}
+		case <-timer:
+			t.Fatalf("timed out waiting for recwatch log: %s", expected)
+		}
+	}
+}
+
+func expectEvent(t *testing.T, events <-chan Event) {
+	t.Helper()
+
+	select {
+	case event := <-events:
+		if event.Error != nil {
+			t.Fatalf("unexpected watcher error: %v", event.Error)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for recwatch event")
+	}
+}


### PR DESCRIPTION
`RecWatcher.Watch()` tracks the current watched path depth with `index` and then slices:

```go
current = strings.Join(patharray[0:index], "/")
```

When watching a missing leaf path, recwatch backs up to an existing parent.

As parent directories and files are created, `fsnotify` can later deliver a parent-path event after recwatch has already
descended **to the leaf**.

The code currently treats that as another descend signal and increments index past len(patharray), causing:

```
panic: runtime error: slice bounds out of range
github.com/purpleidea/mgmt/util/recwatch.(*RecWatcher).Watch
      util/recwatch/recwatch.go:183
```

which is an event-ordering/state-machine race.

### MRE

Run the seed once with a persistent --prefix.
Then rerun the write graph repeatedly with the same prefix while deleting the output directory between runs.

<details>
  <summary>Seed</summary>
  
  ```mcl
kv "recwatch-index-bounds-01" {
    key => "recwatch/index-bounds/01",
    value => "01\n",
}

kv "recwatch-index-bounds-02" {
    key => "recwatch/index-bounds/02",
    value => "02\n",
}
  ```
</details>

<details>
  <summary>Write graph</summary>
  
  ```mcl
import "world"

$root = "/tmp/mgmt-recwatch-index-bounds-showcase/"
$data = "${root}data/"

$v01 = world.getval("recwatch/index-bounds/01")
$v02 = world.getval("recwatch/index-bounds/02")

file $root {
    state => $const.res.file.state.exists,
    mode => "0700",
}

file $data {
    state => $const.res.file.state.exists,
    mode => "0700",
    Depend => File[$root],
}

file "${data}01.txt" {
    state => $const.res.file.state.exists,
    content => $v01->value,
    mode => "0600",
    Depend => File[$data],
}

file "${data}02.txt" {
    state => $const.res.file.state.exists,
    content => $v02->value,
    mode => "0600",
    Depend => File[$data],
}
  ```
</details>

<details>
  <summary>Scripted setup</summary>
  
  ```sh
#!/usr/bin/env bash
set -euo pipefail

mgmt="${1:-./mgmt}"
seed="${2:-./recwatch-index-bounds-seed.mcl}"
write="${3:-./recwatch-index-bounds-write.mcl}"
base="${4:-22401}"

client_url="http://127.0.0.1:${base}"
server_url="http://127.0.0.1:$((base + 1))"
prefix="/tmp/mgmt-recwatch-index-bounds-prefix-${base}"
root="/tmp/mgmt-recwatch-index-bounds-showcase"

rm -rf "$prefix" "$root"

"$mgmt" run \
      --prefix="$prefix" \
      --hostname="recwatch-seed-${base}" \
      --client-urls="$client_url" \
      --server-urls="$server_url" \
      --advertise-client-urls="$client_url" \
      --advertise-server-urls="$server_url" \
      --no-pgp \
      --converged-timeout=5 \
      --max-runtime=60 \
      lang "$seed" >/tmp/recwatch-index-bounds-seed-${base}.log 2>&1

for i in $(seq 1 20); do
      rm -rf "$root"
      log="/tmp/recwatch-index-bounds-write-${base}-${i}.log"

      set +e
      "$mgmt" run \
              --prefix="$prefix" \
              --hostname="recwatch-write-${base}-${i}" \
              --client-urls="$client_url" \
              --server-urls="$server_url" \
              --advertise-client-urls="$client_url" \
              --advertise-server-urls="$server_url" \
              --no-pgp \
              --converged-timeout=2 \
              --max-runtime=30 \
              lang "$write" >"$log" 2>&1
      code=$?
      set -e

      if grep -q "panic: runtime error: slice bounds out of range" "$log"; then
              echo "panic iteration $i"
              tail -n 40 "$log"
              exit 10
      fi

      if [ "$code" -ne 0 ]; then
              echo "nonzero iteration $i code=$code"
              tail -n 40 "$log"
              exit "$code"
      fi

      echo "iteration $i ok"
done

echo "no panic after 20 iterations"
  ```
</details>