### PR TITLE
lang: funcs: Add os.release

### DIFF
--- a/lang/core/os/distro.go
+++ b/lang/core/os/distro.go
@@ -36,9 +36,14 @@ import (
 
 	"github.com/purpleidea/mgmt/lang/funcs/simple"
 	"github.com/purpleidea/mgmt/lang/types"
+	distroUtil "github.com/purpleidea/mgmt/util/distro"
+	"github.com/purpleidea/mgmt/util/errwrap"
 )
 
-const structDistroUID = "struct{distro str; version str; arch str}"
+const (
+	structDistroUID   = "struct{distro str; version str; arch str}"
+	releaseReturnType = "struct{id str; variant_id str; version_id str}"
+)
 
 var typeParseDistroUID = types.NewType(fmt.Sprintf("func(str) %s", structDistroUID))
 
@@ -53,6 +58,19 @@ func init() {
 		T: typeParseDistroUID,
 		F: ParseDistroUID,
 	})
+
+	simple.ModuleRegister(ModuleName, "release", &simple.Scaffold{
+		I: &simple.Info{
+			// In theory these are dependent on runtime.
+			Pure: false,
+			Memo: false,
+			Fast: true,
+			Spec: false,
+		},
+		T: types.NewType(fmt.Sprintf("func() %s", releaseReturnType)),
+		F: Release,
+	})
+
 }
 
 // ParseDistroUID parses a distro UID into its component values. If it cannot
@@ -100,4 +118,27 @@ func parseDistroUID(uid string) (string, string, string, error) {
 	// TODO: check for valid distro or arch?
 
 	return distro, version, arch, nil
+}
+
+// Release parses /etc/os-release and returns a struct containing the id,
+// version_id, and variant_id.
+func Release(ctx context.Context, input []types.Value) (types.Value, error) {
+	release, err := distroUtil.ParseOSRelease(ctx)
+	if err != nil {
+		return nil, errwrap.Wrapf(err, "ParseOSRelease failed")
+	}
+
+	st := types.NewStruct(types.NewType(releaseReturnType))
+
+	if err := st.Set("id", &types.StrValue{V: release.ID}); err != nil {
+		return nil, errwrap.Wrapf(err, "invalid id value")
+	}
+	if err := st.Set("variant_id", &types.StrValue{V: release.VARIANT_ID}); err != nil {
+		return nil, errwrap.Wrapf(err, "invalid variant_id value")
+	}
+	if err := st.Set("version_id", &types.StrValue{V: release.VERSION_ID}); err != nil {
+		return nil, errwrap.Wrapf(err, "invalid version_id value")
+	}
+
+	return st, nil
 }

--- a/util/distro/distro.go
+++ b/util/distro/distro.go
@@ -161,7 +161,7 @@ func IsFamilyArchLinux(ctx context.Context) (bool, error) {
 
 // Distro returns the distro name.
 func Distro(ctx context.Context) (string, error) {
-	output, err := parseOSRelease(ctx)
+	output, err := ParseOSRelease(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -170,7 +170,7 @@ func Distro(ctx context.Context) (string, error) {
 
 // IsDistroDebian detects if the os distro is debian. (Not ubuntu!)
 func IsDistroDebian(ctx context.Context) (bool, error) {
-	output, err := parseOSRelease(ctx)
+	output, err := ParseOSRelease(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -182,7 +182,7 @@ func IsDistroDebian(ctx context.Context) (bool, error) {
 
 // IsDistroFedora detects if the os distro is fedora.
 func IsDistroFedora(ctx context.Context) (bool, error) {
-	output, err := parseOSRelease(ctx)
+	output, err := ParseOSRelease(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -198,10 +198,10 @@ func IsDistroArchLinux(ctx context.Context) (bool, error) {
 	return IsFamilyArchLinux(ctx)
 }
 
-// parseOSRelease is a simple helper function to parse the /etc/os-release file.
+// ParseOSRelease is a simple helper function to parse the /etc/os-release file.
 // TODO: We could probably implement our own cleaner parser eventually.
 // TODO: Cache the result in a global if we don't care about changes.
-func parseOSRelease(ctx context.Context) (*osrelease.OSRelease, error) {
+func ParseOSRelease(ctx context.Context) (*osrelease.OSRelease, error) {
 	// TODO: use ctx around io operations
 	output, err := osrelease.New()
 	if err != nil {


### PR DESCRIPTION
Provides a struct representing parts of /etc/os-release

Example:

    $relinfo = os.release()
    print "release info" {
	    msg => fmt.printf("Distro %s %s (%s)", $relinfo->id, $relinfo->version_id, $relinfo->variant_id),
    }

Output:

    19:57:49 engine: print[release info]: Msg: Distro fedora 44 (cosmic)
