### PR TITLE
Replace non-standard characters with ASCII equivalents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -550,16 +550,16 @@ releases_path:
 	@echo "releases/$(VERSION)/"
 
 release_test: $(DEP_BINARY_AMD64) $(DEP_BINARY_ARM64) $(DEP_FEDORA-LATEST) $(DEP_FEDORA-OLDER) $(DEP_STREAM-LATEST) $(DEP_DEBIAN-STABLE) $(DEP_UBUNTU-LATEST) $(DEP_ARCHLINUX) $(SHA256SUMS_ASC)
-	@echo '$$< denotes ‘the first dependency of the current rule’.'
+	@echo '$$< denotes "the first dependency of the current rule".'
 	@echo '> '"$<"
 	@echo
-	@echo '$$@ denotes ‘the target of the current rule’.'
+	@echo '$$@ denotes "the target of the current rule".'
 	@echo '> '"$@"
 	@echo
-	@echo '$$^ denotes ‘the dependencies of the current rule’.'
+	@echo '$$^ denotes "the dependencies of the current rule".'
 	@echo '> '"$^"
 	@echo
-	@echo '$$* denotes ‘the stem with which the pattern of the current rule matched’.'
+	@echo '$$* denotes "the stem with which the pattern of the current rule matched".'
 	@echo '> '"$*"
 	@echo
 	@echo "TOKEN_BINARY_AMD64: $(TOKEN_BINARY_AMD64)"

--- a/docs/on-the-web.md
+++ b/docs/on-the-web.md
@@ -16,7 +16,7 @@ if we missed something that you think is relevant!
 | Felix Frank | blog | [From Catalog To Mgmt (on puppet to mgmt "transpiling")](https://ffrank.github.io/features/2016/02/18/from-catalog-to-mgmt/) |
 | James Shubin | blog | [Automatic edges in mgmt (...and the pkg resource)](https://purpleidea.com/blog/2016/03/14/automatic-edges-in-mgmt/) |
 | James Shubin | blog | [Automatic grouping in mgmt](https://purpleidea.com/blog/2016/03/30/automatic-grouping-in-mgmt/) |
-| John Arundel | tweet | [“Puppet’s days are numbered.”](https://twitter.com/bitfield/status/732157519142002688) |
+| John Arundel | tweet | ["Puppet's days are numbered."](https://twitter.com/bitfield/status/732157519142002688) |
 | Felix Frank | blog | [Puppet, Meet Mgmt (on puppet to mgmt internals)](https://ffrank.github.io/features/2016/06/12/puppet,-meet-mgmt/) |
 | Felix Frank | blog | [Puppet Powered Mgmt (puppet to mgmt tl;dr)](https://ffrank.github.io/features/2016/06/19/puppet-powered-mgmt/) |
 | James Shubin | blog | [Automatic clustering in mgmt](https://purpleidea.com/blog/2016/06/20/automatic-clustering-in-mgmt/) |

--- a/lang/parser/lexparse_test.go
+++ b/lang/parser/lexparse_test.go
@@ -350,7 +350,7 @@ func TestLexParse0(t *testing.T) {
 	// FIXME: why doesn't this overflow, and thus fail?
 	// from the docs: If s is syntactically well-formed but is more than 1/2
 	// ULP away from the largest floating point number of the given size,
-	// ParseFloat returns f = ±Inf, err.Err = ErrRange.
+	// ParseFloat returns f = +/-Inf, err.Err = ErrRange.
 	//{
 	//	testCases = append(testCases, test{
 	//		name: "overflowing float",

--- a/misc/emacs/README.md
+++ b/misc/emacs/README.md
@@ -10,5 +10,5 @@ parallel configuration management tool.
 
 ## Installation
 
-See the MELPA Emacs Lisp package archive’s [getting started](https://melpa.org/#/getting-started)
-guide. Then, select “Options → Manage Emacs Packages” from the menu in Emacs.
+See the MELPA Emacs Lisp package archive's [getting started](https://melpa.org/#/getting-started)
+guide. Then, select "Options -> Manage Emacs Packages" from the menu in Emacs.

--- a/modules/grafana/files/grafana.ini.tmpl
+++ b/modules/grafana/files/grafana.ini.tmpl
@@ -1455,7 +1455,7 @@ allow_loading_unsigned_plugins = performancecopilot-pcp-app,pcp-redis-datasource
 #################################### Grafana Image Renderer Plugin ##########################
 [plugin.grafana-image-renderer]
 # Instruct headless browser instance to use a default timezone when not provided by Grafana, e.g. when rendering panel image of alert.
-# See ICU’s metaZones.txt (https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt) for a list of supported
+# See ICU's metaZones.txt (https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt) for a list of supported
 # timezone IDs. Fallbacks to TZ environment variable if not set.
 ;rendering_timezone =
 

--- a/util/disjoint/disjoint.go
+++ b/util/disjoint/disjoint.go
@@ -28,7 +28,7 @@
 // additional permission.
 
 // Package disjoint implements a "disjoint-set data structure", otherwise known
-// as the "union–find data structure" which is commonly used for type
+// as the "union-find data structure" which is commonly used for type
 // unification, among other things.
 //
 // You create new elements with the NewElem function, which returns an Elem that


### PR DESCRIPTION
Replaced various "weird" special characters (smart quotes, arrows, en-dashes, etc.) with their standard ASCII equivalents in comments, docstrings, and documentation across the codebase. This ensures better compatibility with various tools and environments.

---
*PR created automatically by Jules for task [15044709252551948141](https://jules.google.com/task/15044709252551948141) started by @purpleidea*