### PR TITLE
cli: Add 'check lang' to validate mcl

### DIFF
--- a/cli/check.go
+++ b/cli/check.go
@@ -1,0 +1,65 @@
+// Mgmt
+// Copyright (C) James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Additional permission under GNU GPL version 3 section 7
+//
+// If you modify this program, or any covered work, by linking or combining it
+// with embedded mcl code and modules (and that the embedded mcl code and
+// modules which link with this program, contain a copy of their source code in
+// the authoritative form) containing parts covered by the terms of any other
+// license, the licensors of this program grant you additional permission to
+// convey the resulting work. Furthermore, the licensors of this program grant
+// the original author, James Shubin, additional permission to update this
+// additional permission if he deems it necessary to achieve the goals of this
+// additional permission.
+
+package cli
+
+import (
+	"context"
+
+	cliUtil "github.com/purpleidea/mgmt/cli/util"
+	"github.com/purpleidea/mgmt/lib"
+)
+
+// CheckArgs RunArgs is the CLI parsing structure and type of the parsed result. This
+// particular one contains all the common flags for the `check` subcommand.
+type CheckArgs struct {
+	lib.Config // embedded config (can't be a pointer) https://github.com/alexflint/go-arg/issues/240
+
+	CheckLang *cliUtil.LangArgs `arg:"subcommand:lang" help:"check lang (mcl) payload"`
+}
+
+// Run executes the correct subcommand. It errors if there's ever an error. It
+// returns true if we did activate one of the subcommands. It returns false if
+// we did not. This information is used so that the top-level parser can return
+// usage or help information if no subcommand activates. This particular Run is
+// the run for the main `check` subcommand. The check command allows validation
+// of mcl files, the mgmt program language.
+func (obj *CheckArgs) Run(ctx context.Context, data *cliUtil.Data) (bool, error) {
+	if cmd := obj.CheckLang; cmd != nil {
+		// Run the 'run lang' command, but forcing '--only-unify' enabled.
+		cmd.OnlyUnify = true
+
+		run := RunArgs{
+			RunLang: cmd,
+		}
+		return run.Run(ctx, data)
+	}
+
+	return false, nil
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -117,6 +117,8 @@ type Args struct {
 
 	RunCmd *RunArgs `arg:"subcommand:run" help:"run code on this machine"`
 
+	CheckCmd *CheckArgs `arg:"subcommand:check" help:"check code on this machine"`
+
 	DeployCmd *DeployArgs `arg:"subcommand:deploy" help:"deploy code into a cluster"`
 
 	SetupCmd *SetupArgs `arg:"subcommand:setup" help:"setup some bootstrapping tasks"`
@@ -159,6 +161,10 @@ func (obj *Args) Description() string {
 // usage or help information if no subcommand activates.
 func (obj *Args) Run(ctx context.Context, data *cliUtil.Data) (bool, error) {
 	if cmd := obj.RunCmd; cmd != nil {
+		return cmd.Run(ctx, data)
+	}
+
+	if cmd := obj.CheckCmd; cmd != nil {
 		return cmd.Run(ctx, data)
 	}
 


### PR DESCRIPTION
Currently, this has the same effect as `run lang --only-unify`

This is intended to make it safer for humans to use to check for syntax and unification errors because accidentally omitting the "--only-unify" flag on `run lang` could have negative consequences for the operator.

* [x] ran gofmt
* [x]  passes commit message test

Example usage:

```
mgmt check lang example.mcl
```

(I am OK if this command is removed later once a mclfmt tool becomes available)