### PR TITLE
perf: Internalize the admin slices and maps

### DIFF
--- a/pgraph/graphsync.go
+++ b/pgraph/graphsync.go
@@ -84,11 +84,11 @@ func (obj *Graph) GraphSync(newGraph *Graph, vertexCmpFn func(Vertex, Vertex) (b
 		edgeCmpFn = strEdgeCmpFn // use simple string cmp version
 	}
 
-	var lookup = make(map[Vertex]Vertex, len(newGraph.adjacency))
-	var vertexDels []Vertex                                          // list of vertices which are to be removed
-	var vertexAdds []Vertex                                          // list of vertices which are to be added
-	vertexKeep := make(map[Vertex]struct{}, len(newGraph.adjacency)) // set of vertices which are the same in new graph
-	edgeKeep := make(map[Edge]struct{})                              // set of edges which are the same in new graph
+	clear(oldGraph.lookup)
+	clear(oldGraph.vertexDels)
+	clear(oldGraph.vertexAdds)
+	clear(oldGraph.vertexKeep)
+	clear(oldGraph.edgeKeep)
 
 	// index the old graph by String() so each new vertex only gets compared
 	// against the candidates which could possibly match; see contract above
@@ -121,37 +121,37 @@ func (obj *Graph) GraphSync(newGraph *Graph, vertexCmpFn func(Vertex, Vertex) (b
 
 		// run the removes BEFORE the adds, so don't do the add here...
 		if vertex == nil { // no match found yet
-			vertexAdds = append(vertexAdds, v) // append
+			oldGraph.vertexAdds = append(oldGraph.vertexAdds, v) // append
 			vertex = v
 		}
-		lookup[v] = vertex              // used for constructing edges
-		vertexKeep[vertex] = struct{}{} // mark as kept
+		oldGraph.lookup[v] = vertex              // used for constructing edges
+		oldGraph.vertexKeep[vertex] = struct{}{} // mark as kept
 	}
 	// get rid of any vertices we shouldn't keep (that aren't in new graph)
 	for v := range oldGraph.adjacency {
-		if _, exists := vertexKeep[v]; !exists {
-			vertexDels = append(vertexDels, v) // append
+		if _, exists := oldGraph.vertexKeep[v]; !exists {
+			oldGraph.vertexDels = append(oldGraph.vertexDels, v) // append
 		}
 	}
 
 	// see if any of the add/remove functions actually fail first
 	// XXX: run this as a reverse topological sort or topological sort?
-	for _, vertex := range vertexDels {
+	for _, vertex := range oldGraph.vertexDels {
 		if err := vertexRemoveFn(vertex); err != nil {
 			return errwrap.Wrapf(err, "vertexRemoveFn failed")
 		}
 	}
-	for _, vertex := range vertexAdds {
+	for _, vertex := range oldGraph.vertexAdds {
 		if err := vertexAddFn(vertex); err != nil {
 			return errwrap.Wrapf(err, "vertexAddFn failed")
 		}
 	}
 
 	// no add/remove functions failed, so we can actually modify the graph!
-	for _, vertex := range vertexDels {
+	for _, vertex := range oldGraph.vertexDels {
 		oldGraph.DeleteVertex(vertex)
 	}
-	for _, vertex := range vertexAdds {
+	for _, vertex := range oldGraph.vertexAdds {
 		oldGraph.AddVertex(vertex) // call standalone in case not part of an edge
 	}
 
@@ -162,8 +162,8 @@ func (obj *Graph) GraphSync(newGraph *Graph, vertexCmpFn func(Vertex, Vertex) (b
 		for v2, e := range newGraph.adjacency[v1] {
 			// we have an edge!
 			// lookup vertices (these should exist now)
-			vertex1, exists1 := lookup[v1]
-			vertex2, exists2 := lookup[v2]
+			vertex1, exists1 := oldGraph.lookup[v1]
+			vertex2, exists2 := oldGraph.lookup[v2]
 			if !exists1 || !exists2 { // no match found, bug?
 				//if vertex1 == nil || vertex2 == nil { // no match found
 				return fmt.Errorf("new vertices weren't found") // programming error
@@ -179,14 +179,14 @@ func (obj *Graph) GraphSync(newGraph *Graph, vertexCmpFn func(Vertex, Vertex) (b
 			}
 
 			oldGraph.AddEdge(vertex1, vertex2, edge) // store it
-			edgeKeep[edge] = struct{}{}              // mark as saved
+			oldGraph.edgeKeep[edge] = struct{}{}     // mark as saved
 		}
 	}
 
 	// delete unused edges in a single pass over adjacency
 	for v1 := range oldGraph.adjacency {
 		for v2, e := range oldGraph.adjacency[v1] {
-			if _, ok := edgeKeep[e]; !ok {
+			if _, ok := oldGraph.edgeKeep[e]; !ok {
 				oldGraph.DeleteEdgeBetween(v1, v2)
 			}
 		}

--- a/pgraph/pgraph.go
+++ b/pgraph/pgraph.go
@@ -62,6 +62,17 @@ type Graph struct {
 	adjacency map[Vertex]map[Vertex]Edge // Vertex -> Vertex (edge)
 	revadjmap map[Vertex]map[Vertex]Edge // Vertex <- Vertex (edge) mirror index
 	kv        map[string]interface{}     // some values associated with the graph
+
+	// administration for GraphSync
+	lookup     map[Vertex]Vertex
+	vertexDels []Vertex            // list of vertices which are to be removed
+	vertexAdds []Vertex            // list of vertices which are to be added
+	vertexKeep map[Vertex]struct{} // set of vertices which are the same in new graph
+	edgeKeep   map[Edge]struct{}   // set of edges which are the same in new graph
+
+	// administration for GraphCmp
+	index map[string][]Vertex
+	seen  map[Vertex]Vertex
 }
 
 // Vertex is the primary vertex struct in this library. It can be anything that
@@ -96,6 +107,15 @@ func (obj *Graph) Init() error {
 func NewGraph(name string) (*Graph, error) {
 	g := &Graph{
 		Name: name,
+
+		lookup:     map[Vertex]Vertex{},
+		vertexDels: []Vertex{},
+		vertexAdds: []Vertex{},
+		vertexKeep: map[Vertex]struct{}{},
+		edgeKeep:   map[Edge]struct{}{},
+
+		index: map[string][]Vertex{},
+		seen:  map[Vertex]Vertex{},
 	}
 	return g, g.Init()
 }
@@ -127,6 +147,12 @@ func (obj *Graph) Copy() *Graph {
 		adjacency: make(map[Vertex]map[Vertex]Edge, len(obj.adjacency)),
 		revadjmap: make(map[Vertex]map[Vertex]Edge, len(obj.revadjmap)),
 		kv:        obj.kv,
+
+		lookup:     obj.lookup,
+		vertexDels: obj.vertexDels,
+		vertexAdds: obj.vertexAdds,
+		vertexKeep: obj.vertexKeep,
+		edgeKeep:   obj.edgeKeep,
 	}
 	for v1, m := range obj.adjacency {
 		newGraph.adjacency[v1] = nil // preserve any lazy (nil) maps
@@ -1054,20 +1080,22 @@ func (obj *Graph) GraphCmp(graph *Graph, vertexCmpFn func(Vertex, Vertex) (bool,
 		return fmt.Errorf("base graph has %d edges, while input graph has %d", e1, e2)
 	}
 
+	clear(obj.index)
+	clear(obj.seen)
+
 	// index the input graph by String() since most comparison functions
 	// only ever match vertices with equal String() values, so probing the
 	// same-String candidates first usually avoids the full quadratic scan
-	index := make(map[string][]Vertex, len(graph.adjacency))
 	for v2 := range graph.adjacency {
 		s := v2.String()
-		index[s] = append(index[s], v2)
+		obj.index[s] = append(obj.index[s], v2)
 	}
 
 	var m = make(map[Vertex]Vertex) // obj to graph vertex correspondence
 Loop:
 	// check vertices
 	for v1 := range obj.adjacency { // for each vertex in g
-		for _, v2 := range index[v1.String()] { // probe the candidates
+		for _, v2 := range obj.index[v1.String()] { // probe the candidates
 			b, err := vertexCmpFn(v1, v2)
 			if err != nil {
 				return errwrap.Wrapf(err, "could not run vertexCmpFn() properly")
@@ -1102,12 +1130,11 @@ Loop:
 
 	// check if mapping is unique (are there duplicates?)
 	// (check values only, the keys are unique by virtue of m being a map)
-	seen := make(map[Vertex]Vertex, len(m))
 	for k, v := range m {
-		if prev, exists := seen[v]; exists {
+		if prev, exists := obj.seen[v]; exists {
 			return fmt.Errorf("mapping to %s is used more than once from: %s and %s", v, prev, k)
 		}
-		seen[v] = k
+		obj.seen[v] = k
 	}
 
 	// check edges


### PR DESCRIPTION
Modest speed increase ~-10%, but esp in memory usage which helps with GC.

```txt
goos: linux
goarch: arm64
pkg: github.com/purpleidea/mgmt/pgraph
                            │ /home/miek/old.txt │         /home/miek/new.txt          │
                            │       sec/op       │    sec/op     vs base               │
GraphSync/identical/100-8           383.7µ ± ∞ ¹   362.4µ ± ∞ ¹        ~ (p=0.343 n=4)
GraphSync/identical/1000-8          4.886m ± ∞ ¹   4.320m ± ∞ ¹  -11.59% (p=0.029 n=4)
GraphSync/identical/10000-8         51.52m ± ∞ ¹   44.31m ± ∞ ¹        ~ (p=0.114 n=4)
GraphSync/delta/1000-8              4.977m ± ∞ ¹   4.696m ± ∞ ¹   -5.64% (p=0.029 n=4)
GraphSync/delta/10000-8             53.87m ± ∞ ¹   50.97m ± ∞ ¹        ~ (p=0.686 n=4)
GraphCmp/identical/100-8            63.81µ ± ∞ ¹   65.30µ ± ∞ ¹        ~ (p=0.686 n=4)
GraphCmp/identical/1000-8           908.2µ ± ∞ ¹   832.7µ ± ∞ ¹   -8.31% (p=0.029 n=4)
GraphCmp/identical/10000-8          9.349m ± ∞ ¹   7.362m ± ∞ ¹  -21.25% (p=0.029 n=4)
geomean                             3.299m         3.005m         -8.92%
¹ need >= 6 samples for confidence interval at level 0.95

                            │ /home/miek/old.txt │          /home/miek/new.txt          │
                            │        B/op        │     B/op       vs base               │
GraphSync/identical/100-8          190.1Ki ± ∞ ¹   155.8Ki ± ∞ ¹  -18.03% (p=0.029 n=4)
GraphSync/identical/1000-8         2.155Mi ± ∞ ¹   1.608Mi ± ∞ ¹  -25.35% (p=0.029 n=4)
GraphSync/identical/10000-8        19.96Mi ± ∞ ¹   15.58Mi ± ∞ ¹  -21.92% (p=0.029 n=4)
GraphSync/delta/1000-8             2.229Mi ± ∞ ¹   1.682Mi ± ∞ ¹  -24.51% (p=0.029 n=4)
GraphSync/delta/10000-8            20.70Mi ± ∞ ¹   16.32Mi ± ∞ ¹  -21.13% (p=0.029 n=4)
GraphCmp/identical/100-8           20.46Ki ± ∞ ¹   10.38Ki ± ∞ ¹  -49.26% (p=0.029 n=4)
GraphCmp/identical/1000-8          348.0Ki ± ∞ ¹   171.9Ki ± ∞ ¹  -50.62% (p=0.029 n=4)
GraphCmp/identical/10000-8         2.776Mi ± ∞ ¹   1.400Mi ± ∞ ¹  -49.57% (p=0.029 n=4)
geomean                            1.274Mi         860.9Ki        -34.01%
¹ need >= 6 samples for confidence interval at level 0.95

                            │ /home/miek/old.txt │         /home/miek/new.txt         │
                            │     allocs/op      │  allocs/op    vs base              │
GraphSync/identical/100-8            941.0 ± ∞ ¹    922.0 ± ∞ ¹  -2.02% (p=0.029 n=4)
GraphSync/identical/1000-8          8.905k ± ∞ ¹   8.849k ± ∞ ¹  -0.63% (p=0.029 n=4)
GraphSync/identical/10000-8         89.09k ± ∞ ¹   88.75k ± ∞ ¹  -0.38% (p=0.029 n=4)
GraphSync/delta/1000-8              9.334k ± ∞ ¹   9.280k ± ∞ ¹  -0.58% (p=0.029 n=4)
GraphSync/delta/10000-8             93.18k ± ∞ ¹   92.85k ± ∞ ¹  -0.36% (p=0.029 n=4)
GraphCmp/identical/100-8             115.0 ± ∞ ¹    109.0 ± ∞ ¹  -5.22% (p=0.029 n=4)
GraphCmp/identical/1000-8           1.030k ± ∞ ¹   1.020k ± ∞ ¹  -0.97% (p=0.029 n=4)
GraphCmp/identical/10000-8          10.14k ± ∞ ¹   10.08k ± ∞ ¹  -0.65% (p=0.029 n=4)
geomean                             5.452k         5.377k        -1.36%
¹ need >= 6 samples for confidence interval at level 0.95
```