### PR TITLE
util: atomicfile: Atomic file delivery

### DIFF
--- a/engine/resources/file.go
+++ b/engine/resources/file.go
@@ -53,6 +53,7 @@ import (
 	"github.com/purpleidea/mgmt/lang/interfaces"
 	"github.com/purpleidea/mgmt/lang/types"
 	"github.com/purpleidea/mgmt/util"
+	"github.com/purpleidea/mgmt/util/atomicfile"
 	"github.com/purpleidea/mgmt/util/errwrap"
 	"github.com/purpleidea/mgmt/util/recwatch"
 
@@ -716,14 +717,15 @@ func (obj *FileRes) fileCheckApply(ctx context.Context, apply bool, src io.ReadS
 	}
 
 	_ = dstClose() // unlock file usage so we can write to it (may return os.ErrInvalid)
-	dstFile, err = os.Create(dst)
+
+	newFile, err := atomicfile.New(dst)
 	if err != nil {
 		return sha256sum, false, err
 	}
-	defer dstFile.Close() // TODO: is this redundant because of the earlier deferred Close() ?
+	defer newFile.Close()
 
 	if isFile { // set mode because it's a new file
-		if err := dstFile.Chmod(srcStat.Mode()); err != nil {
+		if err := newFile.Chmod(srcStat.Mode()); err != nil {
 			return sha256sum, false, err
 		}
 	}
@@ -738,12 +740,18 @@ func (obj *FileRes) fileCheckApply(ctx context.Context, apply bool, src io.ReadS
 		obj.init.Logf("copy %d bytes", length)
 	}
 
-	if n, err := io.Copy(dstFile, src); err != nil {
+	if n, err := io.Copy(newFile, src); err != nil {
 		return sha256sum, false, err
 	} else if obj.init.Debug {
 		obj.init.Logf("copied: %v", n)
 	}
-	return sha256sum, false, dstFile.Sync()
+
+	err = newFile.Sync()
+	if err != nil {
+		return sha256sum, false, err
+	}
+
+	return sha256sum, false, newFile.Commit()
 }
 
 // dirCheckApply is the CheckApply operation for an empty directory.

--- a/engine/resources/http_client.go
+++ b/engine/resources/http_client.go
@@ -47,8 +47,10 @@ import (
 
 	"github.com/purpleidea/mgmt/engine"
 	"github.com/purpleidea/mgmt/engine/traits"
+	"github.com/purpleidea/mgmt/util/atomicfile"
 	"github.com/purpleidea/mgmt/util/errwrap"
 	"github.com/purpleidea/mgmt/util/recwatch"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -152,7 +154,6 @@ type HTTPClientRes struct {
 	// XXX: Can this method really guarantee the server started a watch?
 	LongpollConditional bool `lang:"longpoll_conditional" yaml:"longpoll_conditional"`
 
-	tmp string // download location
 	dst string // the file location
 
 	sha256 string // cache of dst
@@ -395,7 +396,6 @@ func (obj *HTTPClientRes) Init(init *engine.Init) error {
 	if err != nil {
 		return errwrap.Wrapf(err, "could not get VarDir in Init()")
 	}
-	obj.tmp = filepath.Join(dir, "tmp") // return a unique file
 
 	obj.dst = obj.getDst()
 	if obj.dst == "" { // user didn't specify file
@@ -842,26 +842,7 @@ func (obj *HTTPClientRes) processResp(ctx context.Context, resp *http.Response, 
 		return false, nil
 	}
 
-	// If we're writing a file, we should stream it to a vardir and then
-	// swap it atomically so that (1) we don't buffer the entire file into
-	// memory and (2) so that we don't have a partial (corrupt) file if the
-	// http fails to complete or validate the hash correctly. Note that we
-	// *don't* store the file twice in the steady state, since the vardir
-	// version overwrites the final destination when things check out okay.
-	tmpdel := true
-	defer func() {
-		// once file moved away, we should not run remove!
-		if !tmpdel {
-			return
-		}
-		// cleanup the partial file if not moved...
-		if err := os.Remove(obj.tmp); err != nil {
-			// XXX: should we bubble an error up instead?
-			obj.init.Logf("error removing tmp file %q: %v", obj.tmp, err)
-		}
-	}()
-
-	file, err := os.Create(obj.tmp)
+	file, err := atomicfile.New(obj.dst)
 	if err != nil {
 		return false, err
 	}
@@ -897,12 +878,6 @@ func (obj *HTTPClientRes) processResp(ctx context.Context, resp *http.Response, 
 	if err := file.Sync(); err != nil {
 		return false, err
 	}
-	// "The behavior of Close after the first call is undefined. Specific
-	// implementations may document their own behavior." We double close in
-	// defer above, which as per the *os.File implementation is allowed.
-	if err := file.Close(); err != nil {
-		return false, err
-	}
 
 	// Set the mtime on the download from the server's Last-Modified header
 	// so that subsequent calls using the `If-Modified-Since` header will
@@ -913,9 +888,30 @@ func (obj *HTTPClientRes) processResp(ctx context.Context, resp *http.Response, 
 		if err != nil { // not a permanent error
 			obj.init.Logf("could not parse Last-Modified %q: %v", lm, err)
 
-		} else if err := os.Chtimes(obj.tmp, t, t); err != nil {
-			return false, errwrap.Wrapf(err, "could not set mtime on %s", obj.tmp)
+		} else {
+			//if err := os.Chtimes(obj.tmp, t, t); err != nil {
+			syscall, err := file.SyscallConn()
+			if err != nil {
+				return false, errwrap.Wrapf(err, "could not setup syscall conn (platform problem?)")
+			}
+			//if err := os.Chtimes(obj.tmp, t, t); err != nil {
+			var utimesErr error
+			err = syscall.Control(func(fd uintptr) {
+				utimesErr = unix.Futimes(int(fd), []unix.Timeval{{Sec: 0, Usec: 0}, {Sec: t.Unix(), Usec: 0}})
+			})
+
+			if err != nil {
+				return false, errwrap.Wrapf(err, "failed to set mtime temporary file for %s", obj.dst)
+			}
+
+			if utimesErr != nil {
+				return false, errwrap.Wrapf(err, "failed to set mtime on temporary file for %s", obj.dst)
+			}
 		}
+	}
+
+	if err := file.Commit(); err != nil {
+		return false, err
 	}
 
 	if obj.sha256 == "" { // not cached
@@ -932,16 +928,6 @@ func (obj *HTTPClientRes) processResp(ctx context.Context, resp *http.Response, 
 	// server version. That mtime is our long poll cursor: if stale it would
 	// make the server return immediately on every poll in an infinite loop.
 	unchanged := obj.sha256 == sum()
-
-	// XXX: VarDir may be on a different filesystem than dst, in which case
-	// os.Rename fails with syscall.EXDEV. Eventually VarDir should expose
-	// that and give us an API that lets us receive a dir on the same
-	// filesystem we're on or just fall back to a copy to the same dir as
-	// the dst but with a .tmp?
-	if err := os.Rename(obj.tmp, obj.dst); err != nil {
-		return false, err
-	}
-	tmpdel = false
 
 	content := buf.String()
 	if err := obj.send(content); err != nil { // send/recv

--- a/util/atomicfile/atomicfile.go
+++ b/util/atomicfile/atomicfile.go
@@ -32,7 +32,11 @@
 package atomicfile
 
 import (
+	"io/fs"
 	"os"
+	"path"
+
+	"golang.org/x/sys/unix"
 )
 
 // AtomicFile is an os.File-like struct which allows you to write data and
@@ -85,4 +89,28 @@ func (obj *AtomicFile) Commit() error {
 	_ = obj.Close()
 
 	return err
+}
+
+// A default "create a nearby tempfile" strategy
+func openTemp(fspath string) (*os.File, error) {
+	f, err := os.CreateTemp(path.Dir(fspath), path.Base(fspath)+".new*")
+	if err, ok := err.(*fs.PathError); ok && err.Err == unix.EACCES {
+		var err2 error
+		f, err2 = os.CreateTemp("", path.Base(fspath)+".new*")
+		if err2 != nil {
+			// XXX: Return a composite error of err+err2?
+			return nil, err2
+		}
+	} else if err != nil {
+		return nil, err
+	}
+
+	// Delete the filename while leaving the file open.
+	// The file will get a real name on disk during commit()
+	err = os.Remove(f.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
 }

--- a/util/atomicfile/atomicfile.go
+++ b/util/atomicfile/atomicfile.go
@@ -32,6 +32,7 @@
 package atomicfile
 
 import (
+	"io"
 	"io/fs"
 	"os"
 	"path"
@@ -94,15 +95,17 @@ func (obj *AtomicFile) Commit() error {
 // A default "create a nearby tempfile" strategy
 func openTemp(fspath string) (*os.File, error) {
 	f, err := os.CreateTemp(path.Dir(fspath), path.Base(fspath)+".new*")
-	if err, ok := err.(*fs.PathError); ok && err.Err == unix.EACCES {
-		var err2 error
-		f, err2 = os.CreateTemp("", path.Base(fspath)+".new*")
-		if err2 != nil {
-			// XXX: Return a composite error of err+err2?
-			return nil, err2
+	if err, ok := err.(*fs.PathError); ok {
+		if err.Err == unix.ENOENT || err.Err == unix.EACCES {
+			var err2 error
+			f, err2 = os.CreateTemp("", path.Base(fspath)+".new*")
+			if err2 != nil {
+				// XXX: Return a composite error of err+err2?
+				return nil, err2
+			}
+		} else {
+			return nil, err
 		}
-	} else if err != nil {
-		return nil, err
 	}
 
 	// Delete the filename while leaving the file open.
@@ -113,4 +116,36 @@ func openTemp(fspath string) (*os.File, error) {
 	}
 
 	return f, nil
+}
+
+// Open the existing path for writing and copy our data into it.
+// This is a last resort to write the data in cases where atomic operations
+// like rename(2) are not available.
+func (obj *AtomicFile) commitByCopy() error {
+
+	// Truncate the file and open it for writing.
+	// This is not "atomic" but this function is a fallback for cases
+	// where atomic methods do not work.
+	file, err := os.OpenFile(obj.path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Move the reader to the beginning of our temporary file.
+	obj.Seek(0, io.SeekStart)
+
+	if _, err = io.Copy(file, obj); err != nil {
+		return err
+	}
+
+	if err = file.Sync(); err != nil {
+		if err, ok := err.(*fs.PathError); ok && err.Err == unix.EINVAL {
+			// Filesystem likely doesn't support fsync. Safe to ignore.
+		} else {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/util/atomicfile/atomicfile.go
+++ b/util/atomicfile/atomicfile.go
@@ -1,0 +1,88 @@
+// Mgmt
+// Copyright (C) James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Additional permission under GNU GPL version 3 section 7
+//
+// If you modify this program, or any covered work, by linking or combining it
+// with embedded mcl code and modules (and that the embedded mcl code and
+// modules which link with this program, contain a copy of their source code in
+// the authoritative form) containing parts covered by the terms of any other
+// license, the licensors of this program grant you additional permission to
+// convey the resulting work. Furthermore, the licensors of this program grant
+// the original author, James Shubin, additional permission to update this
+// additional permission if he deems it necessary to achieve the goals of this
+// additional permission.
+
+// Package atomicfile contains a mechanism to write ore replace a given filename
+// with a single, atomic operation.
+package atomicfile
+
+import (
+	"os"
+)
+
+// AtomicFile is an os.File-like struct which allows you to write data and
+// modify metadata before committing it to a specific filename.
+//
+// The intended use is to ensure complete files are only ever available at the
+// given path.
+//
+// If, for any reason, a Commit() never occurs, this module attempts to ensure
+// that no temporary files are left around.
+//
+// Thus:
+// * If the program crashes before a Commit(), the temporary file shall be
+//   lost (on purpose).
+// * If the program calls Close() without a Commit(), the temporary file and
+//   its writes shall be lost (on purpose).
+// * If the computer fails before a Commit(), the temporary file shall be
+//   lost (on purpose).
+//
+// For any of the above scenarios, no disk space should be occupied by these
+// lost files.
+//
+// This module focuses on delivering "whole files" and is not concerned with
+// durability or serializability of operations.
+type AtomicFile struct {
+	os.File
+	path string
+}
+
+// New opens an unnamed temporary file.
+//
+// If you wish to commit writes to the given fspath, you must call Commit().
+func New(fspath string) (*AtomicFile, error) {
+	f, err := open(fspath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &AtomicFile{File: *f, path: fspath}, nil
+}
+
+// Commit acts upon the file to atomically replace it on disk.
+// This closes the file and further changes should not be attempted.
+func (obj *AtomicFile) Commit() error {
+	err := obj.commit()
+
+	// Close after attempting to commit, even if the commit fails.
+	// Nothing can be done so we should still close the file
+	_ = obj.Close()
+
+	return err
+}

--- a/util/atomicfile/atomicfile_linux.go
+++ b/util/atomicfile/atomicfile_linux.go
@@ -32,8 +32,12 @@
 package atomicfile
 
 import (
+	"io"
+	"io/fs"
+	"math/rand/v2"
 	"os"
 	"path"
+	"strconv"
 
 	"golang.org/x/sys/unix"
 )
@@ -47,39 +51,130 @@ func open(fspath string) (*os.File, error) {
 	// > Create an unnamed temporary regular file.  The path
 	// > argument specifies a directory; an unnamed inode will be
 	// > created in that directory's filesystem.
-	return os.OpenFile(path.Dir(fspath), unix.O_RDWR|unix.O_TMPFILE, 0600)
+	//
+	// Where a filesystem doesn't support O_TMPFILE, open() will return
+	// EOPNOTSUPP.
+	dir := path.Dir(fspath)
+	f, err := os.OpenFile(dir, unix.O_RDWR|unix.O_TMPFILE, 0600)
+	if err == nil {
+		return f, nil
+	}
+
+	// Check if OpenFile failed because O_TMPFILE isn't supported by the
+	// filesystem.
+	if err, ok := err.(*fs.PathError); ok && err.Err == unix.EOPNOTSUPP {
+		// O_TMPFILE doesn't work on this filesystem, try another method.
+		return openTemp(fspath)
+	}
+
+	return nil, err
+}
+
+func (obj *AtomicFile) onSameFilesystem() (bool, error) {
+	conn, err := obj.SyscallConn()
+	if err != nil {
+		return false, err
+	}
+
+	var srcstat, dststat unix.Stat_t
+	conn.Control(func(fd uintptr) {
+		err = unix.Fstat(int(fd), &srcstat)
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if err = unix.Stat(obj.path, &dststat); err != nil {
+		if os.IsNotExist(err) {
+			// Full path doesn't exist. Check the parent directory.
+			if err = unix.Stat(path.Dir(obj.path), &dststat); err != nil {
+				return false, err
+			}
+
+			return srcstat.Dev == dststat.Dev, nil
+		}
+		return false, err
+	}
+
+	return srcstat.Dev == dststat.Dev, nil
 }
 
 func (obj *AtomicFile) commit() error {
-	temp, err := os.CreateTemp(path.Dir(obj.path), path.Base(obj.path)+".new*")
+	same, err := obj.onSameFilesystem()
 	if err != nil {
 		return err
 	}
+	if same {
+		err = obj.commitWithLinkat()
+		if err, ok := err.(*fs.PathError); ok && err.Err == unix.EACCES {
+			return obj.commitByCopy()
+		}
+		return err
+	} else {
+		return obj.commitByCopy()
+	}
+}
+
+func (obj *AtomicFile) commitByCopy() error {
+	temp, err := os.CreateTemp("", path.Base(obj.path))
+	if err != nil {
+		return err
+	}
+
+	defer os.Remove(temp.Name())
 	defer temp.Close()
 
-	err = os.Remove(temp.Name())
+	file, err := os.OpenFile(obj.path, os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}
-	// Note: There is a race condition here between the Remove and Linkat calls.
-	// Above, CreateTemp is used to create a temporary, named file. It is removed
-	// in order to link our unnamed file to that pathname.
-	//
-	// If, between the Remove and Linkat, something else creates a file with the
-	// same name, the Linkat call will fail due to the filename already existing..
-	//
-	// A future improvement would be to try (possibly multiple times) different
-	// names to give to our temporary file.
+	defer file.Close()
 
-	// Previously, our open() func used O_TMPFILE to create an unnamed file, and
-	// in order to rename(2) to deliver our committed file, we must give our
-	// unnamed file a name!
-	// See linkat(2) and open(2)'s O_TMPFILE documentation on Linux for more information.
-	err = unix.Linkat(int(obj.Fd()), "", unix.AT_FDCWD, temp.Name(), unix.AT_EMPTY_PATH)
-	if err != nil {
+	if _, err = io.Copy(file, temp); err != nil {
 		return err
 	}
+
+	return nil
+}
+
+func (obj *AtomicFile) commitWithLinkat() error {
+	try := 0
+	base := path.Join(
+		path.Dir(obj.path),
+		path.Base(obj.path)+".new-",
+	)
+
+	// Select a filename that doesn't exist yet in order to give our
+	// currently unnamed file a real name so that we can rename() it.
+	//
+	// Note: This for loop was modeled after golang's CreateTemp implementation
+	var current string
+	for {
+		current = base + strconv.FormatUint(rand.Uint64(), 16)
+
+		// Previously, our open() func should have created an unnamed file. In
+		// order to rename(2) to deliver our committed file, we must give our
+		// unnamed file a name!
+		// See linkat(2) and open(2)'s O_TMPFILE documentation on Linux for more
+		// information.
+		err := unix.Linkat(int(obj.Fd()), "", unix.AT_FDCWD, current, unix.AT_EMPTY_PATH)
+		if err != nil {
+			if os.IsExist(err) {
+				if try++; try < 10000 {
+					continue
+				}
+
+				// Exhausted tries.
+				return &os.PathError{Op: "linkat", Path: current, Err: err}
+			} else {
+				return err
+			}
+		}
+
+		// Linkat succeeded!
+		break
+	}
+
 	defer obj.Close()
-
-	return os.Rename(temp.Name(), obj.path)
+	return os.Rename(current, obj.path)
 }

--- a/util/atomicfile/atomicfile_linux.go
+++ b/util/atomicfile/atomicfile_linux.go
@@ -1,0 +1,85 @@
+// Mgmt
+// Copyright (C) James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Additional permission under GNU GPL version 3 section 7
+//
+// If you modify this program, or any covered work, by linking or combining it
+// with embedded mcl code and modules (and that the embedded mcl code and
+// modules which link with this program, contain a copy of their source code in
+// the authoritative form) containing parts covered by the terms of any other
+// license, the licensors of this program grant you additional permission to
+// convey the resulting work. Furthermore, the licensors of this program grant
+// the original author, James Shubin, additional permission to update this
+// additional permission if he deems it necessary to achieve the goals of this
+// additional permission.
+
+//go:build linux
+
+package atomicfile
+
+import (
+	"os"
+	"path"
+
+	"golang.org/x/sys/unix"
+)
+
+func open(fspath string) (*os.File, error) {
+	// Note: this only works on certain filesystems on Linux. See the `O_TMPFILE`
+	// documentation on `open(2)` for more details.
+	//
+	// Relevant notes from Linux's open(2) are:
+	//
+	// > Create an unnamed temporary regular file.  The path
+	// > argument specifies a directory; an unnamed inode will be
+	// > created in that directory's filesystem.
+	return os.OpenFile(path.Dir(fspath), unix.O_RDWR|unix.O_TMPFILE, 0600)
+}
+
+func (obj *AtomicFile) commit() error {
+	temp, err := os.CreateTemp(path.Dir(obj.path), path.Base(obj.path)+".new*")
+	if err != nil {
+		return err
+	}
+	defer temp.Close()
+
+	err = os.Remove(temp.Name())
+	if err != nil {
+		return err
+	}
+	// Note: There is a race condition here between the Remove and Linkat calls.
+	// Above, CreateTemp is used to create a temporary, named file. It is removed
+	// in order to link our unnamed file to that pathname.
+	//
+	// If, between the Remove and Linkat, something else creates a file with the
+	// same name, the Linkat call will fail due to the filename already existing..
+	//
+	// A future improvement would be to try (possibly multiple times) different
+	// names to give to our temporary file.
+
+	// Previously, our open() func used O_TMPFILE to create an unnamed file, and
+	// in order to rename(2) to deliver our committed file, we must give our
+	// unnamed file a name!
+	// See linkat(2) and open(2)'s O_TMPFILE documentation on Linux for more information.
+	err = unix.Linkat(int(obj.Fd()), "", unix.AT_FDCWD, temp.Name(), unix.AT_EMPTY_PATH)
+	if err != nil {
+		return err
+	}
+	defer obj.Close()
+
+	return os.Rename(temp.Name(), obj.path)
+}

--- a/util/atomicfile/atomicfile_linux.go
+++ b/util/atomicfile/atomicfile_linux.go
@@ -32,7 +32,6 @@
 package atomicfile
 
 import (
-	"io"
 	"io/fs"
 	"math/rand/v2"
 	"os"
@@ -113,28 +112,6 @@ func (obj *AtomicFile) commit() error {
 	} else {
 		return obj.commitByCopy()
 	}
-}
-
-func (obj *AtomicFile) commitByCopy() error {
-	temp, err := os.CreateTemp("", path.Base(obj.path))
-	if err != nil {
-		return err
-	}
-
-	defer os.Remove(temp.Name())
-	defer temp.Close()
-
-	file, err := os.OpenFile(obj.path, os.O_WRONLY, 0600)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	if _, err = io.Copy(file, temp); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (obj *AtomicFile) commitWithLinkat() error {

--- a/util/atomicfile/atomicfile_macos.go
+++ b/util/atomicfile/atomicfile_macos.go
@@ -1,0 +1,70 @@
+// Mgmt
+// Copyright (C) James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Additional permission under GNU GPL version 3 section 7
+//
+// If you modify this program, or any covered work, by linking or combining it
+// with embedded mcl code and modules (and that the embedded mcl code and
+// modules which link with this program, contain a copy of their source code in
+// the authoritative form) containing parts covered by the terms of any other
+// license, the licensors of this program grant you additional permission to
+// convey the resulting work. Furthermore, the licensors of this program grant
+// the original author, James Shubin, additional permission to update this
+// additional permission if he deems it necessary to achieve the goals of this
+// additional permission.
+
+//go:build darwin
+
+package atomicfile
+
+import (
+	"os"
+	"path"
+
+	"golang.org/x/sys/unix"
+)
+
+func open(fspath string) (*os.File, error) {
+	f, err := os.CreateTemp(path.Dir(fspath), path.Base(fspath)+".new*")
+	if err != nil {
+		return nil, err
+	}
+
+	// Delete the filename while leaving the file open.
+	// The file will get a real name on disk during commit()
+	err = os.Remove(f.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+func (obj *AtomicFile) commit() error {
+	fd := int(obj.Fd())
+
+	// Give the file a name again...
+	// Note: This could fail if a file with this name already exists.
+	// It is a race condition that affects the linux implementation, also, so see
+	// atomicfile_linux.go for details on what can happen.
+	err := unix.Fclonefileat(fd, fd, obj.Name(), 0)
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(obj.Name(), obj.path)
+}

--- a/util/atomicfile/atomicfile_macos.go
+++ b/util/atomicfile/atomicfile_macos.go
@@ -33,25 +33,12 @@ package atomicfile
 
 import (
 	"os"
-	"path"
 
 	"golang.org/x/sys/unix"
 )
 
 func open(fspath string) (*os.File, error) {
-	f, err := os.CreateTemp(path.Dir(fspath), path.Base(fspath)+".new*")
-	if err != nil {
-		return nil, err
-	}
-
-	// Delete the filename while leaving the file open.
-	// The file will get a real name on disk during commit()
-	err = os.Remove(f.Name())
-	if err != nil {
-		return nil, err
-	}
-
-	return f, nil
+	return openTemp(fspath)
 }
 
 func (obj *AtomicFile) commit() error {

--- a/util/atomicfile/atomicfile_test.go
+++ b/util/atomicfile/atomicfile_test.go
@@ -1,0 +1,275 @@
+// Mgmt
+// Copyright (C) James Shubin and the project contributors
+// Written by James Shubin <james@shubin.ca> and the project contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Additional permission under GNU GPL version 3 section 7
+//
+// If you modify this program, or any covered work, by linking or combining it
+// with embedded mcl code and modules (and that the embedded mcl code and
+// modules which link with this program, contain a copy of their source code in
+// the authoritative form) containing parts covered by the terms of any other
+// license, the licensors of this program grant you additional permission to
+// convey the resulting work. Furthermore, the licensors of this program grant
+// the original author, James Shubin, additional permission to update this
+// additional permission if he deems it necessary to achieve the goals of this
+// additional permission.
+
+package atomicfile
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestWrites(t *testing.T) {
+	workdir, err := os.MkdirTemp("", "atomic-file")
+	if err != nil {
+		t.Errorf("test bug: failed to create a temporary directory to use with testing: %s", err)
+		return
+	}
+
+	defer os.Remove(workdir)
+
+	filename := path.Join(workdir, "hello-world")
+
+	_, err = os.Stat(filename)
+	if err == nil {
+		t.Errorf("test bug: File shouldn't exist before we commit it")
+		return
+	}
+
+	// Test new file creation
+	check(t, filename, "Hello world!")
+
+	_, err = os.Stat(filename)
+	if err != nil {
+		t.Errorf("test bug: File should exist at this point: %s", err)
+		return
+	}
+
+	// Test atomic file replacement
+	check(t, filename, "Put on your fancy pants!")
+	os.Remove(filename)
+
+}
+
+func TestMetadata(t *testing.T) {
+	workdir, err := os.MkdirTemp("", "atomic-file")
+	if err != nil {
+		t.Errorf("during setup, failed to create a temporary directory to use with testing: %s", err)
+		return
+	}
+	defer os.Remove(workdir)
+
+	filename := path.Join(workdir, "hello-world")
+
+	checkStat(t, filename,
+		func(f *AtomicFile) error {
+			return f.Chmod(0654)
+		},
+		func(i fs.FileInfo) error {
+			if i.Mode() != 0654 {
+				return fmt.Errorf("file mode expected to be %0o, but is %0o", 0654, i.Mode())
+			}
+			return nil
+		},
+	)
+}
+
+func TestWithoutCommit(t *testing.T) {
+	workdir, err := os.MkdirTemp("", "atomic-file")
+	if err != nil {
+		t.Errorf("during setup, failed to create a temporary directory to use with testing: %s", err)
+		return
+	}
+
+	defer os.Remove(workdir)
+
+	filename := path.Join(workdir, "hello-world")
+
+	_, err = os.Stat(filename)
+	if err == nil {
+		t.Errorf("test Bug: File shouldn't exist before we commit it")
+		return
+	}
+
+	f, err := New(filename)
+
+	if err != nil {
+		t.Errorf("bug: New(%s) failed unexpectedly: %s", filename, err)
+		return
+	}
+
+	input_bytes := []byte("Hello world")
+
+	n, err := f.Write(input_bytes)
+	if err != nil {
+		t.Errorf("test bug: Write() expected to write %d bytes, but only %d were written: %s", len(input_bytes), n, err)
+		return
+	}
+
+	_, err = os.ReadFile(filename)
+
+	if err == nil {
+		// An error is expected, this file should not exist because we did not Commit()
+		t.Errorf("os.ReadFile should fail when an AtomicFile has not been Commit()'d.")
+		return
+	}
+
+	err = f.Close()
+	if err != nil {
+		t.Errorf("bug: Close() failed: %s", err)
+		return
+	}
+
+	// Assert the temporary file path doesn't exist either.
+	files, err := os.ReadDir(path.Dir(f.path))
+	if err != nil {
+		t.Errorf("test bug: could not read the test's temporary directory")
+		return
+	}
+	if len(files) > 1 {
+		t.Errorf("bug: temporary file should not exist after Close()")
+		return
+	}
+}
+
+func FuzzMetadata(f *testing.F) {
+	workdir, err := os.MkdirTemp("", "atomic-file")
+	if err != nil {
+		f.Errorf("during setup, failed to create a temporary directory to use with testing: %s", err)
+		return
+	}
+	defer os.Remove(workdir)
+
+	filename := path.Join(workdir, "hello-world")
+	f.Add(int32(0755), "hello-world")
+
+	const minimal = 0400
+	// Go's fuzzer has no concept(?) of os.FileMode, so in order to fuzz it,
+	f.Fuzz(func(t *testing.T, perms int32, _ string) {
+		// We have to make sure the permissions are valid.
+		// Permissions must have owner read, for example.
+		mode := os.FileMode(perms&0777 | minimal)
+
+		checkStat(t, filename,
+			func(f *AtomicFile) error {
+				//t.Logf("Chmod %#o", mode)
+				return f.Chmod(mode)
+			},
+			func(i fs.FileInfo) error {
+				if i.Mode() != mode {
+					return fmt.Errorf("file mode expected to be %0o, but is %0o", mode, i.Mode())
+				}
+				return nil
+			},
+		)
+	})
+}
+
+func check(t *testing.T, filename string, input string) {
+	f, err := New(filename)
+
+	if err != nil {
+		t.Errorf("call to New(%s) failed unexpectedly: %s", filename, err)
+		return
+	}
+
+	input_bytes := []byte(input)
+
+	n, err := f.Write(input_bytes)
+	//if n < len(input_bytes) {
+	if err != nil {
+		t.Errorf("call to Write() expected to write %d bytes, but only %d were written: %s", len(input_bytes), n, err)
+		return
+	}
+
+	// Check that the target file doesn't already have our contents
+	// This check assumes the tet suite isn't writing the same contents to an existing file.
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		// It's ok if reading failed, maybe the file doesn't exist.
+	} else if bytes.Equal(data, input_bytes) {
+		t.Errorf("bug: before Commit(), the file contents should not have been written.")
+		return
+	}
+
+	err = f.Commit()
+	if err != nil {
+		t.Errorf("bug: Commit() failed: %s", err)
+		return
+	}
+
+	data, err = os.ReadFile(filename)
+
+	if err != nil {
+		t.Errorf("bug: error reading file after commit: %s", err)
+		return
+	}
+
+	if !bytes.Equal(data, input_bytes) {
+		t.Errorf("bug: file contents did not match what was written %v vs %v", string(data), string(input_bytes))
+		return
+	}
+
+	// Assert the temporary file path doesn't exist either.
+	files, err := os.ReadDir(path.Dir(f.path))
+	if err != nil {
+		t.Errorf("test bug: could not read the test's temporary directory")
+		return
+	}
+	if len(files) > 1 {
+		t.Errorf("bug: temporary file should not exist after Close() - %s vs %s", f.Name(), f.path)
+		return
+	}
+
+}
+
+func checkStat(t *testing.T, filename string, operation func(*AtomicFile) error, validate func(fs.FileInfo) error) {
+	f, err := New(filename)
+	if err != nil {
+		t.Errorf("call to New(%s) failed unexpectedly: %s", filename, err)
+		return
+	}
+
+	err = operation(f)
+	if err != nil {
+		t.Errorf("test bug: checkStat operation func returned error: %s", err)
+		return
+	}
+
+	err = f.Commit()
+	if err != nil {
+		t.Errorf("bug: call to Commit() failed for file %s: %s", f.path, err)
+		return
+	}
+
+	stat, err := os.Stat(filename)
+	if err != nil {
+		t.Errorf("test bug: os.Stat() failed: %s", err)
+		return
+	}
+
+	err = validate(stat)
+	if err != nil {
+		t.Errorf("bug: checkStat validation failed: %s", err)
+		return
+	}
+}


### PR DESCRIPTION
This allows file writes to be delivered atomically by staging writes to a temporary file and using rename(2) to replace the target file only when we are ready. This means mgmt could update files (with the file resource, etc) without race conditions between `os.Create()` (which creates/truncates a file) and future writes to that File.

The gist is that we treat AtomicFile the same way we do a File, with two differences:
* atomicfile.New("destination") instead of os.Create("destination")
* call Commit() when you are ready to deliver the file to the destination path.

I have included implementations for Linux and macOS as they have different syscalls needed to achieve the same effects. Tests pass for me on Linux (fedora 44) and macOS (26.6.2).

A non-exhaustive list of places in mgmt where this pattern of atomic file delivery may be of value:
* file resource
* http:client when used with the 'file' param
* line resource
* ssh_authorized_key resource
* tar resource

Implementation thoughts: I tried to keep the temporary files invisible to the filesystem. On Linux, this is achieved with O_TMPFILE, and on macOS, I delete the filename as soon as I can while keeping the file open. The goal with this method is several:
1. I don't know yet how mgmt's use of inotify might make things _wierd_ with temporary files popping up.
2. If for any reason the program/computer crashes or mgmt decides not to complete the file writing, the temporary file is automatically freed by the filesystem.

Background: I have `http:server:file` serving files, and `file` writing contents to that file. There are occasions when the http server sends a zero-length file. My hypothesis is that this happens becasue the `file` resource writes to a file by calling os.Create on that path (which truncates it) and later writes data to that file. This gives us a small window of time where the file has zero length. It could also affect larger files where an external process might read  a file *while* it is being writtten by mgmt resulting in a partial read.

Out of scope (for this PR):
* Some filesystems on Linux do not support O_TMPFILE. Detecting this case would be a useful future improvement.
* Windows support
* Changes to resources to use this package should happen in a future PR, unless you feel otherwise.
