### PR TITLE
lang: types: Export struct field names in Reflect

### DIFF
--- a/lang/interpret_test/TestAstFunc2/value-res-any-list0.txtar
+++ b/lang/interpret_test/TestAstFunc2/value-res-any-list0.txtar
@@ -1,0 +1,8 @@
+-- main.mcl --
+$example = ["a", "b", "c"]
+
+value "example" {
+	any => $example,
+}
+-- OUTPUT --
+Vertex: value[example]

--- a/lang/interpret_test/TestAstFunc2/value-res-any-map0.txtar
+++ b/lang/interpret_test/TestAstFunc2/value-res-any-map0.txtar
@@ -1,0 +1,8 @@
+-- main.mcl --
+$example = {"one" => 1, "two" => 2}
+
+value "example" {
+	any => $example,
+}
+-- OUTPUT --
+Vertex: value[example]

--- a/lang/interpret_test/TestAstFunc2/value-res-any-nested0.txtar
+++ b/lang/interpret_test/TestAstFunc2/value-res-any-nested0.txtar
@@ -1,0 +1,18 @@
+-- main.mcl --
+$inner = struct{
+	deep => ["x", "y"],
+}
+
+$example = struct{
+	foo => "Hello world",
+	bar => 42,
+	baz => $inner,
+	items => [struct{num => 1}, struct{num => 2}],
+	pairs => {"key" => struct{ok => true}},
+}
+
+value "example" {
+	any => $example,
+}
+-- OUTPUT --
+Vertex: value[example]

--- a/lang/interpret_test/TestAstFunc2/value-res-any-struct0.txtar
+++ b/lang/interpret_test/TestAstFunc2/value-res-any-struct0.txtar
@@ -1,0 +1,10 @@
+-- main.mcl --
+$example = struct {
+	foo => "Hello world",
+}
+
+value "example" {
+	any => $example,
+}
+-- OUTPUT --
+Vertex: value[example]

--- a/lang/interpret_test/TestAstFunc2/value-res-any-struct0.txtar
+++ b/lang/interpret_test/TestAstFunc2/value-res-any-struct0.txtar
@@ -1,5 +1,5 @@
 -- main.mcl --
-$example = struct {
+$example = struct{
 	foo => "Hello world",
 }
 

--- a/lang/types/type.go
+++ b/lang/types/type.go
@@ -1076,7 +1076,7 @@ func (obj *Type) Reflect() reflect.Type {
 
 			// Our struct field names are lowercase, which
 			// reflect.StructOf would panic on, since those are
-			// unexported, so export the name by capitalizing it,
+			// unexported, so export the name by capitalising it,
 			// and store the original in the `lang` struct tag,
 			// which TypeOf and Into already use for this mapping.
 			r, size := utf8.DecodeRuneInString(k)

--- a/lang/types/type.go
+++ b/lang/types/type.go
@@ -35,6 +35,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/purpleidea/mgmt/util"
 	"github.com/purpleidea/mgmt/util/disjoint"
@@ -1062,6 +1064,7 @@ func (obj *Type) Reflect() reflect.Type {
 		}
 
 		fields := []reflect.StructField{}
+		seen := make(map[string]string) // exported name -> field name
 		for _, k := range obj.Ord {
 			t, ok := obj.Map[k]
 			if !ok {
@@ -1070,16 +1073,33 @@ func (obj *Type) Reflect() reflect.Type {
 			if t == nil {
 				panic("malformed struct field")
 			}
-			if strings.Title(k) != k { // is exported?
-				//k = strings.Title(k) // TODO: is this helpful?
+
+			// Our struct field names are lowercase, which
+			// reflect.StructOf would panic on, since those are
+			// unexported, so export the name by capitalizing it,
+			// and store the original in the `lang` struct tag,
+			// which TypeOf and Into already use for this mapping.
+			r, size := utf8.DecodeRuneInString(k)
+			u := unicode.ToUpper(r)
+			if !unicode.IsUpper(u) { // eg: leading underscore
 				// reflect.StructOf would panic on anything unexported
-				panic(fmt.Sprintf("struct has unexported field: %s", k))
+				panic(fmt.Sprintf("struct has unexportable field: %s", k))
+			}
+			name := string(u) + k[size:]
+			if dup, exists := seen[name]; exists {
+				panic(fmt.Sprintf("struct fields `%s` and `%s` both export as `%s`", dup, k, name))
+			}
+			seen[name] = k
+
+			var tag reflect.StructTag
+			if name != k { // renamed, keep the original in the tag
+				tag = reflect.StructTag(fmt.Sprintf("%s:%q", StructTag, k))
 			}
 
 			fields = append(fields, reflect.StructField{
-				Name: k, // struct field name
+				Name: name, // exported struct field name
 				Type: t.Reflect(),
-				//Tag:  `mgmt:"foo"`, // unused
+				Tag:  tag,
 			})
 		}
 

--- a/lang/types/type_test.go
+++ b/lang/types/type_test.go
@@ -1840,23 +1840,29 @@ func TestResTypeOfSkipPrivateFields(t *testing.T) {
 }
 
 func TestReflect0(t *testing.T) {
-	mustPanic := func() (reterr error) {
-		defer func() {
-			// catch unhandled panics
-			if r := recover(); r != nil {
-				reterr = fmt.Errorf("panic: %+v", r)
-			}
-		}()
+	// Lowercase (unexported) struct field names get capitalized, so that
+	// reflect.StructOf doesn't panic on them, and the original name is
+	// stored in the `lang` struct tag, which TypeOf uses to map it back.
+	typ := NewType("struct{field1 str}")
+	st := typ.Reflect()
 
-		// It's unclear if we want this behaviour forever, but it is the
-		// current behaviour, and I'd at least like to know if it
-		// changes so we can understand where (if at all) it's required.
-		typ := NewType("struct{field1 str}")
-		_ = typ.Reflect()
-		return nil
+	field, ok := st.FieldByName("Field1")
+	if !ok {
+		t.Fatalf("expected a `Field1` field, got: %+v", st)
+	}
+	if field.Type.Kind() != reflect.String {
+		t.Errorf("expected a string field, got: %+v", field.Type)
+	}
+	if alias, ok := field.Tag.Lookup(StructTag); !ok || alias != "field1" {
+		t.Errorf("expected a `%s` tag of `field1`, got: `%s`", StructTag, alias)
 	}
 
-	if err := mustPanic(); err == nil {
-		t.Errorf("expected panic, got nil")
+	// And the original type can round trip back out of the golang type.
+	out, err := TypeOf(st)
+	if err != nil {
+		t.Fatalf("could not TypeOf the reflected struct: %+v", err)
+	}
+	if err := typ.Cmp(out); err != nil {
+		t.Errorf("type did not round trip through Reflect: %+v", err)
 	}
 }

--- a/lang/types/value.go
+++ b/lang/types/value.go
@@ -1413,8 +1413,10 @@ func (obj *StructValue) Value() interface{} {
 	typ := obj.T.Reflect()
 	val := reflect.New(typ).Elem() // New returns a PtrTo(typ)
 
-	for _, k := range obj.T.Ord {
-		val.FieldByName(k).Set(reflect.ValueOf(obj.V[k].Value())) // recurse
+	for i, k := range obj.T.Ord {
+		// Reflect() exports the field names, but preserves the field
+		// order, so set by index instead of by name.
+		val.Field(i).Set(reflect.ValueOf(obj.V[k].Value())) // recurse
 	}
 	return val.Interface()
 }

--- a/lang/types/value_test.go
+++ b/lang/types/value_test.go
@@ -618,6 +618,40 @@ func TestStruct2(t *testing.T) {
 	}
 }
 
+func TestStruct3(t *testing.T) {
+	// Lowercase field names get exported (capitalized) by Reflect, with
+	// the original name kept in the `lang` struct tag, so a struct value
+	// can round trip through a golang interface{} and back via ValueOf.
+	st := NewStruct(NewType("struct{answer int; nested struct{truth bool}}"))
+	if err := st.Set("answer", &IntValue{V: 42}); err != nil {
+		t.Errorf("struct could not set key, error: %v", err)
+		return
+	}
+	inner := NewStruct(NewType("struct{truth bool}"))
+	if err := inner.Set("truth", &BoolValue{V: true}); err != nil {
+		t.Errorf("struct could not set key, error: %v", err)
+		return
+	}
+	if err := st.Set("nested", inner); err != nil {
+		t.Errorf("struct could not set key, error: %v", err)
+		return
+	}
+
+	v := st.Value() // this used to panic on the unexported field names
+	if typ := fmt.Sprintf("%T", v); typ != `struct { Answer int64 "lang:\"answer\""; Nested struct { Truth bool "lang:\"truth\"" } "lang:\"nested\"" }` {
+		t.Errorf("struct displayed type value: %s", typ)
+	}
+
+	out, err := ValueOfGolang(v)
+	if err != nil {
+		t.Errorf("could not get value of golang struct, error: %v", err)
+		return
+	}
+	if err := st.Cmp(out); err != nil {
+		t.Errorf("struct value did not round trip, error: %v", err)
+	}
+}
+
 func TestValueOf0(t *testing.T) {
 	testCases := map[Value]interface{}{
 		&BoolValue{V: true}:  true,


### PR DESCRIPTION
This allows composite types (struct, list, map, and nested combinations) in the value resource's `any` field, per your request on #978.

Our struct field names are lowercase, which `reflect.StructOf` panics on, since those are unexported in golang. Instead, `Reflect()` now exports each field name by capitalizing it and keeps the original in the `lang` struct tag — the same tag `TypeOf` and `Into` already read — so values round trip back out unchanged, including from `ValueOfGolang`. `StructValue.Value()` sets fields by index instead of by name, since the reflected names may now differ. Already-exported names keep their exact previous representation, with no tag.

Tests, as requested in TestAstFunc2/:
- `value-res-any-struct0.txtar` — the exact example from the issue
- `value-res-any-list0.txtar`, `value-res-any-map0.txtar`
- `value-res-any-nested0.txtar` — struct containing a str, an int, an inner struct, a list of structs, and a map with struct values

Verification notes, stated honestly:
- struct0 and nested0 panic on unmodified master with the exact reported panic (`struct has unexported field: foo`) and pass with this patch. list0/map0 pass on master too — scalar lists/maps never hit the struct path — so those two lock in coverage rather than guard a regression.
- `TestReflect0` expected the old panic; its own comment said the behaviour was provisional and to update it if this ever changed, so it now asserts the new name+tag mapping and the `TypeOf` round trip. Added `TestStruct3` covering the full value round trip (`Value()` → `ValueOfGolang` → `Cmp`) including a nested struct.
- Full `go test ./lang/...` passes except `lang/format`, which fails identically on unmodified master in my environment (missing generated golang func wrappers), so it's pre-existing and unrelated.

As you requested, this patch was generated by Claude Fable 5, via Claude Code (the earlier analysis comments on the issue were Claude Opus 5). AI-assisted-by: Claude Fable 5, via Claude Code