### PR TITLE
perf: sync.Pool for vertex

### DIFF
--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -34,6 +34,9 @@ package lang
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
+	"os"
 	"sync"
 	"testing"
 
@@ -1107,6 +1110,71 @@ func TestInterpretMany(t *testing.T) {
 				t.Errorf("test #%d: cmp error:\n%v", index, err)
 				return
 			}
+		})
+	}
+}
+
+var files = []string{
+	"../examples/lang/http-server0.mcl",
+	"../examples/lang/http-server1.mcl",
+	"../examples/lang/http-server-flag1.mcl",
+}
+
+// BenchmarkLang benchmarks to initial parsing of the mcl code.
+func BenchmarkLang(b *testing.B) {
+	for _, arg := range files {
+		data, err := os.ReadFile(arg)
+		if err != nil {
+			b.Fatal(err)
+		}
+		code := string(data)
+		log.SetOutput(io.Discard)
+		b.Run(arg, func(b *testing.B) {
+			// copied from lang/lang_test.go
+			mmFs := afero.NewMemMapFs()
+			afs := &afero.Afero{Fs: mmFs}
+			fs := &util.AferoFs{Afero: afs}
+
+			b.ResetTimer()
+
+			for b.Loop() {
+				output, err := inputs.ParseInput(code, fs)
+				if err != nil {
+					log.Fatal(err)
+				}
+				for _, fn := range output.Workers {
+					if err := fn(fs); err != nil {
+						log.Fatal(err)
+					}
+				}
+
+				ctx := context.Background()
+				ctx, cancel := context.WithCancel(ctx)
+				lang := &Lang{
+					Fs:    fs,
+					Input: "/" + interfaces.MetadataFilename,
+					Data: &Data{
+						UnificationStrategy: make(map[string]string),
+					},
+					Debug: false,
+					Logf:  log.Printf,
+				}
+
+				if err := lang.Init(ctx); err != nil {
+					log.Fatal(err)
+				}
+
+				wg := &sync.WaitGroup{}
+				wg.Go(func() {
+					if err := lang.Run(ctx); err != nil && err != context.Canceled {
+						log.Fatal(err)
+					}
+				})
+				cancel()
+				wg.Wait()
+				lang.Cleanup()
+			}
+
 		})
 	}
 }

--- a/pgraph/pgraph.go
+++ b/pgraph/pgraph.go
@@ -33,6 +33,7 @@ package pgraph
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
@@ -701,7 +702,7 @@ func (obj *Graph) InDegree() map[Vertex]int {
 	if obj == nil || obj.adjacency == nil {
 		return nil
 	}
-	result := make(map[Vertex]int, len(obj.adjacency))
+	result := vertexPool.Get().(map[Vertex]int)
 	for k := range obj.adjacency {
 		result[k] = len(obj.revadjmap[k])
 	}
@@ -714,7 +715,7 @@ func (obj *Graph) OutDegree() map[Vertex]int {
 	if obj == nil || obj.adjacency == nil {
 		return nil
 	}
-	result := make(map[Vertex]int, len(obj.adjacency))
+	result := vertexPool.Get().(map[Vertex]int)
 	for k := range obj.adjacency {
 		result[k] = len(obj.adjacency[k])
 	}
@@ -1143,25 +1144,11 @@ Loop:
 
 // VertexContains is an "in array" function to test for a vertex in a slice of
 // vertices.
-func VertexContains(needle Vertex, haystack []Vertex) bool {
-	for _, v := range haystack {
-		if needle == v {
-			return true
-		}
-	}
-	return false
-}
+func VertexContains(needle Vertex, haystack []Vertex) bool { return slices.Contains(haystack, needle) }
 
 // EdgeContains is an "in array" function to test for an edge in a slice of
 // edges.
-func EdgeContains(needle Edge, haystack []Edge) bool {
-	for _, v := range haystack {
-		if needle == v {
-			return true
-		}
-	}
-	return false
-}
+func EdgeContains(needle Edge, haystack []Edge) bool { return slices.Contains(haystack, needle) }
 
 // Reverse reverses a list of vertices.
 func Reverse(vs []Vertex) []Vertex {

--- a/pgraph/subgraph.go
+++ b/pgraph/subgraph.go
@@ -29,6 +29,8 @@
 
 package pgraph
 
+import "sync"
+
 // AddGraph adds the set of edges and vertices of a graph to the existing graph.
 func (obj *Graph) AddGraph(graph *Graph) {
 	obj.addEdgeVertexGraphHelper(nil, graph, nil, false, false)
@@ -88,6 +90,9 @@ func (obj *Graph) addEdgeVertexGraphHelper(vertex Vertex, graph *Graph, edgeGenF
 	} else if light { // && !reverse
 		degree = graph.InDegree()
 	}
+	if degree == nil {
+		degree = vertexPool.Get().(map[Vertex]int)
+	}
 	for _, v := range graph.VerticesSorted() { // sort to help out edgeGenFn
 
 		// forward:
@@ -118,4 +123,12 @@ func (obj *Graph) addEdgeVertexGraphHelper(vertex Vertex, graph *Graph, edgeGenF
 			obj.AddEdge(v1, v2, e)
 		}
 	}
+	clear(degree)
+	vertexPool.Put(degree)
+}
+
+var vertexPool = sync.Pool{
+	New: func() any {
+		return make(map[Vertex]int)
+	},
 }


### PR DESCRIPTION
This adds a small sync.Pool for the vertex map use in addEdgeVertexGraphHelper. Is saves 2% as evident from the benchstat.

It adds the benchmark test to lang_test.go and modernizes 2 functions to use slices.Contains, instead of a manual loop.

```
% go test -run=xxxx -bench=BenchmarkLang -benchmem -tags='nodocker noaugeas' -count=8 -cpuprofile cpu.prof | tee ~/old.txt
goos: linux
goarch: arm64
pkg: github.com/purpleidea/mgmt/lang
BenchmarkLang/../examples/lang/http-server0.mcl-8                    811           1482738 ns/op         1250108 B/op      11674 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    867           1449186 ns/op         1248584 B/op      11673 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    858           1439424 ns/op         1245086 B/op      11672 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    898           1424195 ns/op         1243325 B/op      11672 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    789           1465525 ns/op         1241198 B/op      11671 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    854           1469401 ns/op         1239258 B/op      11671 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    747           1469360 ns/op         1239681 B/op      11671 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    864           1437191 ns/op         1238747 B/op      11671 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    528           2243074 ns/op         1803077 B/op      17665 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    535           2238604 ns/op         1802737 B/op      17665 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    476           2263311 ns/op         1802562 B/op      17665 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    526           2372096 ns/op         1802309 B/op      17665 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    512           2283777 ns/op         1802981 B/op      17665 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    478           2262333 ns/op         1802026 B/op      17665 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    532           2299960 ns/op         1801606 B/op      17665 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    564           2232247 ns/op         1800523 B/op      17665 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               402           2905401 ns/op         2265442 B/op      21835 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               398           2901989 ns/op         2266697 B/op      21828 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               439           2947230 ns/op         2266154 B/op      21826 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               385           3079179 ns/op         2267605 B/op      21844 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               381           3146267 ns/op         2264965 B/op      21826 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               384           2965028 ns/op         2264759 B/op      21825 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               386           2925619 ns/op         2263786 B/op      21809 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               373           3064809 ns/op         2263812 B/op      21822 allocs/op
PASS
ok      github.com/purpleidea/mgmt/lang 28.733s
```
and

```
% go test -run=xxxx -bench=BenchmarkLang -benchmem -tags='nodocker noaugeas' -count=8 -cpuprofile cpu.prof | tee ~/new.txt
goos: linux
goarch: arm64
pkg: github.com/purpleidea/mgmt/lang
BenchmarkLang/../examples/lang/http-server0.mcl-8                    855           1413728 ns/op         1249395 B/op      11675 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    872           1438797 ns/op         1247469 B/op      11674 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    787           1431246 ns/op         1244902 B/op      11673 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    825           1433985 ns/op         1242864 B/op      11673 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    817           1440686 ns/op         1241058 B/op      11672 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    802           1416251 ns/op         1240446 B/op      11672 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    912           1449235 ns/op         1238401 B/op      11671 allocs/op
BenchmarkLang/../examples/lang/http-server0.mcl-8                    841           1409562 ns/op         1238582 B/op      11671 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    523           2206577 ns/op         1803643 B/op      17666 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    549           2209658 ns/op         1801917 B/op      17666 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    618           2175001 ns/op         1802437 B/op      17666 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    532           2278923 ns/op         1801589 B/op      17666 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    585           2231891 ns/op         1801873 B/op      17666 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    502           2223394 ns/op         1801535 B/op      17665 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    536           2263832 ns/op         1800124 B/op      17665 allocs/op
BenchmarkLang/../examples/lang/http-server1.mcl-8                    592           2193539 ns/op         1800420 B/op      17665 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               439           2806371 ns/op         2263011 B/op      21802 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               422           2943353 ns/op         2268191 B/op      21837 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               400           2915601 ns/op         2264599 B/op      21825 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               402           3172420 ns/op         2264971 B/op      21817 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               417           3022917 ns/op         2263557 B/op      21809 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               426           2958178 ns/op         2264784 B/op      21810 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               434           2779301 ns/op         2262828 B/op      21815 allocs/op
BenchmarkLang/../examples/lang/http-server-flag1.mcl-8               406           2857711 ns/op         2262608 B/op      21821 allocs/op
PASS
ok      github.com/purpleidea/mgmt/lang 29.408s
```
with:

```
% benchstat ~/old.txt ~/new.txt
goos: linux
goarch: arm64
pkg: github.com/purpleidea/mgmt/lang
                                              │ /home/miek/old.txt │        /home/miek/new.txt         │
                                              │       sec/op       │   sec/op     vs base              │
Lang/../examples/lang/http-server0.mcl-8               1.457m ± 2%   1.433m ± 2%  -1.70% (p=0.028 n=8)
Lang/../examples/lang/http-server1.mcl-8               2.263m ± 2%   2.217m ± 2%  -2.05% (p=0.021 n=8)
Lang/../examples/lang/http-server-flag1.mcl-8          2.956m ± 4%   2.929m ± 5%       ~ (p=0.328 n=8)
geomean                                                2.136m        2.103m       -1.55%

                                              │ /home/miek/old.txt │         /home/miek/new.txt         │
                                              │        B/op        │     B/op      vs base              │
Lang/../examples/lang/http-server0.mcl-8              1.185Mi ± 1%   1.184Mi ± 0%       ~ (p=0.721 n=8)
Lang/../examples/lang/http-server1.mcl-8              1.719Mi ± 0%   1.718Mi ± 0%       ~ (p=0.161 n=8)
Lang/../examples/lang/http-server-flag1.mcl-8         2.160Mi ± 0%   2.159Mi ± 0%       ~ (p=0.130 n=8)
geomean                                               1.639Mi        1.638Mi       -0.04%

                                              │ /home/miek/old.txt │        /home/miek/new.txt         │
                                              │     allocs/op      │  allocs/op   vs base              │
Lang/../examples/lang/http-server0.mcl-8               11.67k ± 0%   11.67k ± 0%       ~ (p=0.303 n=8)
Lang/../examples/lang/http-server1.mcl-8               17.66k ± 0%   17.67k ± 0%  +0.01% (p=0.026 n=8)
Lang/../examples/lang/http-server-flag1.mcl-8          21.83k ± 0%   21.82k ± 0%       ~ (p=0.061 n=8)
geomean                                                16.51k        16.51k       -0.01%
```

This improves sec/op, not any memory - as expected.