### PR TITLE
test: Add go mod madness test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
           - basic
           - shell
           - race
+          - gomod
       fail-fast: false
 
     steps:
@@ -67,5 +68,6 @@ jobs:
 
       - name: Run test
         working-directory: ./go/src/github.com/purpleidea/mgmt
+        continue-on-error: ${{ matrix.test_block == 'gomod' }}
         run: |
           TEST_BLOCK="${{ matrix.test_block }}" make test

--- a/misc/gomodupgrade.sh
+++ b/misc/gomodupgrade.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Mgmt
+# Copyright (C) James Shubin and the project contributors
+# Written by James Shubin <james@shubin.ca> and the project contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Additional permission under GNU GPL version 3 section 7
+#
+# If you modify this program, or any covered work, by linking or combining it
+# with embedded mcl code and modules (and that the embedded mcl code and
+# modules which link with this program, contain a copy of their source code in
+# the authoritative form) containing parts covered by the terms of any other
+# license, the licensors of this program grant you additional permission to
+# convey the resulting work. Furthermore, the licensors of this program grant
+# the original author, James Shubin, additional permission to update this
+# additional permission if he deems it necessary to achieve the goals of this
+# additional permission.
+
+set -e
+
+# Instead of relying on a single bulk upgrade which might fail due to "weird
+# corner cases" (e.g. incompatible Go versions, retracted sub-packages, or
+# other upstream issues in a single transitive dependency), we attempt a bulk
+# upgrade first. If that fails, we fallback to upgrading each direct
+# dependency individually so that valid upgrades aren't blocked by one failure.
+
+if ! go get -u -t ./...; then
+	echo "Bulk upgrade failed, attempting module-by-module upgrade..."
+	# Get all direct dependencies of the project
+	# We use awk since `go list` output formatting can sometimes be tricky
+	# with large dependency graphs.
+	direct_mods=$(go list -m -f '{{if not (or .Main .Indirect)}}{{.Path}}{{end}}' all)
+
+	for mod in $direct_mods; do
+		echo "Upgrading $mod..."
+		# -u: use the network to find the latest versions
+		# -t: also consider modules needed to build tests
+		go get -u -t "$mod" || echo "Warning: failed to upgrade $mod, skipping."
+	done
+fi
+
+# tidy up and remove unused dependencies
+go mod tidy

--- a/test.sh
+++ b/test.sh
@@ -55,6 +55,10 @@ function skip-testsuite() {
 # used at the end to tell if everything went fine
 failures=''
 
+if label-block "gomod"; then
+	run-testsuite ./test/test-gomod.sh
+fi
+
 if label-block "basic"; then
 	run-testsuite ./test/test-vet.sh
 	run-testsuite ./test/test-misc.sh

--- a/test/test-gomod.sh
+++ b/test/test-gomod.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Mgmt
+# Copyright (C) James Shubin and the project contributors
+# Written by James Shubin <james@shubin.ca> and the project contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Additional permission under GNU GPL version 3 section 7
+#
+# If you modify this program, or any covered work, by linking or combining it
+# with embedded mcl code and modules (and that the embedded mcl code and
+# modules which link with this program, contain a copy of their source code in
+# the authoritative form) containing parts covered by the terms of any other
+# license, the licensors of this program grant you additional permission to
+# convey the resulting work. Furthermore, the licensors of this program grant
+# the original author, James Shubin, additional permission to update this
+# additional permission if he deems it necessary to achieve the goals of this
+# additional permission.
+
+echo running "$0"
+set -o errexit
+#set -o nounset
+set -o pipefail
+
+ROOT=$(dirname "${BASH_SOURCE}")/..
+cd "${ROOT}"
+. test/util.sh
+
+# 1. Run the upgrade script
+if ! ./misc/gomodupgrade.sh; then
+	fail_test "Failed to run ./misc/gomodupgrade.sh"
+fi
+
+# 2. Check for changes
+# We use --exit-code to return 1 if there are changes
+if ! git diff --exit-code go.mod go.sum > /dev/null; then
+	git diff go.mod go.sum
+	fail_test "go.mod or go.sum are not up to date. Run ./misc/gomodupgrade.sh to update them."
+fi
+
+# 3. Check if it still builds
+# We use 'go build ./...' to ensure everything compiles
+if ! go build ./...; then
+	fail_test "Build failed after dependency upgrade."
+fi
+
+echo 'PASS'


### PR DESCRIPTION
Fixes #749

This PR adds a test to help automate and verify dependency updates, addressing the "go mod madness" discussed in #749.

### Changes
*   **Idempotent Upgrade Script:** Created `misc/gomodupgrade.sh` to automatically update all dependencies and test dependencies to their latest versions using `go get -u -t ./...` and `go mod tidy`.
*   **New Test Case:** Added `test/test-gomod.sh` which runs the upgrade script, fails if there are uncommitted changes to `go.mod` or `go.sum` (indicating they were out of date), and verifies that the project still builds.
*   **CI Integration:** Integrated the test into the main `test.sh` script under the `gomod` block, and added it to the GitHub Actions test matrix. It is marked with `continue-on-error` so it acts as an early-warning signal for maintainers without blocking other valid PRs if upstream breaks.