### PR TITLE
engine: resources: packagekit: Use signal info for installed state

### DIFF
--- a/engine/resources/packagekit/packagekit.go
+++ b/engine/resources/packagekit/packagekit.go
@@ -257,6 +257,15 @@ type PkPackageIDActionData struct {
 	Newest    bool
 }
 
+type resolvedPackage struct {
+	Info      uint32
+	PackageID string
+}
+
+// PackageKit's Package signal uses sequential PkInfoEnum values, not the
+// bitfield values used by the PkInfoEnum constants above.
+const packageInfoInstalledValue uint32 = 1
+
 // NewBus returns a new bus connection.
 func NewBus() (*Conn, error) {
 	// if we share the bus with others, we will get each others messages!!
@@ -371,11 +380,42 @@ func (obj *Conn) CreateTransaction() (dbus.ObjectPath, error) {
 
 // ResolvePackages runs the PackageKit Resolve method and returns the result.
 func (obj *Conn) ResolvePackages(ctx context.Context, packages []string, filter uint64) ([]string, error) {
-	packageIDs := []string{}
+	resolved, err := obj.resolvePackagesWithInfo(ctx, packages, filter)
+	if err != nil {
+		return nil, err
+	}
+	packageIDs := make([]string, 0, len(resolved))
+	for _, pkg := range resolved {
+		packageIDs = append(packageIDs, pkg.PackageID)
+	}
+	return packageIDs, nil
+}
+
+func newResolvedPackage(body []interface{}) (*resolvedPackage, bool) {
+	if len(body) < 2 {
+		return nil, false
+	}
+	info, _ := body[0].(uint32)
+	packageID, ok := body[1].(string)
+	if !ok {
+		return nil, false
+	}
+	return &resolvedPackage{
+		Info:      info,
+		PackageID: packageID,
+	}, true
+}
+
+func (obj resolvedPackage) installed() bool {
+	return obj.Info == packageInfoInstalledValue
+}
+
+func (obj *Conn) resolvePackagesWithInfo(ctx context.Context, packages []string, filter uint64) ([]resolvedPackage, error) {
+	resolved := []resolvedPackage{}
 	ch := make(chan *dbus.Signal, PkBufferSize)   // we need to buffer :(
 	interfacePath, err := obj.CreateTransaction() // emits Destroy on close
 	if err != nil {
-		return []string{}, err
+		return []resolvedPackage{}, err
 	}
 
 	// add signal matches for Package and Finished which will always be last
@@ -394,7 +434,7 @@ func (obj *Conn) ResolvePackages(ctx context.Context, packages []string, filter 
 		obj.Logf("ResolvePackages(): Call: Success!")
 	}
 	if call.Err != nil {
-		return []string{}, call.Err
+		return []resolvedPackage{}, call.Err
 	}
 loop:
 	for {
@@ -403,7 +443,7 @@ loop:
 		case signal, ok := <-ch:
 			if !ok {
 				// channel closed, e.g. the bus connection died
-				return []string{}, fmt.Errorf("signal channel closed unexpectedly")
+				return []resolvedPackage{}, fmt.Errorf("signal channel closed unexpectedly")
 			}
 			if obj.Debug {
 				obj.Logf("ResolvePackages(): Signal: %+v", signal)
@@ -414,21 +454,18 @@ loop:
 			}
 
 			if signal.Name == FmtTransactionMethod("ErrorCode") {
-				return []string{}, newPkError(signal.Body)
+				return []resolvedPackage{}, newPkError(signal.Body)
 			} else if signal.Name == FmtTransactionMethod("Package") {
-				//pkg_int, ok := signal.Body[0].(int)
-				packageID, ok := signal.Body[1].(string)
-				// format is: name;version;arch;data
+				pkg, ok := newResolvedPackage(signal.Body)
 				if !ok {
 					continue loop
 				}
-				//comment, ok := signal.Body[2].(string)
-				for _, p := range packageIDs {
-					if packageID == p {
+				for _, p := range resolved {
+					if pkg.PackageID == p.PackageID {
 						continue loop // duplicate!
 					}
 				}
-				packageIDs = append(packageIDs, packageID)
+				resolved = append(resolved, *pkg)
 			} else if signal.Name == FmtTransactionMethod("Finished") {
 				// TODO: should we wait for the Destroy signal?
 				break loop
@@ -436,39 +473,35 @@ loop:
 				// should already be broken
 				break loop
 			} else {
-				return []string{}, fmt.Errorf("error in body: %v", signal.Body)
+				return []resolvedPackage{}, fmt.Errorf("error in body: %v", signal.Body)
 			}
 
 		case <-ctx.Done(): // the engine cancelled us, e.g. a slow network
-			return []string{}, ctx.Err()
+			return []resolvedPackage{}, ctx.Err()
 		}
 	}
-	return packageIDs, nil
+	return resolved, nil
 }
 
 // IsInstalledList queries a list of packages to see if they are installed.
 func (obj *Conn) IsInstalledList(ctx context.Context, packages []string) ([]bool, error) {
 	var filter uint64          // initializes at the "zero" value of 0
 	filter += PkFilterEnumArch // always search in our arch
-	packageIDs, err := obj.ResolvePackages(ctx, packages, filter)
+	resolved, err := obj.resolvePackagesWithInfo(ctx, packages, filter)
 	if err != nil {
 		return nil, errwrap.Wrapf(err, "error resolving packages")
 	}
 
 	var m = make(map[string]int)
-	for _, packageID := range packageIDs {
-		s := strings.Split(packageID, ";")
+	for _, packageInfo := range resolved {
+		s := strings.Split(packageInfo.PackageID, ";")
 		//if len(s) != 4 { continue } // this would be a bug!
 		pkg := s[0]
-		flags := strings.Split(s[3], ":")
-		for _, f := range flags {
-			if f == "installed" {
-				if _, exists := m[pkg]; !exists {
-					m[pkg] = 0
-				}
-				m[pkg]++ // if we see pkg installed, increment
-				break
+		if packageInfo.installed() {
+			if _, exists := m[pkg]; !exists {
+				m[pkg] = 0
 			}
+			m[pkg]++ // if we see pkg installed, increment
 		}
 	}
 
@@ -889,7 +922,7 @@ func (obj *Conn) PackagesToPackageIDs(ctx context.Context, packageMap map[string
 	if obj.Debug {
 		obj.Logf("PackagesToPackageIDs(): %s", strings.Join(packages, ", "))
 	}
-	resolved, err := obj.ResolvePackages(ctx, packages, filter)
+	resolved, err := obj.resolvePackagesWithInfo(ctx, packages, filter)
 	if err != nil {
 		return nil, errwrap.Wrapf(err, "error resolving")
 	}
@@ -904,13 +937,14 @@ func (obj *Conn) PackagesToPackageIDs(ctx context.Context, packageMap map[string
 	}
 	var index int
 
-	for _, packageID := range resolved {
+	for _, packageInfo := range resolved {
 		index = -1
+		packageID := packageInfo.PackageID
 		//obj.Logf("* %v", packageID)
 		// format is: name;version;arch;data
 		s := strings.Split(packageID, ";")
 		//if len(s) != 4 { continue } // this would be a bug!
-		pkg, ver, arch, data := s[0], s[1], s[2], s[3]
+		pkg, ver, arch, _ := s[0], s[1], s[2], s[3]
 		// we might need to allow some of this, eg: i386 .deb on amd64
 		b, err := IsMyArch(arch)
 		if err != nil {
@@ -940,7 +974,7 @@ func (obj *Conn) PackagesToPackageIDs(ctx context.Context, packageMap map[string
 			}
 		}
 
-		if FlagInData("installed", data) {
+		if packageInfo.installed() {
 			installed[index] = true
 			version[index] = ver
 			// state of "uninstalled" matched during CheckApply, and

--- a/engine/resources/packagekit/packagekit_test.go
+++ b/engine/resources/packagekit/packagekit_test.go
@@ -57,3 +57,47 @@ func TestNewPkErrorInvalidBody(t *testing.T) {
 		t.Errorf("expected error")
 	}
 }
+
+func TestResolvedPackageInstalledStateUsesSignalInfo(t *testing.T) {
+	const (
+		packageKitSignalInfoInstalled uint32 = 1
+		packageKitSignalInfoAvailable uint32 = 2
+	)
+
+	tests := []struct {
+		name      string
+		body      []interface{}
+		installed bool
+	}{
+		{
+			name: "debian apt installed signal",
+			body: []interface{}{
+				packageKitSignalInfoInstalled,
+				"qemu-utils;1:10.0.8+ds-0+deb13u1+b2;amd64;auto:debian-stable-main",
+				"QEMU utilities",
+			},
+			installed: true,
+		},
+		{
+			name: "available signal",
+			body: []interface{}{
+				packageKitSignalInfoAvailable,
+				"qemu-utils;1:10.0.8+ds-0+deb13u1+b2;amd64;debian-stable-main",
+				"QEMU utilities",
+			},
+			installed: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pkg, ok := newResolvedPackage(test.body)
+			if !ok {
+				t.Fatalf("expected package signal body to parse")
+			}
+			if pkg.installed() != test.installed {
+				t.Fatalf("installed: got %t, want %t", pkg.installed(), test.installed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix installed-state detection for the PackageKit package resource.

PackageKit resolve results expose the package state (installed/absent, or other classification) in the Package signal `info` argument:

```text
Package(info, package_id, summary)
```

The `package_id` is only the package identifier:

```text
name;version;arch;data
```

mgmt was using the package ID `data` field to decide whether a package was installed. That is backend-specific and breaks with the `apt` backend (Debian, ...).

Observed installed package data:

```text
Debian 13 / apt:
Package(1, "qemu-utils;1:10.0.8+ds-0+deb13u1+b2;amd64;auto:debian-stable-main", ...)

Fedora 42 / dnf:
Package(1, "bash;5.2.37-1.fc42;x86_64;installed:anaconda", ...)
```

In both cases `info=1` is `PK_INFO_ENUM_INSTALLED`.
For an available package that is not installed (e.g. `sl`) it shows 2:

```text
Package(2, "sl;5.02-1+b1;amd64;debian-stable-main", ...)
```

See the [enum source in PackageKit](https://github.com/PackageKit/PackageKit/blob/c6eb21d7f4e1005fd2296f50572420906d7d3ae4/lib/packagekit-glib2/pk-enum.h#L620-L660)
```h
typedef enum {
	PK_INFO_ENUM_UNKNOWN, // index 0
	PK_INFO_ENUM_INSTALLED, // index 1
	PK_INFO_ENUM_AVAILABLE, // index 2
// ...
```

The package ID `data` field still shows a difference between backends:

```text
apt: auto:debian-stable-main
dnf: installed:anaconda
```

The apt backend intentionally uses `manual:` / `auto:` package ID data for installed packages. So the portable state source is the PackageKit `info` enum, not the package ID string.

## Minimal reproduction

```mcl
pkg "qemu-utils" {
    state => "installed",
}
```

On Debian with `qemu-utils` already installed, upstream mgmt repeatedly applies the package because it classifies the apt package ID as not installed:

```text
engine: pkg[qemu-utils]: Check: pkg[qemu-utils]
engine: pkg[qemu-utils]: Apply: pkg[qemu-utils]
engine: pkg[qemu-utils]: Set(installed): pkg[qemu-utils]...
engine: pkg[qemu-utils]: Set(installed) success: pkg[qemu-utils]
engine: pkg[qemu-utils]: Check: pkg[qemu-utils]
engine: pkg[qemu-utils]: Apply: pkg[qemu-utils]
...
error: max runtime reached
```

## Fix

Preserve the PackageKit signal `info` value while resolving packages, and use that value for installed-state checks.

`ResolvePackages` still returns package IDs as before; the retained signal info is only used internally where mgmt needs package state.

There is no fallback to package ID `data` parsing for installed state.

## Tests

The unit test covers the new condition directly:

```text
info=1, package_id=...;auto:debian-stable-main => installed
info=2, package_id=...;debian-stable-main      => not installed
```

Focused test run:

```sh
nix shell nixpkgs#go --command env CGO_ENABLED=0 go test -tags 'noaugeas novirt' ./engine/resources/packagekit
```

Manual smoke runs with the patched binary:

```text
Debian 13, PackageKit 1.3.1, pkg "qemu-utils": converged.
Fedora 42, PackageKit 1.3.4, pkg "bash": converged.
```