### PR TITLE
perf: Remove fmt.Sprintf

### DIFF
--- a/lang/ast/scopegraph.go
+++ b/lang/ast/scopegraph.go
@@ -30,10 +30,11 @@
 package ast
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/purpleidea/mgmt/lang/interfaces"
 	"github.com/purpleidea/mgmt/pgraph"
+	"github.com/purpleidea/mgmt/util/strutil"
 )
 
 // ScopeGraph adds nodes and vertices to the supplied graph.
@@ -180,7 +181,7 @@ func (obj *ExprCall) ScopeGraph(g *pgraph.Graph) {
 			panic("can't graph scope") // programming error
 		}
 		arg.ScopeGraph(g)
-		g.AddEdge(obj, arg, &pgraph.SimpleEdge{Name: fmt.Sprintf("arg%d", i)})
+		g.AddEdge(obj, arg, &pgraph.SimpleEdge{Name: strutil.Concat("arg", strconv.FormatInt(int64(i), 10))})
 	}
 }
 

--- a/lang/funcs/funcgen/config.go
+++ b/lang/funcs/funcgen/config.go
@@ -34,6 +34,7 @@ import (
 	"math/bits"
 
 	"github.com/purpleidea/mgmt/lang/types"
+	"github.com/purpleidea/mgmt/util/strutil"
 )
 
 type config struct {
@@ -106,10 +107,10 @@ func (obj *arg) OldToGolang() (string, error) {
 func (obj *arg) ToGolang(val string) (string, error) {
 	switch obj.Type {
 	case "bool":
-		return fmt.Sprintf("%s.Bool()", val), nil
+		return strutil.Concat(val, ".Bool()"), nil
 
 	case "string", "[]byte":
-		return fmt.Sprintf("%s.Str()", val), nil
+		return strutil.Concat(val, ".Str()"), nil
 
 	case "int":
 		// TODO: consider switching types.Value int64 to int everywhere

--- a/lang/funcs/funcgen/func.go
+++ b/lang/funcs/funcgen/func.go
@@ -34,8 +34,11 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
+
+	"github.com/purpleidea/mgmt/util/strutil"
 )
 
 type function struct {
@@ -114,16 +117,16 @@ func generateTemplate(c config, f functions, path, templateFile, finalName strin
 func (obj *function) MakeGolangArgs() (string, error) {
 	var args []string
 	for i, a := range obj.Args {
-		gol, err := a.ToGolang(fmt.Sprintf("args[%d]", i))
+		gol, err := a.ToGolang(strutil.Concat("args[", strconv.FormatInt(int64(i), 10), "]"))
 		if err != nil {
 			return "", err
 		}
 
 		switch a.Type {
 		case "int":
-			gol = fmt.Sprintf("int(%s)", gol)
+			gol = strutil.Concat("int(", gol, ")")
 		case "[]byte":
-			gol = fmt.Sprintf("[]byte(%s)", gol)
+			gol = strutil.Concat("[]byte(", gol, ")")
 		}
 
 		// Variadic expansion for the last slice argument.

--- a/lang/funcs/structs/call.go
+++ b/lang/funcs/structs/call.go
@@ -37,6 +37,7 @@ import (
 	"github.com/purpleidea/mgmt/lang/types"
 	"github.com/purpleidea/mgmt/lang/types/full"
 	"github.com/purpleidea/mgmt/util/errwrap"
+	"github.com/purpleidea/mgmt/util/strutil"
 )
 
 const (
@@ -107,7 +108,7 @@ func (obj *CallFunc) Validate() error {
 func (obj *CallFunc) Info() *interfaces.Info {
 	var typ *types.Type
 	if obj.Type != nil && obj.FuncType != nil { // don't panic if called speculatively
-		typ = types.NewType(fmt.Sprintf("func(%s %s) %s", obj.EdgeName, obj.FuncType, obj.Type))
+		typ = types.NewType(strutil.Concat("func(", obj.EdgeName, " ", obj.FuncType.String(), ") ", obj.Type.String())) // func(%s %s) %s
 	}
 
 	return &interfaces.Info{

--- a/lang/funcs/structs/for.go
+++ b/lang/funcs/structs/for.go
@@ -37,6 +37,7 @@ import (
 	"github.com/purpleidea/mgmt/lang/interfaces"
 	"github.com/purpleidea/mgmt/lang/types"
 	"github.com/purpleidea/mgmt/util/errwrap"
+	"github.com/purpleidea/mgmt/util/strutil"
 )
 
 const (
@@ -104,7 +105,7 @@ func (obj *ForFunc) Info() *interfaces.Info {
 		// XXX: Improve function engine so it can return no value?
 		//typ = types.NewType(fmt.Sprintf("func(%s []%s)", obj.EdgeName, obj.ValueType)) // returns nothing
 		// dummy type to prove we're dropping the output since we don't use it.
-		typ = types.NewType(fmt.Sprintf("func(%s []%s) nil", obj.EdgeName, obj.ValueType))
+		typ = types.NewType(strutil.Concat("func(", obj.EdgeName, "[]", obj.ValueType.String(), ") nil")) // func(%s []%s) nil
 	}
 
 	return &interfaces.Info{
@@ -150,7 +151,7 @@ func (obj *ForFunc) replaceSubGraph(subgraphInput interfaces.Func) error {
 
 					return list.List()[i], nil
 				},
-				T: types.NewType(fmt.Sprintf("func(%s %s) %s", argName, obj.listType(), obj.ValueType)),
+				T: types.NewType(strutil.Concat("func(", argName, " ", obj.listType().String(), ") ", obj.ValueType.String())), // func(%s %s) %s
 			},
 		)
 		obj.init.Txn.AddVertex(inputElemFunc)
@@ -168,7 +169,7 @@ func (obj *ForFunc) replaceSubGraph(subgraphInput interfaces.Func) error {
 }
 
 func (obj *ForFunc) listType() *types.Type {
-	return types.NewType(fmt.Sprintf("[]%s", obj.ValueType))
+	return types.NewType(strutil.Concat("[]", obj.ValueType.String()))
 }
 
 // Call this function with the input args and return the value if it is possible

--- a/lang/funcs/structs/forkv.go
+++ b/lang/funcs/structs/forkv.go
@@ -36,6 +36,7 @@ import (
 	"github.com/purpleidea/mgmt/lang/interfaces"
 	"github.com/purpleidea/mgmt/lang/types"
 	"github.com/purpleidea/mgmt/util/errwrap"
+	"github.com/purpleidea/mgmt/util/strutil"
 )
 
 const (
@@ -104,7 +105,7 @@ func (obj *ForKVFunc) Info() *interfaces.Info {
 		// XXX: Improve function engine so it can return no value?
 		//typ = types.NewType(fmt.Sprintf("func(%s map{%s: %s})", obj.EdgeName, obj.KeyType, obj.ValType)) // returns nothing
 		// dummy type to prove we're dropping the output since we don't use it.
-		typ = types.NewType(fmt.Sprintf("func(%s map{%s: %s}) nil", obj.EdgeName, obj.KeyType, obj.ValType))
+		typ = types.NewType(strutil.Concat("func(", obj.EdgeName, " map{", obj.KeyType.String(), ": ", obj.ValType.String(), "}) nil")) // func(%s map{%s: %s}) nil"
 	}
 
 	return &interfaces.Info{
@@ -156,7 +157,7 @@ func (obj *ForKVFunc) replaceSubGraph(subgraphInput interfaces.Func) error {
 					//return m.Map().Index(?), nil
 					return k, nil
 				},
-				T: types.NewType(fmt.Sprintf("func(%s %s) %s", argNameKey, obj.mapType(), obj.KeyType)),
+				T: types.NewType(strutil.Concat("func(", argNameKey, " ", obj.mapType().String(), ") ", obj.KeyType.String())), // func(%s %s) %s
 			},
 		)
 		obj.init.Txn.AddVertex(inputElemFuncKey)
@@ -167,7 +168,7 @@ func (obj *ForKVFunc) replaceSubGraph(subgraphInput interfaces.Func) error {
 
 		// the val
 		inputElemFuncVal := SimpleFnToDirectFunc(
-			fmt.Sprintf("forkvInputElemVal[%v]", ptr),
+			fmt.Sprintf("forkvInputElemVal[%v]", ptr), // %v can't convert to util.Concat
 			&types.FuncValue{
 				V: func(_ context.Context, args []types.Value) (types.Value, error) {
 					if len(args) != 1 {
@@ -187,7 +188,7 @@ func (obj *ForKVFunc) replaceSubGraph(subgraphInput interfaces.Func) error {
 					}
 					return val, nil
 				},
-				T: types.NewType(fmt.Sprintf("func(%s %s) %s", argNameVal, obj.mapType(), obj.ValType)),
+				T: types.NewType(strutil.Concat("func(", argNameVal, " ", obj.mapType().String(), ") ", obj.ValType.String())), // func(%s %s) %s
 			},
 		)
 		obj.init.Txn.AddVertex(inputElemFuncVal)
@@ -205,7 +206,7 @@ func (obj *ForKVFunc) replaceSubGraph(subgraphInput interfaces.Func) error {
 }
 
 func (obj *ForKVFunc) mapType() *types.Type {
-	return types.NewType(fmt.Sprintf("map{%s: %s}", obj.KeyType, obj.ValType))
+	return types.NewType(strutil.Concat("map{", obj.KeyType.String(), ": ", obj.ValType.String(), "}")) // map{%s: %s}
 }
 
 // cmpMapKeys compares the input map with the cached private lastForKVMap field.

--- a/lang/funcs/structs/output.go
+++ b/lang/funcs/structs/output.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/purpleidea/mgmt/lang/interfaces"
 	"github.com/purpleidea/mgmt/lang/types"
+	"github.com/purpleidea/mgmt/util/strutil"
 )
 
 const (
@@ -84,7 +85,7 @@ func (obj *OutputFunc) Validate() error {
 // Info returns some static info about itself.
 func (obj *OutputFunc) Info() *interfaces.Info {
 	// contains "dummy" return type
-	s := fmt.Sprintf("func(%s %s, %s nil) %s", obj.EdgeName, obj.Type, OutputFuncDummyArgName, obj.Type)
+	s := strutil.Concat("func(", obj.EdgeName, " ", obj.Type.String(), ", ", OutputFuncDummyArgName, " nil) ", obj.Type.String()) // func(%s %s, %s nil) %s
 	return &interfaces.Info{
 		Pure: false,
 		Memo: false,

--- a/lang/interfaces/ast.go
+++ b/lang/interfaces/ast.go
@@ -38,6 +38,7 @@ import (
 	"github.com/purpleidea/mgmt/lang/types"
 	"github.com/purpleidea/mgmt/pgraph"
 	"github.com/purpleidea/mgmt/util/errwrap"
+	"github.com/purpleidea/mgmt/util/strutil"
 )
 
 // Node represents either a Stmt or an Expr. It contains the minimum set of
@@ -552,11 +553,10 @@ type Arg struct {
 
 // String returns a short representation of this arg.
 func (obj *Arg) String() string {
-	s := obj.Name
 	if obj.Type != nil {
-		s += fmt.Sprintf(" %s", obj.Type.String())
+		return strutil.Concat(obj.Name, " ", obj.Type.String())
 	}
-	return s
+	return obj.Name
 }
 
 // Edge is the data structure representing a compiled edge that is used in the

--- a/lang/interpret/interpret.go
+++ b/lang/interpret/interpret.go
@@ -39,6 +39,7 @@ import (
 	"github.com/purpleidea/mgmt/lang/interfaces"
 	"github.com/purpleidea/mgmt/pgraph"
 	"github.com/purpleidea/mgmt/util/errwrap"
+	"github.com/purpleidea/mgmt/util/strutil"
 )
 
 // Interpreter is a base struct for handling the Interpret operation. There is
@@ -369,7 +370,7 @@ func (obj *Interpreter) makeEdge(graph *pgraph.Graph, v1, v2 pgraph.Vertex, edge
 	}
 
 	return &engine.Edge{
-		Name:   fmt.Sprintf("%s -> %s", v1, v2),
+		Name:   strutil.Concat(v1.String(), " -> ", v2.String()),
 		Notify: notify,
 	}
 }

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -34,11 +34,15 @@ package lang
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
+	"os"
 	"sync"
 	"testing"
 
 	"github.com/purpleidea/mgmt/engine"
 	"github.com/purpleidea/mgmt/engine/resources"
+	"github.com/purpleidea/mgmt/lang"
 	_ "github.com/purpleidea/mgmt/lang/core" // import so the funcs register
 	"github.com/purpleidea/mgmt/lang/inputs"
 	"github.com/purpleidea/mgmt/lang/interfaces"
@@ -1107,6 +1111,70 @@ func TestInterpretMany(t *testing.T) {
 				t.Errorf("test #%d: cmp error:\n%v", index, err)
 				return
 			}
+		})
+	}
+}
+
+var files = []string{
+	"../../examples/lang/http-server0.mcl",
+	"../../examples/lang/http-server1.mcl",
+}
+
+// BenchmarkLang benchmarks to initial parsing of the mcl code.
+func BenchmarkLang(b *testing.B) {
+	for _, arg := range files {
+		data, err := os.ReadFile(arg)
+		if err != nil {
+			b.Fatal(err)
+		}
+		code := string(data)
+		log.SetOutput(io.Discard)
+		b.Run(arg, func(b *testing.B) {
+			// copied from lang/lang_test.go
+			mmFs := afero.NewMemMapFs()
+			afs := &afero.Afero{Fs: mmFs}
+			fs := &util.AferoFs{Afero: afs}
+
+			b.ResetTimer()
+
+			for b.Loop() {
+				output, err := inputs.ParseInput(code, fs)
+				if err != nil {
+					log.Fatal(err)
+				}
+				for _, fn := range output.Workers {
+					if err := fn(fs); err != nil {
+						log.Fatal(err)
+					}
+				}
+
+				ctx := context.Background()
+				ctx, cancel := context.WithCancel(ctx)
+				lang := &lang.Lang{
+					Fs:    fs,
+					Input: "/" + interfaces.MetadataFilename,
+					Data: &lang.Data{
+						UnificationStrategy: make(map[string]string),
+					},
+					Debug: false,
+					Logf:  log.Printf,
+				}
+
+				if err := lang.Init(ctx); err != nil {
+					log.Fatal(err)
+				}
+
+				wg := &sync.WaitGroup{}
+				wg.Go(func() {
+					if err := lang.Run(ctx); err != nil && err != context.Canceled {
+						log.Fatal(err)
+					}
+				})
+				cancel()
+				wg.Wait()
+				lang.Cleanup()
+			}
+
 		})
 	}
 }

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -1115,8 +1115,9 @@ func TestInterpretMany(t *testing.T) {
 }
 
 var files = []string{
-	"../../examples/lang/http-server0.mcl",
-	"../../examples/lang/http-server.mcl",
+	"../examples/lang/http-server0.mcl",
+	"../examples/lang/http-server1.mcl",
+	"../examples/lang/http-server-flag1.mcl",
 }
 
 // BenchmarkLang benchmarks to initial parsing of the mcl code.

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -42,7 +42,6 @@ import (
 
 	"github.com/purpleidea/mgmt/engine"
 	"github.com/purpleidea/mgmt/engine/resources"
-	"github.com/purpleidea/mgmt/lang"
 	_ "github.com/purpleidea/mgmt/lang/core" // import so the funcs register
 	"github.com/purpleidea/mgmt/lang/inputs"
 	"github.com/purpleidea/mgmt/lang/interfaces"
@@ -1117,7 +1116,7 @@ func TestInterpretMany(t *testing.T) {
 
 var files = []string{
 	"../../examples/lang/http-server0.mcl",
-	"../../examples/lang/http-server1.mcl",
+	"../../examples/lang/http-server.mcl",
 }
 
 // BenchmarkLang benchmarks to initial parsing of the mcl code.
@@ -1150,10 +1149,10 @@ func BenchmarkLang(b *testing.B) {
 
 				ctx := context.Background()
 				ctx, cancel := context.WithCancel(ctx)
-				lang := &lang.Lang{
+				lang := &Lang{
 					Fs:    fs,
 					Input: "/" + interfaces.MetadataFilename,
-					Data: &lang.Data{
+					Data: &Data{
 						UnificationStrategy: make(map[string]string),
 					},
 					Debug: false,

--- a/lang/types/type.go
+++ b/lang/types/type.go
@@ -771,7 +771,7 @@ func (obj *Type) string(table map[*Elem]uint) string {
 			}
 			s[i] = strutil.Concat(k, " ", t.string(table))
 		}
-		return fmt.Sprintf("struct{%s}", strings.Join(s, "; "))
+		return strutil.Concat("struct{", strings.Join(s, "; "), "}")
 
 	case KindFunc:
 		if obj.Map == nil {
@@ -793,13 +793,13 @@ func (obj *Type) string(table map[*Elem]uint) string {
 			// We need to print function arg names for Copy() to use
 			// the String() hack here and avoid erasing them here!
 			//s[i] = t.string(table)
-			s[i] = fmt.Sprintf("%s %s", k, t.string(table)) // strict
+			s[i] = strutil.Concat(k, " ", t.string(table)) // strict
 		}
 		var out string
 		if obj.Out != nil {
-			out = fmt.Sprintf(" %s", obj.Out.string(table))
+			out = strutil.Concat(" ", obj.Out.string(table))
 		}
-		return fmt.Sprintf("func(%s)%s", strings.Join(s, ", "), out)
+		return strutil.Concat("func(", strings.Join(s, ", "), ")", out)
 
 	case KindVariant:
 		return "variant"

--- a/lang/types/type.go
+++ b/lang/types/type.go
@@ -39,6 +39,7 @@ import (
 	"github.com/purpleidea/mgmt/util"
 	"github.com/purpleidea/mgmt/util/disjoint"
 	"github.com/purpleidea/mgmt/util/errwrap"
+	"github.com/purpleidea/mgmt/util/strutil"
 )
 
 const (
@@ -334,7 +335,7 @@ func ConfigurableTypeOf(t reflect.Type, opts ...TypeOfOption) (*Type, error) {
 			if err != nil {
 				return nil, err
 			}
-			name := fmt.Sprintf("%d", i) // invent a function arg name
+			name := strconv.FormatInt(int64(i), 10) // invent a function arg name
 			m[name] = tt
 			ord = append(ord, name) // in order
 		}
@@ -580,7 +581,7 @@ func newType(s string, table map[uint]*Elem) *Type {
 			// just name the keys 0, 1, 2, N...
 			// XXX: util.NumToAlpha ?
 			if key == "" {
-				key = fmt.Sprintf("%d", len(keys))
+				key = strconv.FormatInt(int64(len(keys)), 10)
 			}
 			keys = append(keys, key)
 
@@ -750,7 +751,7 @@ func (obj *Type) string(table map[*Elem]uint) string {
 		if obj.Key == nil || obj.Val == nil {
 			panic("malformed map type")
 		}
-		return fmt.Sprintf("map{%s: %s}", obj.Key.string(table), obj.Val.string(table))
+		return strutil.Concat("map{", obj.Key.string(table), ": ", obj.Val.string(table), "}") // map{%s: %s}
 
 	case KindStruct: // {a bool; b int}
 		if obj.Map == nil {
@@ -768,7 +769,7 @@ func (obj *Type) string(table map[*Elem]uint) string {
 			if t == nil {
 				panic("malformed struct field")
 			}
-			s[i] = fmt.Sprintf("%s %s", k, t.string(table))
+			s[i] = strutil.Concat(k, " ", t.string(table))
 		}
 		return fmt.Sprintf("struct{%s}", strings.Join(s, "; "))
 

--- a/lang/types/value.go
+++ b/lang/types/value.go
@@ -41,6 +41,7 @@ import (
 	"strings"
 
 	"github.com/purpleidea/mgmt/util/errwrap"
+	"github.com/purpleidea/mgmt/util/strutil"
 )
 
 var (
@@ -173,7 +174,7 @@ func ValueOf(v reflect.Value) (Value, error) {
 		}
 
 		return &ListValue{
-			T: NewType(fmt.Sprintf("[]%s", t.String())),
+			T: NewType(strutil.Concat("[]", t.String())),
 			V: values,
 		}, nil
 
@@ -206,7 +207,7 @@ func ValueOf(v reflect.Value) (Value, error) {
 		}
 
 		return &MapValue{
-			T: NewType(fmt.Sprintf("map{%s: %s}", kt.String(), vt.String())),
+			T: NewType(strutil.Concat("map{", kt.String(), ": ", vt.String(), "}")), // map{%s: %s}
 			V: m,
 		}, nil
 
@@ -943,7 +944,7 @@ func (obj *ListValue) String() string {
 	for _, x := range obj.V {
 		s = append(s, x.String())
 	}
-	return fmt.Sprintf("[%s]", strings.Join(s, ", "))
+	return strutil.Concat("[", strings.Join(s, ", "), "]")
 }
 
 // Type returns the type data structure that represents this type.
@@ -1108,9 +1109,9 @@ func (obj *MapValue) String() string {
 
 	var s []string
 	for _, k := range keys {
-		s = append(s, fmt.Sprintf("%s: %s", k.String(), obj.V[k].String()))
+		s = append(s, strutil.Concat(k.String(), ": ", obj.V[k].String()))
 	}
-	return fmt.Sprintf("{%s}", strings.Join(s, ", "))
+	return strutil.Concat("{", strings.Join(s, ", "), "}")
 }
 
 // Type returns the type data structure that represents this type.
@@ -1360,9 +1361,9 @@ func NewStruct(t *Type) *StructValue {
 func (obj *StructValue) String() string {
 	var s []string
 	for _, k := range obj.T.Ord {
-		s = append(s, fmt.Sprintf("%s: %s", k, obj.V[k].String()))
+		s = append(s, strutil.Concat(k, ": ", obj.V[k].String()))
 	}
-	return fmt.Sprintf("struct{%s}", strings.Join(s, "; "))
+	return strutil.Concat("struct{", strings.Join(s, "; "), "}")
 }
 
 // Type returns the type data structure that represents this type.

--- a/util/strutil/strutil.go
+++ b/util/strutil/strutil.go
@@ -1,0 +1,27 @@
+package strutil
+
+import (
+	"strings"
+	"sync"
+)
+
+var builderPool = sync.Pool{
+	New: func() any {
+		return &strings.Builder{}
+	},
+}
+
+// Concat returns the strings that is build by concatenating its arguments. It is used as a cheaper/faster
+// variant then [fmt.Sprintf] as it doesn't use reflection.
+func Concat(sx ...string) string {
+	sb := builderPool.Get().(*strings.Builder)
+	for _, s := range sx {
+		sb.WriteString(s)
+	}
+	s := sb.String()
+
+	sb.Reset()
+	builderPool.Put(sb)
+
+	return s
+}

--- a/util/strutil/strutil_test.go
+++ b/util/strutil/strutil_test.go
@@ -1,0 +1,11 @@
+package strutil
+
+import "testing"
+
+func TestConcat(t *testing.T) {
+	exp := "a b"
+	got := Concat("a", " ", "b")
+	if got != exp {
+		t.Fatalf("expected %s, got %s", exp, got)
+	}
+}


### PR DESCRIPTION
Add simple strutil.Concat function that uses strings.Builder (pooled) to build each string that is create in the language constructs String() methods.

Add highlevel BenchmarkLang test to track performance improvements
