### PR TITLE
Rename method receivers to 'obj'

### DIFF
--- a/engine/graph/autogroup/base.go
+++ b/engine/graph/autogroup/base.go
@@ -45,17 +45,17 @@ type baseGrouper struct {
 }
 
 // Name provides a friendly name for the logs to see.
-func (ag *baseGrouper) Name() string {
+func (obj *baseGrouper) Name() string {
 	return "baseGrouper"
 }
 
 // Init is called only once and before using other AutoGrouper interface methods
 // the name method is the only exception: call it any time without side effects!
-func (ag *baseGrouper) Init(g *pgraph.Graph) error {
-	if ag.graph != nil {
+func (obj *baseGrouper) Init(g *pgraph.Graph) error {
+	if obj.graph != nil {
 		return fmt.Errorf("the init method has already been called")
 	}
-	ag.graph = g // pointer
+	obj.graph = g // pointer
 
 	// We sort deterministically, first by kind, and then by name. In
 	// particular, longer kind chunks sort first. So http:server:ui:input
@@ -70,14 +70,14 @@ func (ag *baseGrouper) Init(g *pgraph.Graph) error {
 	// continues along. If the "longer" resources appear first, then they'll
 	// group together first. We should probably put this into a new Grouper
 	// struct, but for now we might as well leave it here.
-	//vertices := ag.graph.VerticesSorted() // formerly
-	vertices := RHVSort(ag.graph.Vertices())
+	//vertices := obj.graph.VerticesSorted() // formerly
+	vertices := RHVSort(obj.graph.Vertices())
 
-	ag.vertices = vertices // cache in deterministic order!
-	ag.i = 0
-	ag.j = 0
-	if len(ag.vertices) == 0 { // empty graph
-		ag.done = true
+	obj.vertices = vertices // cache in deterministic order!
+	obj.i = 0
+	obj.j = 0
+	if len(obj.vertices) == 0 { // empty graph
+		obj.done = true
 		return nil
 	}
 	return nil
@@ -87,48 +87,48 @@ func (ag *baseGrouper) Init(g *pgraph.Graph) error {
 // an intelligent algorithm would selectively offer only valid pairs of vertices
 // these should satisfy logical grouping requirements for the autogroup designs!
 // the desired algorithms can override, but keep this method as a base iterator!
-func (ag *baseGrouper) VertexNext() (v1, v2 pgraph.Vertex, err error) {
+func (obj *baseGrouper) VertexNext() (v1, v2 pgraph.Vertex, err error) {
 	// this does a for v... { for w... { return v, w }} but stepwise!
-	l := len(ag.vertices)
-	if ag.i < l {
-		v1 = ag.vertices[ag.i]
+	l := len(obj.vertices)
+	if obj.i < l {
+		v1 = obj.vertices[obj.i]
 	}
-	if ag.j < l {
-		v2 = ag.vertices[ag.j]
+	if obj.j < l {
+		v2 = obj.vertices[obj.j]
 	}
 
 	// in case the vertex was deleted
-	if !ag.graph.HasVertex(v1) {
+	if !obj.graph.HasVertex(v1) {
 		v1 = nil
 	}
-	if !ag.graph.HasVertex(v2) {
+	if !obj.graph.HasVertex(v2) {
 		v2 = nil
 	}
 
 	// two nested loops...
-	if ag.j < l {
-		ag.j++
+	if obj.j < l {
+		obj.j++
 	}
-	if ag.j == l {
-		ag.j = 0
-		if ag.i < l {
-			ag.i++
+	if obj.j == l {
+		obj.j = 0
+		if obj.i < l {
+			obj.i++
 		}
-		if ag.i == l {
-			ag.done = true
+		if obj.i == l {
+			obj.done = true
 		}
 	}
 	// TODO: is this index swap better or even valid?
-	//if ag.i < l {
-	//	ag.i++
+	//if obj.i < l {
+	//	obj.i++
 	//}
-	//if ag.i == l {
-	//	ag.i = 0
-	//	if ag.j < l {
-	//		ag.j++
+	//if obj.i == l {
+	//	obj.i = 0
+	//	if obj.j < l {
+	//		obj.j++
 	//	}
-	//	if ag.j == l {
-	//		ag.done = true
+	//	if obj.j == l {
+	//		obj.done = true
 	//	}
 	//}
 
@@ -136,7 +136,7 @@ func (ag *baseGrouper) VertexNext() (v1, v2 pgraph.Vertex, err error) {
 }
 
 // VertexCmp can be used in addition to an overriding implementation.
-func (ag *baseGrouper) VertexCmp(v1, v2 pgraph.Vertex) error {
+func (obj *baseGrouper) VertexCmp(v1, v2 pgraph.Vertex) error {
 	if v1 == nil || v2 == nil {
 		return fmt.Errorf("the vertex is nil")
 	}
@@ -148,21 +148,21 @@ func (ag *baseGrouper) VertexCmp(v1, v2 pgraph.Vertex) error {
 }
 
 // VertexMerge needs to be overridden to add the actual merging functionality.
-func (ag *baseGrouper) VertexMerge(v1, v2 pgraph.Vertex) (v pgraph.Vertex, err error) {
+func (obj *baseGrouper) VertexMerge(v1, v2 pgraph.Vertex) (v pgraph.Vertex, err error) {
 	return nil, fmt.Errorf("vertexMerge needs to be overridden")
 }
 
 // EdgeMerge can be overridden, since it just simply returns the first edge.
-func (ag *baseGrouper) EdgeMerge(e1, e2 pgraph.Edge) pgraph.Edge {
+func (obj *baseGrouper) EdgeMerge(e1, e2 pgraph.Edge) pgraph.Edge {
 	return e1 // noop
 }
 
 // VertexTest processes the results of the grouping for the algorithm to know
 // return an error if something went horribly wrong, and bool false to stop.
-func (ag *baseGrouper) VertexTest(b bool) (bool, error) {
+func (obj *baseGrouper) VertexTest(b bool) (bool, error) {
 	// NOTE: this particular baseGrouper version doesn't track what happens
 	// because since we iterate over every pair, we don't care which merge!
-	if ag.done {
+	if obj.done {
 		return false, nil
 	}
 	return true, nil

--- a/engine/graph/autogroup/nonreachability.go
+++ b/engine/graph/autogroup/nonreachability.go
@@ -41,7 +41,7 @@ type NonReachabilityGrouper struct {
 }
 
 // Name returns the name for the grouper algorithm.
-func (ag *NonReachabilityGrouper) Name() string {
+func (obj *NonReachabilityGrouper) Name() string {
 	return "NonReachabilityGrouper"
 }
 
@@ -49,9 +49,9 @@ func (ag *NonReachabilityGrouper) Name() string {
 // This algorithm relies on the observation that if there's a path from a to b,
 // then they *can't* be merged (b/c of the existing dependency) so therefore we
 // merge anything that *doesn't* satisfy this condition or that of the reverse!
-func (ag *NonReachabilityGrouper) VertexNext() (v1, v2 pgraph.Vertex, err error) {
+func (obj *NonReachabilityGrouper) VertexNext() (v1, v2 pgraph.Vertex, err error) {
 	for {
-		v1, v2, err = ag.baseGrouper.VertexNext() // get all iterable pairs
+		v1, v2, err = obj.baseGrouper.VertexNext() // get all iterable pairs
 		if err != nil {
 			return nil, nil, errwrap.Wrapf(err, "error running autoGroup(vertexNext)")
 		}
@@ -59,11 +59,11 @@ func (ag *NonReachabilityGrouper) VertexNext() (v1, v2 pgraph.Vertex, err error)
 		// ignore self cmp early (perf optimization)
 		if v1 != v2 && v1 != nil && v2 != nil {
 			// if NOT reachable, they're viable...
-			out1, e1 := ag.graph.Reachability(v1, v2)
+			out1, e1 := obj.graph.Reachability(v1, v2)
 			if e1 != nil {
 				return nil, nil, e1
 			}
-			out2, e2 := ag.graph.Reachability(v2, v1)
+			out2, e2 := obj.graph.Reachability(v2, v1)
 			if e2 != nil {
 				return nil, nil, e2
 			}
@@ -73,7 +73,7 @@ func (ag *NonReachabilityGrouper) VertexNext() (v1, v2 pgraph.Vertex, err error)
 		}
 
 		// if we got here, it means we're skipping over this candidate!
-		if ok, err := ag.baseGrouper.VertexTest(false); err != nil {
+		if ok, err := obj.baseGrouper.VertexTest(false); err != nil {
 			return nil, nil, errwrap.Wrapf(err, "error running autoGroup(vertexTest)")
 		} else if !ok {
 			return nil, nil, nil // done!

--- a/engine/util.go
+++ b/engine/util.go
@@ -38,9 +38,9 @@ import (
 // ResourceSlice is a linear list of resources. It can be sorted.
 type ResourceSlice []Res
 
-func (rs ResourceSlice) Len() int           { return len(rs) }
-func (rs ResourceSlice) Swap(i, j int)      { rs[i], rs[j] = rs[j], rs[i] }
-func (rs ResourceSlice) Less(i, j int) bool { return rs[i].String() < rs[j].String() }
+func (obj ResourceSlice) Len() int           { return len(obj) }
+func (obj ResourceSlice) Swap(i, j int)      { obj[i], obj[j] = obj[j], obj[i] }
+func (obj ResourceSlice) Less(i, j int) bool { return obj[i].String() < obj[j].String() }
 
 // Sort the list of resources and return a copy without modifying the input.
 func Sort(rs []Res) []Res {

--- a/engine/util/util_test.go
+++ b/engine/util/util_test.go
@@ -188,33 +188,33 @@ type testEngineRes struct {
 	privateProp2 []int
 }
 
-func (t *testEngineRes) CheckApply(context.Context, bool) (bool, error) { return false, nil }
+func (obj *testEngineRes) CheckApply(context.Context, bool) (bool, error) { return false, nil }
 
-func (t *testEngineRes) Cleanup() error { return nil }
+func (obj *testEngineRes) Cleanup() error { return nil }
 
-func (t *testEngineRes) Cmp(engine.Res) error { return nil }
+func (obj *testEngineRes) Cmp(engine.Res) error { return nil }
 
-func (t *testEngineRes) Default() engine.Res { return t }
+func (obj *testEngineRes) Default() engine.Res { return obj }
 
-func (t *testEngineRes) Init(*engine.Init) error { return nil }
+func (obj *testEngineRes) Init(*engine.Init) error { return nil }
 
-func (t *testEngineRes) Kind() string { return "test-kind" }
+func (obj *testEngineRes) Kind() string { return "test-kind" }
 
-func (t *testEngineRes) MetaParams() *engine.MetaParams { return nil }
+func (obj *testEngineRes) MetaParams() *engine.MetaParams { return nil }
 
-func (t *testEngineRes) Name() string { return "test-name" }
+func (obj *testEngineRes) Name() string { return "test-name" }
 
-func (t *testEngineRes) SetKind(string) {}
+func (obj *testEngineRes) SetKind(string) {}
 
-func (t *testEngineRes) SetMetaParams(*engine.MetaParams) {}
+func (obj *testEngineRes) SetMetaParams(*engine.MetaParams) {}
 
-func (t *testEngineRes) SetName(string) {}
+func (obj *testEngineRes) SetName(string) {}
 
-func (t *testEngineRes) String() string { return "test-string" }
+func (obj *testEngineRes) String() string { return "test-string" }
 
-func (t *testEngineRes) Validate() error { return nil }
+func (obj *testEngineRes) Validate() error { return nil }
 
-func (t *testEngineRes) Watch(context.Context) error { return nil }
+func (obj *testEngineRes) Watch(context.Context) error { return nil }
 
 func TestLangFieldNameToStructType(t *testing.T) {
 	k := "test-kind"

--- a/lang/interpolate/types.go
+++ b/lang/interpolate/types.go
@@ -45,7 +45,7 @@ type Literal struct {
 }
 
 // token ties the Literal to the Token interface.
-func (Literal) token() {}
+func (obj Literal) token() {}
 
 // Variable is a variable name that we have found after interpolation parsing.
 type Variable struct {
@@ -53,6 +53,6 @@ type Variable struct {
 }
 
 // token ties the Variable to the Token interface.
-func (Variable) token() {}
+func (obj Variable) token() {}
 
 // TODO: do we want to allow inline-function calls in a string?

--- a/lang/parser/lexparse.go
+++ b/lang/parser/lexparse.go
@@ -72,8 +72,8 @@ type LexParseErr struct {
 }
 
 // Error displays this error with all the relevant state information.
-func (e *LexParseErr) Error() string {
-	return fmt.Sprintf("%s: `%s` @%d:%d", e.Err, e.Str, e.Row+1, e.Col+1)
+func (obj *LexParseErr) Error() string {
+	return fmt.Sprintf("%s: `%s` @%d:%d", obj.Err, obj.Str, obj.Row+1, obj.Col+1)
 }
 
 // lexParseAST is a struct which we pass into the lexer/parser so that we have a

--- a/lang/types/value.go
+++ b/lang/types/value.go
@@ -528,9 +528,9 @@ func Into(v Value, rv reflect.Value) error {
 // ValueSlice is a linear list of values. It is used for sorting purposes.
 type ValueSlice []Value
 
-func (vs ValueSlice) Len() int           { return len(vs) }
-func (vs ValueSlice) Swap(i, j int)      { vs[i], vs[j] = vs[j], vs[i] }
-func (vs ValueSlice) Less(i, j int) bool { return vs[i].Less(vs[j]) }
+func (obj ValueSlice) Len() int           { return len(obj) }
+func (obj ValueSlice) Swap(i, j int)      { obj[i], obj[j] = obj[j], obj[i] }
+func (obj ValueSlice) Less(i, j int) bool { return obj[i].Less(obj[j]) }
 
 // Base implements the missing methods that all types need.
 type Base struct{}

--- a/pgraph/util_test.go
+++ b/pgraph/util_test.go
@@ -42,8 +42,8 @@ type vertex struct {
 }
 
 // String is a required method of the Vertex interface that we must fulfill.
-func (v *vertex) String() string {
-	return v.name
+func (obj *vertex) String() string {
+	return obj.name
 }
 
 // NV is a helper function to make testing easier. It creates a new noop vertex.
@@ -57,8 +57,8 @@ type edge struct {
 }
 
 // String is a required method of the Edge interface that we must fulfill.
-func (e *edge) String() string {
-	return e.name
+func (obj *edge) String() string {
+	return obj.name
 }
 
 // NE is a helper function to make testing easier. It creates a new noop edge.

--- a/test/Makefile
+++ b/test/Makefile
@@ -32,11 +32,15 @@ SHELL = bash
 
 all: build
 
-build: reflowed-comments
+build: reflowed-comments receiver-check
 
 clean:
-	@rm -f reflowed-comments || true
+	@rm -f reflowed-comments receiver-check || true
 
 reflowed-comments: reflowed-comments.go
 	@echo "Generating: reflowed-comments..."
 	go build reflowed-comments.go
+
+receiver-check: receiver-check.go
+	@echo "Generating: receiver-check..."
+	go build receiver-check.go

--- a/test/receiver-check.go
+++ b/test/receiver-check.go
@@ -1,0 +1,76 @@
+// Mgmt
+// Copyright (C) James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s <file> [file...]\n", os.Args[0])
+		os.Exit(2)
+	}
+
+	exitCode := 0
+	for _, filename := range os.Args[1:] {
+		if errs := check(filename); len(errs) > 0 {
+			for _, err := range errs {
+				fmt.Fprintf(os.Stderr, "Error in %s: %v\n", filename, err)
+			}
+			exitCode = 1
+		}
+	}
+	os.Exit(exitCode)
+}
+
+func check(filename string) []error {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filename, nil, 0)
+	if err != nil {
+		return []error{err}
+	}
+
+	var errs []error
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil || len(fn.Recv.List) == 0 {
+			continue
+		}
+
+		// Method receivers in Go can have only one parameter in the list.
+		field := fn.Recv.List[0]
+		if len(field.Names) == 0 {
+			pos := fset.Position(field.Pos())
+			errs = append(errs, fmt.Errorf("%d:%d: method receiver must be named 'obj', but it is unnamed", pos.Line, pos.Column))
+			continue
+		}
+
+		name := field.Names[0].Name
+		if name != "obj" {
+			pos := fset.Position(field.Names[0].Pos())
+			errs = append(errs, fmt.Errorf("%d:%d: method receiver must be named 'obj', but it is named '%s'", pos.Line, pos.Column, name))
+		}
+	}
+
+	return errs
+}

--- a/test/test-govet.sh
+++ b/test/test-govet.sh
@@ -59,6 +59,26 @@ function naked-error() {
 	return 0
 }
 
+function receiver-check() {
+	if [ "$1" = './lang/core/generated_funcs.go' ]; then
+		return 0
+	fi
+
+	if [ "$1" = './lang/parser/y.go' ]; then
+		return 0
+	fi
+
+	if [ "$1" = './lang/parser/lexer.nn.go' ]; then
+		return 0
+	fi
+
+	if [ "$1" = './lang/interpolate/parse.generated.go' ]; then
+		return 0
+	fi
+
+	./test/receiver-check "$1"
+}
+
 # catch errors that start with a capital
 function lowercase-errors() {
 	if grep -E 'errors\.New\("[A-Z]' "$1"; then
@@ -161,6 +181,7 @@ for file in `find . -maxdepth 9 -type f -name '*.go' -not -path './old/*' -not -
 	run-test lowercase-errors "$file"
 	run-test consistent-imports "$file"
 	run-test reflowed-comments "$file"
+	run-test receiver-check "$file"
 done
 
 if [[ -n "$failures" ]]; then

--- a/util/afero_relpath.go
+++ b/util/afero_relpath.go
@@ -284,8 +284,8 @@ type readDirFile struct {
 
 var _ fs.ReadDirFile = readDirFile{}
 
-func (r readDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
-	items, err := r.File.Readdir(n)
+func (obj readDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	items, err := obj.File.Readdir(n)
 	if err != nil {
 		return nil, err
 	}

--- a/yamlgraph/gconfig.go
+++ b/yamlgraph/gconfig.go
@@ -88,32 +88,32 @@ type Resource struct {
 }
 
 // UnmarshalYAML is the first stage for unmarshaling of resources.
-func (r *Resource) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	r.unmarshal = unmarshal
-	return unmarshal(&r.ResourceData)
+func (obj *Resource) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	obj.unmarshal = unmarshal
+	return unmarshal(&obj.ResourceData)
 }
 
 // Decode is the second stage for unmarshaling of resources (knowing their
 // kind).
-func (r *Resource) Decode(kind string) (err error) {
+func (obj *Resource) Decode(kind string) (err error) {
 	if kind == "" {
 		return fmt.Errorf("can't set empty kind") // bug?
 	}
-	r.resource, err = engine.NewResource(kind)
+	obj.resource, err = engine.NewResource(kind)
 	if err != nil {
 		return err
 	}
 
 	// i think this erases the `SetKind` that happens with the NewResource
 	// so as a result, we need to do it again below... this is a hack...
-	err = r.unmarshal(r.resource)
+	err = obj.unmarshal(obj.resource)
 	if err != nil {
 		return err
 	}
 
 	// set resource name and kind
-	r.resource.SetName(r.Name)
-	r.resource.SetKind(kind)
+	obj.resource.SetName(obj.Name)
+	obj.resource.SetKind(kind)
 	// TODO: I don't think meta is getting unmarshalled properly anymore
 	return
 }


### PR DESCRIPTION
Renamed all method receivers to 'obj' across the codebase to comply with the style guide. Updated internal usages and added names to unnamed receivers.

---
*PR created automatically by Jules for task [7520509434589471899](https://jules.google.com/task/7520509434589471899) started by @purpleidea*