### PR TITLE
cli: Add Explicit key selection

### DIFF
--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -68,6 +68,10 @@ type DeployArgs struct {
 	// is specified, then it overrides looking for it in the URL.
 	SSHHostKey string `arg:"--ssh-hostkey" help:"use this ssh known hosts key when connecting over SSH"`
 
+	// SSHID is the private key path for SSH client auth with --ssh-url. If empty,
+	// mgmt scans the default SSH directory for id_* private keys.
+	SSHID string `arg:"--ssh-id" help:"private key for SSH client auth"`
+
 	Seeds []string `arg:"--seeds,separate,env:MGMT_SEEDS" help:"default etcd client endpoints"`
 	Noop  bool     `arg:"--noop" help:"globally force all resources into no-op mode"`
 	Sema  int      `arg:"--sema" default:"-1" help:"globally add a semaphore to all resources with this lock count"`
@@ -218,6 +222,7 @@ func (obj *DeployArgs) Run(ctx context.Context, data *cliUtil.Data) (bool, error
 		world = &etcdSSH.World{
 			URL:            obj.SSHURL,
 			HostKey:        obj.SSHHostKey,
+			SSHID:          obj.SSHID,
 			Seeds:          obj.Seeds,
 			NS:             lib.NS,
 			MetadataPrefix: lib.MetadataPrefix,

--- a/cli/util/args.go
+++ b/cli/util/args.go
@@ -166,6 +166,7 @@ type SetupSvcArgs struct {
 	BinaryPath string `arg:"--binary-path" help:"path to the binary"`
 	SSHURL     string `arg:"--ssh-url" help:"transport the etcd client connection over SSH to this server"`
 	SSHHostKey string `arg:"--ssh-hostkey" help:"use this ssh known hosts key when connecting over SSH"`
+	SSHID      string `arg:"--ssh-id" help:"private key for SSH client auth"`
 
 	Seeds []string `arg:"--seeds,separate,env:MGMT_SEEDS" help:"default etcd client endpoints"`
 

--- a/etcd/ssh/ssh.go
+++ b/etcd/ssh/ssh.go
@@ -94,10 +94,9 @@ type World struct {
 	// is specified, then it overrides looking for it in the URL.
 	HostKey string
 
-	// SSHID is the path to the ~/.ssh/id_??? key to use for auth. If you
-	// omit this then this will look for your private key in all possible
-	// paths. If you specific a specific path, then only that will be used.
-	// This will expand the ~/ and ~user/ style path expansions.
+	// SSHID is the private key path for SSH client auth to URL. If empty,
+	// Connect scans defaultSSHDir for id_* private keys. This will expand
+	// the ~/ and ~user/ style path expansions.
 	SSHID string
 
 	// Seeds are the list of etcd endpoints to connect to.

--- a/lang/core/embedded/provisioner/main.mcl
+++ b/lang/core/embedded/provisioner/main.mcl
@@ -622,6 +622,7 @@ class base:host($name, $config) {
 	$handoff_module_path = $config->handoff_module_path || ""
 	$handoff_svc_sshurl = $config->handoff_svc_sshurl || ""
 	$handoff_svc_hostkey = $config->handoff_svc_hostkey || ""
+	$handoff_svc_sshid = $config->handoff_svc_sshid || ""
 	panic(($handoff_svc_sshurl != "") != ($handoff_svc_hostkey != ""), "provisioner:host $handoff_svc needs sshurl (${handoff_svc_sshurl}) and hostkey (${handoff_svc_hostkey})")
 
 	panic($handoff_code != "" and not golang_strings.has_prefix($handoff_code, "/"), "provisioner:host $handoff_code is not absolute")
@@ -838,7 +839,7 @@ class base:host($name, $config) {
 		# Setup the remote mgmt service, which starts on firstboot.
 		# NOTE: We use the short mgmt path because it's easier to pivot.
 		# XXX: read the ssh hostkey from a .known_hosts file instead
-		"${handoff_binary_path} setup svc --binary-path='mgmt' --install --enable --ssh-url='${handoff_svc_sshurl}' --ssh-hostkey='${handoff_svc_hostkey}' --seeds='http://127.0.0.1:2379'"
+		"${handoff_binary_path} setup svc --binary-path='mgmt' --install --enable --ssh-url='${handoff_svc_sshurl}' --ssh-hostkey='${handoff_svc_hostkey}' --ssh-id='${handoff_svc_sshid}' --seeds='http://127.0.0.1:2379'"
 	} else {
 		if $handoff_type == "code" {
 			# Setup the mgmt service, which starts on firstboot.
@@ -1012,7 +1013,8 @@ class base:host($name, $config) {
 }
 
 class base:runner($config) {
-	$sshkey = $config->sshkey || ""
+	$sshkey = $config->sshkey || "" # pub key installed on new host
+	$sshid = $config->sshid || "" # custom private key on new host used for client auth | empty: pass all available as possible signer
 
 	$etcd_server = world.getval("provisioner_etcd_server")->value # struct{value str; exists bool}
 	if $etcd_server != "" {
@@ -1069,8 +1071,9 @@ class base:runner($config) {
 				handoff => "svc", # sets up mgmt with handoff_svc
 				handoff_svc_sshurl => $etcd_server_sshurl,
 				handoff_svc_hostkey => $etcd_server_hostkey,
+				handoff_svc_sshid => $sshid,
 				#handoff => "exec", # sets up mgmt with handoff_exec
-				#handoff_exec => "mgmt run --ssh-url='${etcd_server_sshurl}' --ssh-hostkey='${etcd_server_hostkey}' --seeds=http://127.0.0.1:2379 --no-autoedges --no-autogroup --no-pgp empty",
+				#handoff_exec => "mgmt run --ssh-url='${etcd_server_sshurl}' --ssh-hostkey='${etcd_server_hostkey}' --ssh-id='${sshid}' --seeds=http://127.0.0.1:2379 --no-autoedges --no-autogroup --no-pgp empty",
 				#handoff_code => "/etc/mgmt/", # one way to do it
 				#handoff_module_path => "/etc/mgmt/modules/",
 				handoff_hostname => $k,

--- a/lib/main.go
+++ b/lib/main.go
@@ -167,6 +167,10 @@ type Config struct {
 	// is specified, then it overrides looking for it in the URL.
 	SSHHostKey string `arg:"--ssh-hostkey" help:"use this ssh known hosts key when connecting over SSH"`
 
+	// SSHID is the private key path for SSH client auth with --ssh-url. If empty,
+	// mgmt scans the default SSH directory for id_* private keys.
+	SSHID string `arg:"--ssh-id" help:"private key for SSH client auth"`
+
 	// Seeds are the list of default etcd client endpoints. If empty, it
 	// will startup a new server.
 	Seeds []string `arg:"--seeds,separate,env:MGMT_SEEDS" help:"default etcd client endpoints"`
@@ -758,6 +762,7 @@ func (obj *Main) Run(ctx context.Context) (reterr error) {
 		world = &etcdSSH.World{
 			URL:            obj.SSHURL,
 			HostKey:        obj.SSHHostKey,
+			SSHID:          obj.SSHID,
 			Seeds:          obj.Seeds,
 			NS:             NS,
 			MetadataPrefix: MetadataPrefix,

--- a/modules/mgmt/files/mgmt.service.tmpl
+++ b/modules/mgmt/files/mgmt.service.tmpl
@@ -6,7 +6,7 @@ After=local-fs.target
 Wants=local-fs.target
 
 [Service]
-ExecStart={{ .Exec }} run {{ if .Pprof }}--pprof='{{ .Pprof }}'{{ end }} {{ if .Ssh_url }}--ssh-url='{{ .Ssh_url }}'{{ end }} {{ if .Ssh_hostkey }}--ssh-hostkey='{{ .Ssh_hostkey }}'{{ end }} {{ .Valid_seeds }} --no-autoedges --no-autogroup empty $OPTS
+ExecStart={{ .Exec }} run {{ if .Pprof }}--pprof='{{ .Pprof }}'{{ end }} {{ if .Ssh_url }}--ssh-url='{{ .Ssh_url }}'{{ end }} {{ if .Ssh_hostkey }}--ssh-hostkey='{{ .Ssh_hostkey }}'{{ end }} {{ if .Ssh_id }}--ssh-id='{{ .Ssh_id }}'{{ end }} {{ .Valid_seeds }} --no-autoedges --no-autogroup empty $OPTS
 RestartSec=5s
 Restart=always
 LimitNOFILE=65536

--- a/modules/mgmt/main.mcl
+++ b/modules/mgmt/main.mcl
@@ -67,6 +67,7 @@ class service_file($path, $st) {
 	$exec str = $st->exec # required
 	$ssh_url = $st->ssh_url || "" # optional
 	$ssh_hostkey = $st->ssh_hostkey || "" # optional
+	$ssh_id = $st->ssh_id || "" # optional
 	$seeds []str = $st->seeds # required
 	$pprof = $st->pprof || "" # eg: 127.0.0.1:6060 to enable
 
@@ -77,6 +78,7 @@ class service_file($path, $st) {
 		exec => $exec,
 		ssh_url => $ssh_url,
 		ssh_hostkey => $ssh_hostkey,
+		ssh_id => $ssh_id,
 		#seeds => $seeds,
 		valid_seeds => $valid_seeds,
 		pprof => $pprof,
@@ -111,6 +113,7 @@ class master($st) {
 	$ssh_url = $st->ssh_url || "" # optional
 	$ssh_hostkey = $st->ssh_hostkey || "" # optional
 	$pprof = $st->pprof || "" # eg: 127.0.0.1:6060 to enable
+	$ssh_id = $st->ssh_id || "" # optional
 
 	# 1) package repo
 	include misc.yum_repo("mgmt", struct{
@@ -137,6 +140,7 @@ class master($st) {
 		exec => "/usr/bin/mgmt",
 		ssh_url => $ssh_url,
 		ssh_hostkey => $ssh_hostkey,
+		ssh_id => $ssh_id,
 		seeds => $seeds,
 		pprof => $pprof,
 	})

--- a/setup/svc.go
+++ b/setup/svc.go
@@ -116,6 +116,10 @@ func (obj *Svc) Run(ctx context.Context) error {
 			argv = append(argv, fmt.Sprintf("--ssh-hostkey=%s", s))
 		}
 
+		if s := obj.SetupSvcArgs.SSHID; s != "" {
+			argv = append(argv, fmt.Sprintf("--ssh-id=%s", s))
+		}
+
 		for _, seed := range obj.SetupSvcArgs.Seeds {
 			// TODO: validate each seed?
 			s := fmt.Sprintf("--seeds=%s", seed)


### PR DESCRIPTION
Adds a --ssh-id CLI flag to select an exact SSH private key path.
This sets the internal `SSHID` variable (`etcd/ssh/ssh.go`), which was previously not exposed directly.

With an unset/empty `SSHID` we collect SSH client signers only by scanning the default SSH directory for `id_*` private keys.

This change exposes the existing `SSHID` field as an explicit single-key alternative.

Why this was needed:
- My PK files are not neccessarily under ~/.ssh
- The current scan does not respect a custom HOME override
ExpandHome ends up using the actual user home setting via os.user
```go
	if strings.HasPrefix(p, "~/") {
		usr, err := user.Current()
		if err != nil {
			return p, fmt.Errorf("can't expand ~ into home directory")
		}
		return path.Join(usr.HomeDir, p[len("~/"):]) + suffix, nil
	}
```