### PR TITLE
test: Add automatic link checker to markdown test suite

### DIFF
--- a/test/test-markdownlint.sh
+++ b/test/test-markdownlint.sh
@@ -92,8 +92,7 @@ bad_files=$(
 
 		# check links in docs
 		if $CHECK_LINKS; then
-			# if file is from the directory docs/ then check links
-			if [[ "$i" == docs/* ]] && ! "$LYCHEE" -n "$i" 1>&2; then
+			if ! "$LYCHEE" --root-dir . --accept 200..300,302,429 --timeout 120 --max-retries 2 -n -v "$i" 1>&2; then
 				echo "$i"
 			fi
 		fi


### PR DESCRIPTION
test: Add automatic link checker to markdown test suite
This adds link checking to test/test-markdownlint.sh using lychee. Run with: ./test/test-markdownlint.sh --check-links

Fixes https://github.com/purpleidea/mgmt/issues/440

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>