### PR TITLE
feat: support installing packages from file paths

### DIFF
--- a/engine/resources/packagekit/packagekit.go
+++ b/engine/resources/packagekit/packagekit.go
@@ -1114,3 +1114,56 @@ func IsMyArch(arch string) (bool, error) {
 	}
 	return goarch == runtime.GOARCH, nil
 }
+
+// InstallFiles installs a list of packages from local file paths.
+func (obj *Conn) InstallFiles(fullPaths []string, transactionFlags uint64) error {
+	if err := obj.RefreshCache(false); err != nil {
+		return errwrap.Wrapf(err, "can't refresh cache")
+	}
+	ch := make(chan *dbus.Signal, PkBufferSize)
+	interfacePath, err := obj.CreateTransaction()
+	if err != nil {
+		return err
+	}
+	var signals = []string{"Package", "ErrorCode", "Finished", "Destroy"} // "ItemProgress", "Status" ?
+	removeSignals, err := obj.matchSignal(ch, interfacePath, PkIfaceTransaction, signals)
+	if err != nil {
+		return err
+	}
+	defer removeSignals()
+	bus := obj.GetBus().Object(PkIface, interfacePath)
+	call := bus.Call(FmtTransactionMethod("InstallFiles"), 0, transactionFlags, fullPaths)
+	if call.Err != nil {
+		return call.Err
+	}
+	timeout := -1
+	finished := false
+loop:
+	for {
+		select {
+		case signal := <-ch:
+			if signal.Path != interfacePath {
+				obj.Logf("Woops: Signal.Path: %+v", signal.Path)
+				continue loop
+			}
+			if signal.Name == FmtTransactionMethod("ErrorCode") {
+				return newPkError(signal.Body)
+			} else if signal.Name == FmtTransactionMethod("Package") {
+				timeout = PkSignalPackageTimeout
+			} else if signal.Name == FmtTransactionMethod("Finished") {
+				finished = true
+				timeout = PkSignalDestroyTimeout
+			} else if signal.Name == FmtTransactionMethod("Destroy") {
+				return nil
+			} else {
+				return fmt.Errorf("error in body: %v", signal.Body)
+			}
+		case <-util.TimeAfterOrBlock(timeout):
+			if finished {
+				obj.Logf("Timeout: InstallFiles: Waiting for 'Destroy'")
+				return nil
+			}
+			return fmt.Errorf("timeout installing files: %s", strings.Join(fullPaths, ", "))
+		}
+	}
+}

--- a/engine/resources/pkg.go
+++ b/engine/resources/pkg.go
@@ -426,6 +426,22 @@ func (obj *PkgRes) CheckApply(ctx context.Context, apply bool) (bool, error) {
 	}
 
 	transactionFlags := obj.packageTransactionFlags()
+
+	if strings.HasPrefix(obj.Name(), "/") {
+		obj.init.Logf("Set(%s): %s...", obj.State, obj.fmtNames(util.StrListIntersection(applyPackages, obj.getNames())))
+		fullPaths := []string{obj.Name()}
+		err := bus.InstallFiles(fullPaths, transactionFlags)
+		if err != nil {
+			if e := obj.untrustedError(err); e != nil {
+				return false, e
+			}
+			return false, err
+		}
+		obj.init.Logf("Set(%s) success: %s", obj.State, obj.fmtNames(util.StrListIntersection(applyPackages, obj.getNames())))
+		return false, nil
+	}
+
+	obj.init.Logf("Set(%s): %s...", obj.State, obj.fmtNames(util.StrListIntersection(applyPackages, obj.getNames())))
 	// apply correct state!
 	obj.init.Logf("Set(%s): %s...", obj.State, obj.fmtNames(util.StrListIntersection(applyPackages, obj.getNames())))
 	switch obj.State {


### PR DESCRIPTION
## Description

This PR implements support for installing packages from local file paths, addressing issue #769.

### Changes

- Added `InstallFiles()` method to `packagekit.Conn` that wraps the PackageKit DBus `InstallFiles` method
- Modified `pkg` resource `CheckApply()` to detect file paths (package names starting with `/`)
- When a path is detected, uses `InstallFiles()` directly instead of package repository lookup

### Usage Example

```mcl
pkg "/path/to/local/package.rpm"
```

This allows installing local `.rpm`, `.deb`, or other package files alongside standard repository packages.

### Implementation Notes

- Follows the same transaction flags and error handling as `InstallPackages()`
- Respects `allowuntrusted` flag for GPG signature validation
- Code formatted with `gofmt`